### PR TITLE
Bug/Safety checker to None

### DIFF
--- a/toolkit/stable_diffusion_model.py
+++ b/toolkit/stable_diffusion_model.py
@@ -212,7 +212,7 @@ class StableDiffusion:
                     device=self.device_torch,
                     load_safety_checker=False,
                     requires_safety_checker=False,
-                    safety_checker=False
+                    safety_checker=None
                 ).to(self.device_torch)
             else:
                 pipe = pipln.from_single_file(


### PR DESCRIPTION
Hi 
I am not sure what your branching conventions are, but the current version on main gives me an error, Here is my fix.

## Fix AttributeError by Changing `safety_checker` to `None`

## Description
I encountered an AttributeError while using the code from the main branch. The error message indicated that the issue was related to the `safety_checker` parameter being set to `False`. It appears that the code expects this parameter to be `None` rather than a boolean value.

Change `safety_checker=False` to `safety_checker=None` in `toolkit/stable_diffusion_model.py`  line 215
```
pipe = pipln.from_pretrained(
    model_path,
    dtype=dtype,
    scheduler_type='dpm',
    device=self.device_torch,
    load_safety_checker=False,
    requires_safety_checker=False,
    safety_checker=False
).to(self.device_torch)
```

Here, if safety_checker is `False`, it gives me the error: ```'bool' object has no attribute '__module__'. Did you mean: '__mod__'?``` in `site-packages/diffusers/pipelines/pipeline_utils.py` line 513, since it checks for None value instead of bool in line 504.

Fixes # (issue)

Change `safety_checker=False` to `safety_checker=None` and it works for me.