### PR TITLE
Update train_lora_flux_24gb.yaml

### DIFF
--- a/config/examples/train_lora_flux_24gb.yaml
+++ b/config/examples/train_lora_flux_24gb.yaml
@@ -42,7 +42,7 @@ config:
         gradient_checkpointing: true  # need the on unless you have a ton of vram
         noise_scheduler: "flowmatch" # for training only
         optimizer: "adamw8bit"
-        lr: 1e-4
+        lr: 2e-4
         # uncomment this to skip the pre training sample
 #        skip_first_sample: true
         # uncomment to completely disable sampling


### PR DESCRIPTION
1e-4 looks too low for my tests, 2e-4 and 2000 steps seems to result in much better resemblance (training with ~20 photos of a person).

Close it if you don't agree, was not sure if the 1e-4 has been tested with the new linear_timesteps: true (?)