### PR TITLE
Fix using wrong values for WEBP format caching

### DIFF
--- a/toolkit/dataloader_mixins.py
+++ b/toolkit/dataloader_mixins.py
@@ -455,10 +455,16 @@ class ImageProcessingDTOMixin:
             # throw error, they should match
             print(
                 f"unexpected values: w={w}, h={h}, file_item.scale_to_width={self.scale_to_width}, file_item.scale_to_height={self.scale_to_height}, file_item.path={self.path}")
+            self.scale_to_width, self.scale_to_height = max(self.scale_to_height, self.scale_to_width), min(self.scale_to_height, self.scale_to_width)
+            self.crop_width, self.crop_height = max(self.crop_width, self.crop_height), min(self.crop_width, self.crop_height)
+            self.crop_x, self.crop_y = max(self.crop_x, self.crop_y), min(self.crop_x, self.crop_y)
         elif h > w and self.scale_to_height < self.scale_to_width:
             # throw error, they should match
             print(
                 f"unexpected values: w={w}, h={h}, file_item.scale_to_width={self.scale_to_width}, file_item.scale_to_height={self.scale_to_height}, file_item.path={self.path}")
+            self.scale_to_width, self.scale_to_height = min(self.scale_to_height, self.scale_to_width), max(self.scale_to_height, self.scale_to_width)
+            self.crop_width, self.crop_height = min(self.crop_width, self.crop_height), max(self.crop_width, self.crop_height)
+            self.crop_x, self.crop_y = min(self.crop_x, self.crop_y), max(self.crop_x, self.crop_y)
 
         if self.flip_x:
             # do a flip


### PR DESCRIPTION
WEBP files will use wrong size for latent cache.

Here, you can see the part that would use h,w 
https://github.com/ostris/ai-toolkit/blob/main/toolkit/data_transfer_object/data_loader.py#L58

However, the original code did not have fix in latent caching part. 

the function `load_unconditional_image` throws error, `load_mask_image` swaps the sizes.

It is actually problem of data_loader.py, we can just use

```                
                if self.path.endswith('.webp'):
                    w, h = img.size
                else:
                    h, w = img.size
```

*note, the cache created before patch has to be removed for sanity.
