### PR TITLE
fix: print out the path where the image encode failed

### DIFF
--- a/toolkit/dataloader_mixins.py
+++ b/toolkit/dataloader_mixins.py
@@ -1385,8 +1385,13 @@ class LatentCachingMixin:
                 dtype = self.sd.torch_dtype
                 device = self.sd.device_torch
                 # add batch dimension
-                imgs = file_item.tensor.unsqueeze(0).to(device, dtype=dtype)
-                latent = self.sd.encode_images(imgs).squeeze(0)
+                try:
+                    imgs = file_item.tensor.unsqueeze(0).to(device, dtype=dtype)
+                    latent = self.sd.encode_images(imgs).squeeze(0)
+                except Exception as e:
+                    print(f"Error processing image: {file_item.path}")
+                    print(f"Error: {str(e)}")
+                    raise e
                 # save_latent
                 if to_disk:
                     state_dict = OrderedDict([


### PR DESCRIPTION
FIX: When I have an image in my dataset that is too small in pixels, the training breaks down, but I can't find the path to that image. For example, an image with this pixel value: 122 x 63