### PR TITLE
changed requirements.txt to specific diffuser version 0.30.0, fixes issue #123

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 torch
 torchvision
 safetensors
-git+https://github.com/huggingface/diffusers.git
+diffusers==0.30.0
 transformers
 lycoris-lora==1.8.3
 flatten_json


### PR DESCRIPTION
See this issue: https://github.com/ostris/ai-toolkit/issues/123

This avoids an error message when running when using the latest (as of 22 August 2024) diffuser version:

not working diffuser version: 0.31.0.dev0
Error message: Error running job: cannot import name 'apply_rope' from 'diffusers.models.attention_processor'