### PR TITLE
Update buckets.py to avoid possible error

### DIFF
--- a/toolkit/buckets.py
+++ b/toolkit/buckets.py
@@ -140,6 +140,9 @@ def get_bucket_for_image_size(
     if bucket_size_list is None:
         # if real resolution is smaller, use that instead
         real_resolution = get_resolution(width, height)
+        # Asegurarse de que resolution y real_resolution sean enteros
+        resolution = int(resolution)
+        real_resolution = int(real_resolution)
         resolution = min(resolution, real_resolution)
         bucket_size_list = get_bucket_sizes(resolution=resolution, divisibility=divisibility)
 


### PR DESCRIPTION
Make sure resolution values are integers to avoid this error:

Traceback (most recent call last):
  File "/workspace/ai-toolkit/run.py", line 90, in <module>
    main()
  File "/workspace/ai-toolkit/run.py", line 86, in main
    raise e
  File "/workspace/ai-toolkit/run.py", line 78, in main
    job.run()
  File "/workspace/ai-toolkit/jobs/ExtensionJob.py", line 22, in run
    process.run()
  File "/workspace/ai-toolkit/jobs/process/BaseSDTrainProcess.py", line 1567, in run
    self.data_loader = get_dataloader_from_datasets(self.datasets, self.train_config.batch_size, self.sd)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/ai-toolkit/toolkit/data_loader.py", line 571, in get_dataloader_from_datasets
    dataset = AiToolkitDataset(config, batch_size=batch_size, sd=sd)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/ai-toolkit/toolkit/data_loader.py", line 499, in __init__
    self.setup_epoch()
  File "/workspace/ai-toolkit/toolkit/data_loader.py", line 507, in setup_epoch
    self.setup_buckets()
  File "/workspace/ai-toolkit/toolkit/dataloader_mixins.py", line 222, in setup_buckets
    bucket_resolution = get_bucket_for_image_size(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/ai-toolkit/toolkit/buckets.py", line 143, in get_bucket_for_image_size
    resolution = min(resolution, real_resolution)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'int' and 'str'