### PR TITLE
ScheduleFree AdamW Support

### DIFF
--- a/extensions_built_in/sd_trainer/SDTrainer.py
+++ b/extensions_built_in/sd_trainer/SDTrainer.py
@@ -117,6 +117,10 @@ class SDTrainer(BaseSDTrainProcess):
 
     def hook_before_train_loop(self):
         super().hook_before_train_loop()
+
+
+        if self.train_config.optimizer == 'schedulefree':
+            self.optimizer.train()
         
         if self.train_config.do_prior_divergence:
             self.do_prior_prediction = True

--- a/toolkit/optimizer.py
+++ b/toolkit/optimizer.py
@@ -56,6 +56,13 @@ def get_optimizer(
         optimizer = torch.optim.Adam(params, lr=float(learning_rate), eps=1e-6, **optimizer_params)
     elif lower_type == 'adamw':
         optimizer = torch.optim.AdamW(params, lr=float(learning_rate), eps=1e-6, **optimizer_params)
+    elif lower_type == 'schedulefree':
+        print("Using ScheduleFree optimizer")
+        try:
+            from schedulefree import AdamWScheduleFree
+        except ImportError:
+            raise ImportError("Please install schedulefree to use ScheduleFree optimizer -> pip install schedulefree")
+        optimizer = AdamWScheduleFree(params, lr=learning_rate, **optimizer_params)
     elif lower_type == 'lion':
         try:
             from lion_pytorch import Lion


### PR DESCRIPTION
This pull request adds support for a new "schedule-free" optimizer as described in the paper [Schedule-Free Optimizer for Fast Convergence](https://arxiv.org/abs/2405.15682). This optimizer can be easily integrated into any training pipeline without breaking existing functionality.
Usage

To use this optimizer, simply add the following configuration to your training setup:

```yaml
lr: 5e-4
optimizer: "schedulefree"
optimizer_params:
    weight_decay: 0.1
```

While this optimizer promises faster convergence as per the paper, preliminary results suggest it may overfit or "burn out" quickly in certain cases. Optimal parameters are yet to be determined, so further experimentation may be required to fine-tune for specific tasks.