### PR TITLE
fix optimum-quanto==0.2.4 due to many issues arising from the newer version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ bitsandbytes
 hf_transfer
 lpips
 pytorch_fid
-optimum-quanto
+optimum-quanto==0.2.4
 sentencepiece
 huggingface_hub
 peft


### PR DESCRIPTION
My first public commit. :)
Would like to make this version fixed due to many issues with the version >=0.2.5.
The issues arising currently should be probably fixed later on.