### PR TITLE
Add Google Colab usage instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,25 @@ You will instantiate a UI that will let you upload your images, caption them, tr
 ![image](assets/lora_ease_ui.png)
 
 
+### Google Colab
+
+If you are not using `FLUX.1-dev`, you can skip the `!huggingface-cli login` step.  
+Otherwise, make sure to set your Hugging Face Access Token first:
+
+```bash
+!huggingface-cli login
+```
+
+Next, run the following commands in your Colab notebook:
+
+```bash
+!git clone https://github.com/ostris/ai-toolkit.git
+%cd ai-toolkit
+!git submodule update --init --recursive
+!pip3 install -r requirements.txt
+!python flux_train_ui.py
+```
+
 ## Training in RunPod
 Example RunPod template: **runpod/pytorch:2.2.0-py3.10-cuda12.1.1-devel-ubuntu22.04**
 > You need a minimum of 24GB VRAM, pick a GPU by your preference.


### PR DESCRIPTION
Hello!

This PR updates the README to include instructions for using the AI Toolkit with Google Colab. It provides a step-by-step guide for both scenarios:
- Using `FLUX.1-dev`, where setting the Hugging Face Access Token is required.
- Not using `FLUX.1-dev`, where this step can be skipped.

The changes ensure clarity for users who want to use the AI Toolkit in Google Colab.
Let me know if any further adjustments are needed.
