### PR TITLE
fix: resolve OSError for CUDA_HOME in modal script

### DIFF
--- a/run_modal.py
+++ b/run_modal.py
@@ -30,9 +30,10 @@ MOUNT_DIR = "/root/ai-toolkit/modal_output"  # modal_output, due to "cannot moun
 
 # define modal app
 image = (
-    modal.Image.debian_slim(python_version="3.11")
+    modal.Image.from_registry("nvidia/cuda:12.4.0-devel-ubuntu22.04", add_python="3.11")
     # install required system and pip packages, more about this modal approach: https://modal.com/docs/examples/dreambooth_app
     .apt_install("libgl1", "libglib2.0-0")
+    .pip_install("cupy-cuda12x")
     .pip_install(
         "python-dotenv",
         "torch", 


### PR DESCRIPTION
This is to resolve this problem:
https://github.com/ostris/ai-toolkit/issues/208

And I'm using this example from modal as reference: https://modal.com/playground/gpu