### PR TITLE
Adding the ability in the UI to force stop jobs

### DIFF
--- a/ui/src/app/api/jobs/[jobID]/forcestop/route.ts
+++ b/ui/src/app/api/jobs/[jobID]/forcestop/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export async function GET(request: NextRequest, { params }: { params: { jobID: string } }) {
+    const { jobID } = await params;
+
+    const updatedJob = await prisma.job.update({
+        where: { id: jobID },
+        data: {
+        status: 'stopped',
+        stop: true,
+        info: 'Job force stopped',
+        },
+    });
+
+    return NextResponse.json(updatedJob);
+}

--- a/ui/src/app/api/jobs/[jobID]/stop/route.ts
+++ b/ui/src/app/api/jobs/[jobID]/stop/route.ts
@@ -6,12 +6,8 @@ const prisma = new PrismaClient();
 export async function GET(request: NextRequest, { params }: { params: { jobID: string } }) {
   const { jobID } = await params;
 
-  const job = await prisma.job.findUnique({
-    where: { id: jobID },
-  });
-
   // update job status to 'running'
-  await prisma.job.update({
+  const updatedJob = await prisma.job.update({
     where: { id: jobID },
     data: {
       stop: true,
@@ -19,5 +15,5 @@ export async function GET(request: NextRequest, { params }: { params: { jobID: s
     },
   });
 
-  return NextResponse.json(job);
+  return NextResponse.json(updatedJob);
 }

--- a/ui/src/components/JobActionBar.tsx
+++ b/ui/src/components/JobActionBar.tsx
@@ -1,9 +1,9 @@
 import Link from 'next/link';
-import { Eye, Trash2, Pen, Play, Pause } from 'lucide-react';
+import { Eye, Trash2, Pen, Play, Pause, OctagonX } from 'lucide-react';
 import { Button } from '@headlessui/react';
 import { openConfirm } from '@/components/ConfirmModal';
 import { Job } from '@prisma/client';
-import { startJob, stopJob, deleteJob, getAvaliableJobActions } from '@/utils/jobs';
+import { startJob, stopJob, deleteJob, getAvaliableJobActions, forceStopJob } from '@/utils/jobs';
 
 interface JobActionBarProps {
   job: Job;
@@ -31,6 +31,24 @@ export default function JobActionBar({ job, onRefresh, afterDelete, className, h
         >
           <Play />
         </Button>
+      )}
+      {!canStart && (<Button
+        onClick={() => {
+          openConfirm({
+            title: 'Force Stop Job',
+            message: `This will reset the status of "${job.name}" that is marked as running but may not actually be running. Use this only if you believe the UI is stuck in a running state.`,
+            type: 'warning',
+            confirmText: 'Force Stop',
+            onConfirm: async () => {
+              await forceStopJob(job.id);
+              if (onRefresh) onRefresh();
+            },
+          });
+        }}
+        className={`ml-2 opacity-100`}
+      >
+        <OctagonX />
+      </Button>
       )}
       {canStop && (
         <Button

--- a/ui/src/utils/jobs.ts
+++ b/ui/src/utils/jobs.ts
@@ -34,6 +34,22 @@ export const stopJob = (jobID: string) => {
   });
 };
 
+export const forceStopJob = (jobID: string) => {
+  return new Promise<void>((resolve, reject) => {
+    apiClient
+      .get(`/api/jobs/${jobID}/forcestop`)
+      .then(res => res.data)
+      .then(data => {
+        console.log('Job Force stopped:', data);
+        resolve();
+      })
+      .catch(error => {
+        console.error('Error force stopping job:', error);
+        reject(error);
+      });
+  });
+};
+
 export const deleteJob = (jobID: string) => {
   return new Promise<void>((resolve, reject) => {
     apiClient


### PR DESCRIPTION
Problem:
When problems arise during a training and it's not able to stop as expected, the database entry for the job is left as running and yet the job is not actually running. Further, when using the pause button, jobs in this broken state don't actually get their status changed. You will continue to see 'running' as the status but the info will change to 'Stopping job...'.

The real issue is due to this bug, you can't restart trainings that are already stopped and good to restart.

Repro:
Start training -> hard power off computer -> reboot computer and open UI

Solution:
Add a force stop button that modifies the status in the db to be appropriate. To be honest, it can be a little confusing initially to have both a stop and a pause button but I'm hoping the information prompted in the dialog helps avoid confusion.

![image](https://github.com/user-attachments/assets/a3b78578-ecd1-48bc-9070-6716e24ccaff)

![image](https://github.com/user-attachments/assets/7805dc6d-8da3-4823-8571-8f624c054512)
