### PR TITLE
fix typo in `train_lora_omnigen2_24gb.yaml`

### DIFF
--- a/config/examples/train_lora_omnigen2_24gb.yaml
+++ b/config/examples/train_lora_omnigen2_24gb.yaml
@@ -61,7 +61,7 @@ config:
         # will probably need this if gpu supports it for omnigen2, other dtypes may not work correctly
         dtype: bf16
       model:
-        name_or_path: "OmniGen2/OmniGen2
+        name_or_path: "OmniGen2/OmniGen2"
         arch: "omnigen2"
         quantize_te: true  # quantize_only te
         # quantize: true  # quantize transformer


### PR DESCRIPTION
While using the `config/examples/train_lora_omnigen2_24gb.yaml` file to train LoRA for the OmniGen2 model, I found a minor typo.
I hope this saves others from wasting time searching for the error.