### PR TITLE
fix: Guidance incorrect shape

### DIFF
--- a/extensions_built_in/diffusion_models/flux_kontext/flux_kontext.py
+++ b/extensions_built_in/diffusion_models/flux_kontext/flux_kontext.py
@@ -291,7 +291,8 @@ class FluxKontextModel(BaseModel):
                 else:
                     guidance = torch.tensor(
                         [guidance_embedding_scale], device=self.device_torch)
-                    guidance = guidance.expand(latent_model_input.shape[0])
+                    # Expand guidance to match original batch_size
+                    guidance = guidance.expand(bs)
             else:
                 guidance = None
 


### PR DESCRIPTION
When training a Flux kontext lora with a batch_size>1, an error is produced due to the size mismatch between guidance and timestep shapes as reported in #332.

<img width="1690" height="214" alt="image" src="https://github.com/user-attachments/assets/2a241b1a-07d6-479e-8e4c-042177824f68" />

The solution is to expand the guidance tensor to the batch_size dimension, instead of the latents_model_input.shape[0]
