### PR TITLE
Add force job status API and UI action

### DIFF
--- a/ui/src/app/api/jobs/[jobID]/force-status/route.ts
+++ b/ui/src/app/api/jobs/[jobID]/force-status/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export async function POST(request: NextRequest, { params }: { params: { jobID: string } }) {
+  const { jobID } = await params;
+  const { status } = await request.json();
+
+  // Validate the status
+  const validStatuses = ['stopped', 'completed', 'error'];
+  if (!validStatuses.includes(status)) {
+    return NextResponse.json({ error: 'Invalid status' }, { status: 400 });
+  }
+
+  const job = await prisma.job.findUnique({
+    where: { id: jobID },
+  });
+
+  if (!job) {
+    return NextResponse.json({ error: 'Job not found' }, { status: 404 });
+  }
+
+  // Force update the job status
+  const updatedJob = await prisma.job.update({
+    where: { id: jobID },
+    data: {
+      status: status,
+      stop: false,
+      info: status === 'stopped' ? 'Job stopped' : 
+            status === 'completed' ? 'Training completed' :
+            'Job error',
+    },
+  });
+
+  return NextResponse.json(updatedJob);
+}

--- a/ui/src/components/JobActionBar.tsx
+++ b/ui/src/components/JobActionBar.tsx
@@ -1,9 +1,9 @@
 import Link from 'next/link';
-import { Eye, Trash2, Pen, Play, Pause } from 'lucide-react';
+import { Eye, Trash2, Pen, Play, Pause, AlertTriangle } from 'lucide-react';
 import { Button } from '@headlessui/react';
 import { openConfirm } from '@/components/ConfirmModal';
 import { Job } from '@prisma/client';
-import { startJob, stopJob, deleteJob, getAvaliableJobActions } from '@/utils/jobs';
+import { startJob, stopJob, deleteJob, forceJobStatus, getAvaliableJobActions } from '@/utils/jobs';
 
 interface JobActionBarProps {
   job: Job;
@@ -14,7 +14,7 @@ interface JobActionBarProps {
 }
 
 export default function JobActionBar({ job, onRefresh, afterDelete, className, hideView }: JobActionBarProps) {
-  const { canStart, canStop, canDelete, canEdit } = getAvaliableJobActions(job);
+  const { canStart, canStop, canDelete, canEdit, canForce } = getAvaliableJobActions(job);
 
   if (!afterDelete) afterDelete = onRefresh;
 
@@ -50,6 +50,25 @@ export default function JobActionBar({ job, onRefresh, afterDelete, className, h
           className={`ml-2 opacity-100`}
         >
           <Pause />
+        </Button>
+      )}
+      {canForce && (
+        <Button
+          onClick={() => {
+            openConfirm({
+              title: 'Force Job Status',
+              message: `This job appears to be stuck. Do you want to force it to "stopped" status? This should only be used when a job is not responding to normal stop commands.`,
+              type: 'warning',
+              confirmText: 'Force Stop',
+              onConfirm: async () => {
+                await forceJobStatus(job.id, 'stopped');
+                if (onRefresh) onRefresh();
+              },
+            });
+          }}
+          className={`ml-2 opacity-100 text-orange-400 hover:text-orange-300`}
+        >
+          <AlertTriangle />
         </Button>
       )}
       {!hideView && (


### PR DESCRIPTION
Introduces an API endpoint to force-update a job's status, a utility function to call it, and a new action button in the JobActionBar for stuck jobs. This allows admins to manually set a job's status to 'stopped' when it is unresponsive to normal stop commands. I had an issue where the ui was closed, but the training was still running. The training crashed but didn't report back the error status , so it was stuck in limbo. 

This adds a button to the job list so you can force stop a job.
<img width="2089" height="702" alt="image" src="https://github.com/user-attachments/assets/9851a0b5-90f2-4915-8dc4-6aaf645c5340" />

<img width="479" height="208" alt="firefox_9zf0efrpb7" src="https://github.com/user-attachments/assets/90e62a13-6e4b-4c54-86bf-7496ab50bf8a" />
