### PR TITLE
Add experimental "Automagic" as an option in the UI 

### DIFF
--- a/ui/src/app/jobs/new/SimpleJob.tsx
+++ b/ui/src/app/jobs/new/SimpleJob.tsx
@@ -363,6 +363,7 @@ export default function SimpleJob({
                   options={[
                     { value: 'adamw8bit', label: 'AdamW8Bit' },
                     { value: 'adafactor', label: 'Adafactor' },
+                    { value: 'automagic', label: 'Automagic' },
                   ]}
                 />
                 <NumberInput


### PR DESCRIPTION
I want to add the ability to select `automagic` via the ui.
This optimizer is pure magic and works everytime, whatever I throw at it.
Unfortunately its not selectable and one needs to edit it via the advanced tab which is okay nothing too hard. 
But it would make my life simpler if I was be able to directly select it. ;)

<img width="1263" height="370" alt="image" src="https://github.com/user-attachments/assets/a9e860fc-6bd3-404a-843a-114bb7ea7990" />

P.S.:
To be honest, this app, this tool is unbelivable good and amazing to use. Nothing gets simplier.
Now with this "automagic" option I literally trained so many good loras. 
One thing for that just missing now is to get the best image available.

Best,