### PR TITLE
Ensure input text stays white in both light and dark themes when addi…

### DIFF
--- a/ui/src/components/formInputs.tsx
+++ b/ui/src/components/formInputs.tsx
@@ -12,7 +12,7 @@ const Select = dynamic(() => import('react-select'), { ssr: false });
 
 const labelClasses = 'block text-xs mb-1 mt-2 text-gray-300';
 const inputClasses =
-  'w-full text-sm px-3 py-1 bg-gray-800 border border-gray-700 rounded-sm focus:ring-2 focus:ring-gray-600 focus:border-transparent';
+'w-full text-sm px-3 py-1 bg-gray-800 border border-gray-700 rounded-sm focus:ring-2 focus:ring-gray-600 focus:border-transparent text-white';
 
 export interface InputProps {
   label?: string;


### PR DESCRIPTION
Fixes #367

This PR fixes the black-on-black text issue in the dataset name input field. 
The text color now contrasts properly with the background.

Before the fix:
<img width="1127" height="657" alt="Screenshot 2025-08-14 at 10 11 27 PM" src="https://github.com/user-attachments/assets/fa299143-3751-42d4-a1aa-d6232eaa8ced" />
After the fix:
<img width="1127" height="657" alt="Screenshot 2025-08-14 at 10 09 24 PM" src="https://github.com/user-attachments/assets/59b68172-a674-4ba5-b9d9-f2796007e85a" />
