### PR TITLE
fix(ui): parse Windows paths correctly to restore left-arrow navigation

### DIFF
--- a/ui/src/components/SampleImageModal.tsx
+++ b/ui/src/components/SampleImageModal.tsx
@@ -45,7 +45,8 @@ export default function SampleImageModal() {
       promptIdx: 0,
     };
     if (imageModal?.imgPath) {
-      const filename = imageModal.imgPath.split('/').pop();
+      const sep = imageModal.imgPath.includes('\\') ? '\\' : '/';
+      const filename = imageModal.imgPath.split(sep).pop();
       if (!filename) return ii;
       // filename is <timestep>__<zero_pad_step>_<prompt_idx>.<ext>
       ii.filename = filename as string;


### PR DESCRIPTION
Viewing sample images on Windows failed to parse the filename because the code split on '/', leaving promptIdx stuck at 0 and breaking left-arrow navigation. Detect the correct path separator when extracting the filename from imgPath in SampleImageModal.tsx. Behavior on macOS/Linux is unchanged.