### PR TITLE
Fix: Don't override user-specified T_0 in cosine_with_restarts scheduler

### DIFF
--- a/toolkit/scheduler.py
+++ b/toolkit/scheduler.py
@@ -15,8 +15,12 @@ def get_lr_scheduler(
             optimizer, **kwargs
         )
     elif name == "cosine_with_restarts":
-        if 'total_iters' in kwargs:
+        # Only use total_iters as T_0 if T_0 not already specified by user
+        if 'total_iters' in kwargs and 'T_0' not in kwargs:
             kwargs['T_0'] = kwargs.pop('total_iters')
+        elif 'total_iters' in kwargs:
+            # Remove total_iters if T_0 is already specified
+            kwargs.pop('total_iters')
         return torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
             optimizer, **kwargs
         )


### PR DESCRIPTION
## Summary
- Fixes bug where user-specified T_0 parameter was overridden by total_iters
- Preserves user's custom restart cycle configuration  
- Only uses total_iters as T_0 fallback when T_0 not provided
- Cleans up total_iters parameter to prevent PyTorch errors

## Problem
When using `cosine_with_restarts` scheduler with custom T_0, the scheduler ignores user configuration and uses total_iters instead, resulting in single long decay instead of restart cycles.

## Solution
Added conditional logic to preserve user-specified T_0 while maintaining backward compatibility for configs that don't specify T_0.

## Test plan
- [x] Verify user-specified T_0 is preserved
- [x] Verify total_iters still works as fallback  
- [x] Verify PyTorch CosineAnnealingWarmRestarts parameters are valid
- [ ] Test with actual training run showing LR resets at specified intervals

🤖 Generated with [Claude Code](https://claude.ai/code)