### PR TITLE
part 2 - this edit makes it so that ai toolkit can now accept user-defined optimizers such as schedule free and paged optimizers. - update BaseSDTrainProcess.py

### DIFF
--- a/jobs/process/BaseSDTrainProcess.py
+++ b/jobs/process/BaseSDTrainProcess.py
@@ -1915,7 +1915,7 @@ class BaseSDTrainProcess(BaseTrainProcess):
             self.step_num = self.train_config.start_step
             self.start_step = self.step_num
 
-        optimizer_type = self.train_config.optimizer.lower()
+        optimizer_type = self.train_config.optimizer
         
         # esure params require grad
         self.ensure_params_requires_grad(force=True)


### PR DESCRIPTION
deleting the .lower() should allow for dynamic importing of optimizers in the toolkit/optimizer.py script. the import is case sensitive - the import fails if optimizer_type is bitsandbytes.optim.pagedadamw, it would need to be bitsandbytes.optim.PagedAdamW

setting optimizer_type to lower() is redundant because optimzer.py is already reducing all to lower() when it checks for matches anyway.

Usage:
in the config, simply set the optimizer to the full module and class.

"bitsandbytes.optim.PagedAdamW" or "prodigyplus.prodigy_plus_schedulefree.ProdigyPlusScheduleFree"