### PR TITLE
Reserve RAM for video memory spillover

### DIFF
--- a/toolkit/config_modules.py
+++ b/toolkit/config_modules.py
@@ -638,6 +638,8 @@ class ModelConfig:
         # 0 is off and 1.0 is 100% of the layers
         self.layer_offloading_transformer_percent = kwargs.get("layer_offloading_transformer_percent", 1.0)
         self.layer_offloading_text_encoder_percent = kwargs.get("layer_offloading_text_encoder_percent", 1.0)
+        # number of GBs to reserve in RAM to prevent cuda OOM during initial load
+        self.reserve_ram_for_spillover = kwargs.get("reserve_ram_for_spillover", 0)
 
         # can be used to load the extras like text encoder or vae from here
         # only setup for some models but will prevent having to download the te for

--- a/ui/src/app/jobs/new/SimpleJob.tsx
+++ b/ui/src/app/jobs/new/SimpleJob.tsx
@@ -212,15 +212,26 @@ export default function SimpleJob({
                   checked={jobConfig.config.process[0].model.low_vram}
                   onChange={value => setJobConfig(value, 'config.process[0].model.low_vram')}
                 />
+                {jobConfig.config.process[0].model.low_vram && (
+                  <SliderInput
+                    label="Reserve RAM for Spillover (GB)"
+                    docKey="model.reserve_ram_for_spillover"
+                    value={jobConfig.config.process[0].model.reserve_ram_for_spillover ?? 0}
+                    onChange={value => setJobConfig(value, 'config.process[0].model.reserve_ram_for_spillover')}
+                    min={0}
+                    max={12}
+                    step={1}
+                  />
+                )}
               </FormGroup>
             )}
             {modelArch?.additionalSections?.includes('model.qie.match_target_res') && (
-                <Checkbox
-                  label="Match Target Res"
-                  docKey="model.qie.match_target_res"
-                  checked={jobConfig.config.process[0].model.model_kwargs.match_target_res}
-                  onChange={value => setJobConfig(value, 'config.process[0].model.model_kwargs.match_target_res')}
-                />
+              <Checkbox
+                label="Match Target Res"
+                docKey="model.qie.match_target_res"
+                checked={jobConfig.config.process[0].model.model_kwargs.match_target_res}
+                onChange={value => setJobConfig(value, 'config.process[0].model.model_kwargs.match_target_res')}
+              />
             )}
             {modelArch?.additionalSections?.includes('model.layer_offloading') && (
               <>

--- a/ui/src/docs.tsx
+++ b/ui/src/docs.tsx
@@ -228,6 +228,25 @@ const docs: { [key: string]: ConfigDoc } = {
       </>
     ),
   },
+
+  'model.reserve_ram_for_spillover': {
+    title: 'Reserve RAM for spillover',
+    description: (
+      <>
+        This option will reserve the specified amount of RAM (in gigabytes) at the beginning of the training run and
+        release it just before the model is loaded to video memory.
+        <br />
+        <br />
+        This can prevent CUDA Out of Memory errors during the training initialization in case when both RAM and VRAM are
+        at full capacity and the system cannot allocate RAM for video memory spillover. Especially useful in combination
+        with the "Layer Offloading" option as it uses a lot of RAM.
+        <br />
+        <br />
+        On low-end systems with both low RAM and low VRAM, system memory will be paged to disk and video memory will
+        fall back to RAM. This makes training slow but it will complete successfully even on low-end systems.
+      </>
+    ),
+  },
 };
 
 export const getDoc = (key: string | null | undefined): ConfigDoc | null => {

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -156,6 +156,7 @@ export interface ModelConfig {
   layer_offloading?: boolean;
   layer_offloading_transformer_percent?: number;
   layer_offloading_text_encoder_percent?: number;
+  reserve_ram_for_spillover?: number;
 }
 
 export interface SampleItem {


### PR DESCRIPTION
Hi, I tried the new "Layer Offloading" function and I'd like to contribute a little improvement that enables people to train on low-end systems where RAM is also low.
I added documentation that explains the idea:

> This option will reserve the specified amount of RAM (in gigabytes) at the beginning of the training run and
release it just before the model is loaded to video memory.
This can prevent CUDA Out of Memory errors during the training initialization in case when both RAM and VRAM are
at full capacity and the system cannot allocate RAM for video memory spillover. Especially useful in combination
with the "Layer Offloading" option as it uses a lot of RAM.
 On low-end systems with both low RAM and low VRAM, system memory will be paged to disk and video memory will
fall back to RAM. This makes training slow but it will complete successfully even on low-end systems.

---

I added a slider that shows under the "Low VRAM" option - with these settings I managed to run Qwen-Image training with just 12GB VRAM and just 32GB of RAM, instead of running into OOM:
<img width="662" height="499" alt="image" src="https://github.com/user-attachments/assets/9236efe6-5b3c-48b1-ab98-5c388e1a562e" />
<img width="560" height="381" alt="image" src="https://github.com/user-attachments/assets/95857522-2148-4b7d-805f-59976864248f" />

---

Please have a look whether this is an acceptable solution. I tested it on Windows.
