### PR TITLE
Enable Chroma finetune within 32gb RAM & 24gb VRAM

### DIFF
--- a/extensions_built_in/diffusion_models/chroma/chroma_model.py
+++ b/extensions_built_in/diffusion_models/chroma/chroma_model.py
@@ -167,8 +167,13 @@ class ChromaModel(BaseModel):
 
         chroma_params.depth = double_blocks
         chroma_params.depth_single_blocks = single_blocks
+
+        # load Chroma into RAM in bfloat16, go back to fp32 afterwards
+        def_dtype = torch.get_default_dtype()
+        torch.set_default_dtype(torch.bfloat16)
         transformer = Chroma(chroma_params)
-        
+        torch.set_default_dtype(def_dtype)
+
         # add dtype, not sure why it doesnt have it
         transformer.dtype = dtype
         # load the state dict into the model


### PR DESCRIPTION
Hello, I was trying to finetune Chroma1-HD on my setup, RTX 3090 and 32gb RAM. However, I was getting stuck during model loading, because the RAM was getting filled, resulting in my computer freezing every time.

In the `ChromaModel` class, the safetensors file is loaded first into the CPU, to be quantized. The Chroma checkpoint is too big to be loaded in full precision within 32gb RAM, so I changed the global dtype to be `bfloat16` during the initial loading, and then the normal dtypes afterwards.

With this configuration, I can easily finetune Chroma with my setup. 

I also fixed a bug related to `FakeTextEncoder` during loading (related issue: https://github.com/ostris/ai-toolkit/issues/405). 