### PR TITLE
Fix: Auto-start queue when job is queued

### DIFF
--- a/ui/src/app/api/jobs/[jobID]/start/route.ts
+++ b/ui/src/app/api/jobs/[jobID]/start/route.ts
@@ -34,13 +34,19 @@ export async function GET(request: NextRequest, { params }: { params: { jobID: s
     },
   });
 
-  // if queue doesn't exist, create it
+  // if queue doesn't exist, create it and start it automatically
   if (!queue) {
     await prisma.queue.create({
       data: {
         gpu_ids: job.gpu_ids,
-        is_running: false,
+        is_running: true,
       },
+    });
+  } else if (!queue.is_running) {
+    // if queue exists but is not running, start it
+    await prisma.queue.update({
+      where: { id: queue.id },
+      data: { is_running: true },
     });
   }
 


### PR DESCRIPTION
Previously, when a job was started via the UI, it would be queued but the queue itself would remain stopped. This caused jobs to never run until the queue was manually started.

Changes:
- Auto-start queue when creating it for a new GPU
- Auto-start existing queue if it's stopped when a job is queued
- Prevents the issue where jobs are queued but queue is not running

This fixes the UX issue where users expect "Start Job" to both queue the job AND start the queue processing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)