### PR TITLE
fix: misuse of train_config causing noise scheduler bug in GenerateProcess

### DIFF
--- a/jobs/process/GenerateProcess.py
+++ b/jobs/process/GenerateProcess.py
@@ -102,7 +102,7 @@ class GenerateProcess(BaseProcess):
             if self.model_config.is_lumina2:
                 arch = 'lumina2'
             sampler = get_sampler(
-                self.train_config.noise_scheduler,
+                self.generate_config.noise_scheduler,
                 {
                     "prediction_type": "v_prediction" if self.model_config.is_v_pred else "epsilon",
                 },


### PR DESCRIPTION
This PR fixes a bug in `GenerateProcess` where `train_config` was incorrectly used instead of `generate_config` when retrieving the noise scheduler configuration.

As reported in #416, users encountered an `AttributeError` when running inference after training:
```shell
AttributeError: 'GenerateProcess' object has no attribute 'train_config'
```