### PR TITLE
Suppress spurious warning about osx-temperature-sensor

### DIFF
--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -13,6 +13,11 @@ const nextConfig: NextConfig = {
       bodySizeLimit: '100mb',
     },
   },
+  webpack: (config) => {
+    // Suppress osx-temperature-sensor warning on non-MacOS
+    config.resolve.alias['osx-temperature-sensor'] = false;
+    return config;
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Running `npm run build_and_start` produces an error message
`Module not found: Can't resolve 'osx-temperature-sensor'`
on non-MacOS platforms.  This error is harmless but a nuisance.
