### PR TITLE
Increase upload body size limit to 500MB to prevent silent upload failures

### DIFF
--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -10,9 +10,9 @@ const nextConfig: NextConfig = {
   },
   experimental: {
     serverActions: {
-      bodySizeLimit: '100mb',
+      bodySizeLimit: '500mb',
     },
-    middlewareClientMaxBodySize: '100mb',
+    middlewareClientMaxBodySize: '500mb',
   },
 };
 


### PR DESCRIPTION
## Summary

Increase `bodySizeLimit` and `middlewareClientMaxBodySize` from **100MB to 500MB**.

## Background / Problem

When attempting to add multiple images whose **total size exceeds 100MB** on the **Datasets** screen, the upload fails silently.

* No error is shown in the UI
* Images are not added successfully
* The console logs the following errors:

```text
[UI] Request body exceeded 100MB for /api/datasets/upload. Only the first 100MB will be available unless configured. See https://nextjs.org/docs/app/api-reference/config/next-config-js/middlewareClientMaxBodySize for more details.
[UI] Upload error: TypeError: Failed to parse body as FormData.
[UI]     at async y (R:\StabilityMatrix\Data\Packages\AI-Toolkit\ui\.next\server\app\api\datasets\upload\route.js:1:1736)
[UI]     at async k (R:\StabilityMatrix\Data\Packages\AI-Toolkit\ui\.next\server\app\api\datasets\upload\route.js:1:5035)
```

This behavior is caused by the request body being truncated at the default 100MB limit, which results in invalid `FormData` being parsed on the server.

## Changes

* Increased `bodySizeLimit`
* Increased `middlewareClientMaxBodySize`
* New limit: **500MB**

## Rationale

Assuming:

* 1 PNG image ≈ **2MB**

The new limit allows uploading approximately **250 images** in a single request, which aligns better with practical dataset creation workflows.

## Impact

* Prevents silent upload failures on the Datasets screen
* Improves reliability when uploading large batches of images
* No behavioral changes for uploads under the previous 100MB limit