### PR TITLE
Fix dropdown font color for better visibility

### DIFF
--- a/ui/src/components/JobActionBar.tsx
+++ b/ui/src/components/JobActionBar.tsx
@@ -124,13 +124,13 @@ export default function JobActionBar({
         </MenuButton>
         <MenuItems anchor="bottom" className="bg-gray-900 border border-gray-700 rounded shadow-lg w-48 px-2 py-2 mt-4">
           <MenuItem>
-            <Link href={`/jobs/new?cloneId=${job.id}`} className="cursor-pointer px-4 py-1 hover:bg-gray-800 rounded block">
+            <Link href={`/jobs/new?cloneId=${job.id}`} className="cursor-pointer px-4 py-1 hover:bg-gray-800 rounded block text-white">
               Clone Job
             </Link>
           </MenuItem>
           <MenuItem>
             <div
-              className="cursor-pointer px-4 py-1 hover:bg-gray-800 rounded"
+              className="cursor-pointer px-4 py-1 hover:bg-gray-800 rounded text-white"
               onClick={() => {
                 let message = `Are you sure you want to mark this job as stopped? This will set the job status to 'stopped' if the status is hung. Only do this if you are 100% sure the job is stopped. This will NOT stop the job.`;
                 openConfirm({


### PR DESCRIPTION
This PR fixes the invisible text issue on the Training Jobs screen.

Before:
<img width="480" height="156" alt="2025-12-23 14_34_56" src="https://github.com/user-attachments/assets/b3f2b676-ba4d-403a-af56-8dacf761259e" />

After:
<img width="491" height="159" alt="2025-12-23 14_34_07" src="https://github.com/user-attachments/assets/b6361a79-b784-4a38-b7ee-610f1e3ab8a8" />

This issue is similar to PR #373 .