### PR TITLE
PR to allow more user-defined optimizers by import path (package.module.name) without breaking prior configs.  So far only works in advanced editor.  Examples include prodigyplus.prodigy_plus_schedulefree.ProdigyPlusScheduleFree

### DIFF
--- a/jobs/process/BaseSDTrainProcess.py
+++ b/jobs/process/BaseSDTrainProcess.py
@@ -1935,7 +1935,7 @@ class BaseSDTrainProcess(BaseTrainProcess):
             self.step_num = self.train_config.start_step
             self.start_step = self.step_num
 
-        optimizer_type = self.train_config.optimizer.lower()
+        optimizer_type = self.train_config.optimizer
         
         # esure params require grad
         self.ensure_params_requires_grad(force=True)


### PR DESCRIPTION
This PR allows users to enter any optimizer import path into their config files.  Prior to this PR, users could only enter the names hardcoded optimizers.  There were only a few to pick from.  This will open it up to any optimizer without needing to rewrite code or make major changes to config files.

I made one very small change to one single line in ai-toolkit/jobs/process/BaseSDTrainProcess.py - this script changes the case of the optimizer input to lower case, but this is redundant as your ai-toolkit/toolkit/optimzer.py also does this when comparing strings with names of hardcoded optimizers.

I tweaked the optimizer.py script to allow users to continue using the hard-coded names of optimizers - this will prevent existing configs to be broken.  I added some changes at the end of the script which will dynamicailly load the entered optimizer.

No code changes needed to be made for optimizer_params as these are passed through from the config file when creating the optimizer.

Note, optimizers should throw their own errors, so you do not need to hardcode any error messages. 

Examples:
bitsandbytes.optim.PagedAdamW
prodigyplus.prodigy_plus_schedulefree.ProdigyPlusScheduleFree
bitsandbytes.optim.LAMB

<img width="870" height="384" alt="image" src="https://github.com/user-attachments/assets/75a8689e-d1a1-49cc-8536-a1d9181f88da" />

<img width="1361" height="239" alt="image" src="https://github.com/user-attachments/assets/2dddee37-1c0d-4f59-ba63-6a2b9e6152b6" />