### PR TITLE
feat: Add sequential_load option for low-RAM environments

### DIFF
--- a/config/examples/train_lora_flux_low_ram.yaml
+++ b/config/examples/train_lora_flux_low_ram.yaml
@@ -1,0 +1,132 @@
+# FLUX LoRA Training Config for Low-RAM Environments (e.g., Google Colab Free Tier)
+# 
+# This config enables training FLUX.1-dev on low-RAM systems by using
+# sequential loading: text encoders are loaded first, embeddings cached to disk,
+# then text encoders are unloaded BEFORE the transformer is loaded.
+# This prevents having both loaded simultaneously, significantly reducing peak RAM.
+#
+# Requirements:
+#   - sequential_load: true (enables deferred transformer loading)
+#   - cache_text_embeddings: true (caches embeddings so TE can be unloaded)
+#   - low_vram: true (keeps components on CPU during quantization)
+#
+# Memory Timeline:
+#   1. Load T5 + CLIP text encoders
+#   2. Cache all text embeddings to disk
+#   3. Unload text encoders (RAM freed)
+#   4. Load transformer
+#   5. Train normally
+
+---
+job: "extension"
+config:
+  name: "flux_lora_low_ram"
+  process:
+    - type: "sd_trainer"
+      training_folder: "output"
+      device: "cuda"
+      trigger_word: null
+      performance_log_every: 10
+      
+      network:
+        type: "lora"
+        linear: 16
+        linear_alpha: 16
+        network_kwargs:
+          ignore_if_contains: []
+          
+      save:
+        dtype: "float16"
+        save_every: 250
+        max_step_saves_to_keep: 2
+        save_format: "diffusers"
+        push_to_hub: false
+        
+      datasets:
+        - folder_path: "/content/training_images"
+          mask_path: null
+          mask_min_value: 0.1
+          default_caption: ""
+          caption_ext: "txt"
+          caption_dropout_rate: 0.05
+          cache_latents_to_disk: true
+          is_reg: false
+          network_weight: 1
+          resolution:
+            - 512
+            - 768
+            - 1024
+          controls: []
+          flip_x: false
+          flip_y: false
+          
+      train:
+        batch_size: 1
+        steps: 1000
+        gradient_accumulation: 1
+        train_unet: true
+        train_text_encoder: false
+        gradient_checkpointing: true
+        noise_scheduler: "flowmatch"
+        timestep_type: "sigmoid"
+        content_or_style: "balanced"
+        optimizer: "adamw8bit"
+        optimizer_params:
+          weight_decay: 0.0001
+        lr: 0.0001
+        dtype: "bf16"
+        # CRITICAL: must cache text embeddings for sequential loading to work
+        cache_text_embeddings: true
+        unload_text_encoder: false
+        ema_config:
+          use_ema: false
+          ema_decay: 0.99
+        skip_first_sample: false
+        force_first_sample: false
+        disable_sampling: false
+        diff_output_preservation: false
+        diff_output_preservation_multiplier: 1
+        diff_output_preservation_class: "person"
+        loss_type: "mse"
+        
+      logging:
+        log_every: 1
+        use_ui_logger: true
+        
+      model:
+        # Can use pre-quantized BnB model or standard model with quantization
+        name_or_path: "diffusers/FLUX.1-dev-bnb-8bit"
+        arch: "flux"
+        
+        # CRITICAL: Enable sequential loading for low RAM usage
+        sequential_load: true
+        
+        # Quantization settings
+        quantize: true
+        qtype: "qfloat8"
+        quantize_te: true
+        qtype_te: "qfloat8"
+        
+        # Keep on CPU during loading/quantization
+        low_vram: true
+        model_kwargs: {}
+        
+      sample:
+        sampler: "flowmatch"
+        sample_every: 250
+        width: 1024
+        height: 1024
+        samples:
+          - prompt: "a photo of [trigger] person"
+          - prompt: "a woman with red hair, studio lighting"
+        neg: ""
+        seed: 42
+        walk_seed: true
+        guidance_scale: 3.5
+        sample_steps: 20
+        num_frames: 1
+        fps: 1
+        
+meta:
+  name: "flux_lora_low_ram"
+  version: "1.0"

--- a/extensions_built_in/sd_trainer/SDTrainer.py
+++ b/extensions_built_in/sd_trainer/SDTrainer.py
@@ -347,6 +347,11 @@ class SDTrainer(BaseSDTrainProcess):
                     # keep legacy usage for now. 
                     self.sd.text_encoder_to("cpu")
                 flush()
+                
+                # Load deferred transformer now that text encoders are unloaded
+                # This is for sequential_load mode to reduce peak RAM usage
+                if hasattr(self.sd, 'load_deferred_transformer'):
+                    self.sd.load_deferred_transformer()
         
         if self.train_config.blank_prompt_preservation and self.cached_blank_embeds is None:
             # make sure we have this if not unloading

--- a/toolkit/config_modules.py
+++ b/toolkit/config_modules.py
@@ -653,6 +653,11 @@ class ModelConfig:
         # 0 is off and 1.0 is 100% of the layers
         self.layer_offloading_transformer_percent = kwargs.get("layer_offloading_transformer_percent", 1.0)
         self.layer_offloading_text_encoder_percent = kwargs.get("layer_offloading_text_encoder_percent", 1.0)
+        
+        # Sequential loading: load text encoders first, cache embeddings, unload, then load transformer
+        # This significantly reduces peak RAM usage for low-RAM environments like Colab Free Tier
+        # Prevents loading transformer AND text encoders simultaneously
+        self.sequential_load = kwargs.get("sequential_load", False)
 
         # can be used to load the extras like text encoder or vae from here
         # only setup for some models but will prevent having to download the te for

--- a/toolkit/stable_diffusion_model.py
+++ b/toolkit/stable_diffusion_model.py
@@ -812,10 +812,8 @@ class StableDiffusion:
                     freeze(transformer)
                     transformer.to(self.device_torch)
                 else:
-                    # BnB pre-quantized models cannot have dtype changed
-                    if is_bnb_quantized(transformer):
-                        transformer.to(self.device_torch)
-                    else:
+                    # BnB pre-quantized models cannot have .to() called at all - already on correct device
+                    if not is_bnb_quantized(transformer):
                         transformer.to(self.device_torch, dtype=dtype)
 
             flush()
@@ -833,10 +831,8 @@ class StableDiffusion:
             text_encoder_2 = T5EncoderModel.from_pretrained(base_model_path, subfolder="text_encoder_2",
                                                             torch_dtype=dtype)
 
-            # BnB pre-quantized models cannot have dtype changed
-            if is_bnb_quantized(text_encoder_2):
-                text_encoder_2.to(self.device_torch)
-            else:
+            # BnB pre-quantized models cannot have .to() called at all - already on correct device
+            if not is_bnb_quantized(text_encoder_2):
                 text_encoder_2.to(self.device_torch, dtype=dtype)
             flush()
 
@@ -849,10 +845,8 @@ class StableDiffusion:
             self.print_and_status_update("Loading CLIP")
             text_encoder = CLIPTextModel.from_pretrained(base_model_path, subfolder="text_encoder", torch_dtype=dtype)
             tokenizer = CLIPTokenizer.from_pretrained(base_model_path, subfolder="tokenizer", torch_dtype=dtype)
-            # BnB pre-quantized models cannot have dtype changed
-            if is_bnb_quantized(text_encoder):
-                text_encoder.to(self.device_torch)
-            else:
+            # BnB pre-quantized models cannot have .to() called at all - already on correct device
+            if not is_bnb_quantized(text_encoder):
                 text_encoder.to(self.device_torch, dtype=dtype)
 
             self.print_and_status_update("Making pipe")
@@ -1220,10 +1214,8 @@ class StableDiffusion:
             freeze(transformer)
             transformer.to(self.device_torch)
         else:
-            # BnB pre-quantized models cannot have dtype changed
-            if is_bnb_quantized(transformer):
-                transformer.to(self.device_torch)
-            else:
+            # BnB pre-quantized models cannot have .to() called at all - already on correct device
+            if not is_bnb_quantized(transformer):
                 transformer.to(self.device_torch, dtype=dtype)
         
         flush()

--- a/ui/src/app/jobs/new/SimpleJob.tsx
+++ b/ui/src/app/jobs/new/SimpleJob.tsx
@@ -219,13 +219,29 @@ export default function SimpleJob({
                 placeholder=""
               />
             )}
-            {modelArch?.additionalSections?.includes('model.low_vram') && (
+            {(modelArch?.additionalSections?.includes('model.low_vram') || modelArch?.additionalSections?.includes('model.sequential_load')) && (
               <FormGroup label="Options">
-                <Checkbox
-                  label="Low VRAM"
-                  checked={jobConfig.config.process[0].model.low_vram}
-                  onChange={value => setJobConfig(value, 'config.process[0].model.low_vram')}
-                />
+                {modelArch?.additionalSections?.includes('model.low_vram') && (
+                  <Checkbox
+                    label="Low VRAM"
+                    checked={jobConfig.config.process[0].model.low_vram}
+                    onChange={value => setJobConfig(value, 'config.process[0].model.low_vram')}
+                  />
+                )}
+                {modelArch?.additionalSections?.includes('model.sequential_load') && (
+                  <Checkbox
+                    label="Sequential Load (Low RAM)"
+                    checked={jobConfig.config.process[0].model.sequential_load || false}
+                    onChange={value => {
+                      setJobConfig(value, 'config.process[0].model.sequential_load');
+                      // Sequential load requires cache_text_embeddings to work
+                      if (value) {
+                        setJobConfig(true, 'config.process[0].train.cache_text_embeddings');
+                      }
+                    }}
+                    docKey="model.sequential_load"
+                  />
+                )}
               </FormGroup>
             )}
             {modelArch?.additionalSections?.includes('model.qie.match_target_res') && (

--- a/ui/src/app/jobs/new/options.ts
+++ b/ui/src/app/jobs/new/options.ts
@@ -23,6 +23,7 @@ type AdditionalSections =
   | 'model.multistage'
   | 'model.layer_offloading'
   | 'model.low_vram'
+  | 'model.sequential_load'
   | 'model.qie.match_target_res'
   | 'model.assistant_lora_path';
 type ModelGroup = 'image' | 'instruction' | 'video';
@@ -55,6 +56,7 @@ export const modelArchs: ModelArch[] = [
       'config.process[0].train.noise_scheduler': ['flowmatch', 'flowmatch'],
     },
     disableSections: ['network.conv'],
+    additionalSections: ['model.low_vram', 'model.sequential_load'],
   },
   {
     name: 'flux_kontext',

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -156,6 +156,7 @@ export interface ModelConfig {
   quantize_kwargs?: QuantizeKwargsConfig;
   arch: string;
   low_vram: boolean;
+  sequential_load?: boolean;
   model_kwargs: { [key: string]: any };
   layer_offloading?: boolean;
   layer_offloading_transformer_percent?: number;


### PR DESCRIPTION
This feature enables training Flux models on systems with limited RAM
(like Google Colab Free Tier) by loading text encoders first, caching
embeddings to disk, unloading text encoders, then loading the transformer.
This prevents having both loaded simultaneously, reducing peak RAM usage.

Changes:
- Add sequential_load config option to ModelConfig
- Defer transformer loading in stable_diffusion_model.py when enabled
- Add load_deferred_transformer() method to StableDiffusion class
- Integrate with SDTrainer to load transformer after TE caching/unload
- Add UI checkbox in SimpleJob.tsx for Flux models
- Add example config: train_lora_flux_low_ram.yaml

Usage:
  model:
    sequential_load: true
  train:
    cache_text_embeddings: true