### PR TITLE
feat: support nested dataset folders

### DIFF
--- a/ui/src/app/api/datasets/delete/route.tsx
+++ b/ui/src/app/api/datasets/delete/route.tsx
@@ -7,8 +7,23 @@ export async function POST(request: Request) {
   try {
     const body = await request.json();
     const { name } = body;
+
+    if (!name) {
+      return NextResponse.json({ error: 'Dataset name is required' }, { status: 400 });
+    }
+
     let datasetsPath = await getDatasetsRoot();
-    let datasetPath = path.join(datasetsPath, name);
+
+    // Security check: normalize the path and validate it
+    const normalizedPath = path.normalize(name).replace(/^(\.\.(\/|\\|$))+/, '');
+    let datasetPath = path.join(datasetsPath, normalizedPath);
+
+    // Ensure paths are within datasetsPath (to prevent path traversal attacks)
+    const resolvedPath = path.resolve(datasetPath);
+    const resolvedBase = path.resolve(datasetsPath);
+    if (!resolvedPath.startsWith(resolvedBase)) {
+      return NextResponse.json({ error: 'Invalid path' }, { status: 400 });
+    }
 
     // if folder doesnt exist, ignore
     if (!fs.existsSync(datasetPath)) {
@@ -19,6 +34,6 @@ export async function POST(request: Request) {
     fs.rmdirSync(datasetPath, { recursive: true });
     return NextResponse.json({ success: true });
   } catch (error) {
-    return NextResponse.json({ error: 'Failed to create dataset' }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to delete dataset' }, { status: 500 });
   }
 }

--- a/ui/src/app/api/datasets/list/route.ts
+++ b/ui/src/app/api/datasets/list/route.ts
@@ -1,6 +1,33 @@
 import { NextResponse } from 'next/server';
 import fs from 'fs';
+import path from 'path';
 import { getDatasetsRoot } from '@/server/settings';
+
+/**
+ * Recursively get all subfolders (returns relative paths)
+ * @param baseDir Base directory
+ * @param currentPath Current relative path
+ * @returns Array of relative paths to all subfolders
+ */
+function getAllSubfolders(baseDir: string, currentPath: string = ''): string[] {
+  const results: string[] = [];
+  const fullPath = path.join(baseDir, currentPath);
+
+  if (!fs.existsSync(fullPath)) return results;
+
+  const items = fs.readdirSync(fullPath, { withFileTypes: true });
+
+  for (const item of items) {
+    if (item.isDirectory() && !item.name.startsWith('.') && item.name !== '_controls') {
+      const relativePath = currentPath ? `${currentPath}/${item.name}` : item.name;
+      results.push(relativePath);
+      // Recursively get subfolders
+      results.push(...getAllSubfolders(baseDir, relativePath));
+    }
+  }
+
+  return results;
+}
 
 export async function GET() {
   try {
@@ -8,15 +35,11 @@ export async function GET() {
 
     // if folder doesnt exist, create it
     if (!fs.existsSync(datasetsPath)) {
-      fs.mkdirSync(datasetsPath);
+      fs.mkdirSync(datasetsPath, { recursive: true });
     }
 
-    // find all the folders in the datasets folder
-    let folders = fs
-      .readdirSync(datasetsPath, { withFileTypes: true })
-      .filter(dirent => dirent.isDirectory())
-      .filter(dirent => !dirent.name.startsWith('.'))
-      .map(dirent => dirent.name);
+    // Recursively get all folders (including nested)
+    const folders = getAllSubfolders(datasetsPath);
 
     return NextResponse.json(folders);
   } catch (error) {


### PR DESCRIPTION
I found that the dataset only supports first-level directories, and now this pr support the selection of nested datasets.
The goal is to:
- Allow users to logically organize datasets in hierarchical folders
- Ensure all filesystem operations remain safely scoped within the datasets root
## Changes
### **Backend (API)**
**Create dataset**
- Clean dataset names per path segment (preserves /)
- Reject empty / invalid paths
- Create directories recursively for nested datasets
- Delete / listImages / upload
- Normalize user-provided paths
- Enforce resolved paths to stay within datasets root

**List datasets**

- Recursively enumerate dataset folders
- Exclude hidden folders and internal control directories

### **Frontend (UI)**
- Switch dataset routing to catch-all route: `/datasets/[...datasetPath]`
- Display hierarchical datasets with folder depth indicators
- Add breadcrumb navigation for nested datasets
- Show full dataset path when inside nested folders
- Improve dataset creation UX with clearer hints and examples

<img width="2196" height="642" alt="image" src="https://github.com/user-attachments/assets/843d3fdd-cf48-4b90-8776-13923bae6638" />

<img width="1750" height="642" alt="image" src="https://github.com/user-attachments/assets/ed5cc1c3-d3eb-464e-9a96-a29ffc3a9b7e" />

<img width="2218" height="1044" alt="image" src="https://github.com/user-attachments/assets/c8b3a673-ca2b-4c1a-84ae-eb84f1c6aad2" />
<img width="2238" height="1194" alt="image" src="https://github.com/user-attachments/assets/4716187c-916c-4415-9a88-8c6a3a22f8ac" />

