### PR TITLE
feat: stricter layer offloading for flux2-klein

### DIFF
--- a/extensions_built_in/diffusion_models/flux2/flux2_klein_model.py
+++ b/extensions_built_in/diffusion_models/flux2/flux2_klein_model.py
@@ -45,7 +45,7 @@ class Flux2KleinModel(Flux2Model):
             torch_dtype=dtype,
         )
 
-        if not self.model_config.layer_offloading:
+        if not self.model_config.low_vram:
             text_encoder.to(self.device_torch, dtype=dtype)
 
         if self.model_config.quantize_te:

--- a/extensions_built_in/diffusion_models/flux2/flux2_klein_model.py
+++ b/extensions_built_in/diffusion_models/flux2/flux2_klein_model.py
@@ -44,13 +44,15 @@ class Flux2KleinModel(Flux2Model):
             self.flux2_klein_te_path,
             torch_dtype=dtype,
         )
-        text_encoder.to(self.device_torch, dtype=dtype)
 
-        flush()
+        if self.model_config.layer_offloading:
+            text_encoder.to('cpu')
+        else:
+            text_encoder.to(self.device_torch, dtype=dtype)
 
         if self.model_config.quantize_te:
             self.print_and_status_update("Quantizing Qwen3")
-            quantize(text_encoder, weights=get_qtype(self.model_config.qtype))
+            quantize(text_encoder, weights=get_qtype(self.model_config.qtype_te))
             freeze(text_encoder)
             flush()
 
@@ -63,6 +65,8 @@ class Flux2KleinModel(Flux2Model):
                 self.device_torch,
                 offload_percent=self.model_config.layer_offloading_text_encoder_percent,
             )
+
+        flush()
 
         tokenizer = Qwen2Tokenizer.from_pretrained(self.flux2_klein_te_path)
         return text_encoder, tokenizer

--- a/extensions_built_in/diffusion_models/flux2/flux2_klein_model.py
+++ b/extensions_built_in/diffusion_models/flux2/flux2_klein_model.py
@@ -45,9 +45,7 @@ class Flux2KleinModel(Flux2Model):
             torch_dtype=dtype,
         )
 
-        if self.model_config.layer_offloading:
-            text_encoder.to('cpu')
-        else:
+        if not self.model_config.layer_offloading:
             text_encoder.to(self.device_torch, dtype=dtype)
 
         if self.model_config.quantize_te:
@@ -65,6 +63,9 @@ class Flux2KleinModel(Flux2Model):
                 self.device_torch,
                 offload_percent=self.model_config.layer_offloading_text_encoder_percent,
             )
+
+        if self.model_config.layer_offloading:
+            text_encoder.to('cpu')
 
         flush()
 

--- a/extensions_built_in/diffusion_models/flux2/flux2_model.py
+++ b/extensions_built_in/diffusion_models/flux2/flux2_model.py
@@ -102,7 +102,7 @@ class Flux2Model(BaseModel):
             )
         )
  
-        if not self.model_config.layer_offloading:
+        if not self.model_config.low_vram:
             text_encoder.to(self.device_torch, dtype=dtype)
 
         if self.model_config.quantize_te:

--- a/extensions_built_in/diffusion_models/flux2/flux2_model.py
+++ b/extensions_built_in/diffusion_models/flux2/flux2_model.py
@@ -160,7 +160,7 @@ class Flux2Model(BaseModel):
         transformer.load_state_dict(transformer_state_dict, assign=True)
 
         if not self.model_config.layer_offloading:
-            transformer.to(self.device_torch, dtype=dtype)
+            transformer.to(self.quantize_device, dtype=dtype)
 
         if self.model_config.quantize:
             # patch the state dict method

--- a/extensions_built_in/diffusion_models/flux2/flux2_model.py
+++ b/extensions_built_in/diffusion_models/flux2/flux2_model.py
@@ -101,7 +101,7 @@ class Flux2Model(BaseModel):
                 torch_dtype=dtype,
             )
         )
-        if not self.model_config.low_vram and not self.model_config.layer_offloading:
+        if not self.model_config.layer_offloading:
             text_encoder.to(self.device_torch, dtype=dtype)
 
         if self.model_config.quantize_te:
@@ -155,7 +155,7 @@ class Flux2Model(BaseModel):
 
         transformer.load_state_dict(transformer_state_dict, assign=True)
 
-        if not self.model_config.low_vram and not self.model_config.layer_offloading:
+        if not self.model_config.layer_offloading:
             transformer.to(self.device_torch, dtype=dtype)
 
         if self.model_config.quantize:
@@ -164,11 +164,11 @@ class Flux2Model(BaseModel):
             self.print_and_status_update("Quantizing Transformer")
             quantize_model(self, transformer)
             flush()
-            if not self.model_config.low_vram and not self.model_config.layer_offloading:
+            if not self.model_config.layer_offloading:
                 # make sure we are on the same device after quantization
                 transformer.to(self.device_torch, dtype=dtype)
 
-        if self.model_config.low_vram and self.model_config.layer_offloading:
+        if self.model_config.layer_offloading:
             self.print_and_status_update("Moving transformer to CPU")
             transformer.to("cpu")
 
@@ -240,7 +240,7 @@ class Flux2Model(BaseModel):
         text_encoder[0].to(self.device_torch)
         text_encoder[0].requires_grad_(False)
         text_encoder[0].eval()
-        if not self.model_config.low_vram and not self.model_config.layer_offloading:
+        if not self.model_config.layer_offloading:
             pipe.transformer = pipe.transformer.to(self.device_torch)
         flush()
 

--- a/extensions_built_in/diffusion_models/flux2/flux2_model.py
+++ b/extensions_built_in/diffusion_models/flux2/flux2_model.py
@@ -168,13 +168,12 @@ class Flux2Model(BaseModel):
             self.print_and_status_update("Quantizing Transformer")
             quantize_model(self, transformer)
             flush()
-            if not self.model_config.layer_offloading:
-                # make sure we are on the same device after quantization
-                transformer.to(self.device_torch, dtype=dtype)
 
         if self.model_config.layer_offloading:
             self.print_and_status_update("Moving transformer to CPU")
             transformer.to("cpu")
+        else:
+            transformer.to(self.device_torch, dtype=dtype)
 
         if (
             self.model_config.layer_offloading

--- a/extensions_built_in/diffusion_models/flux2/flux2_model.py
+++ b/extensions_built_in/diffusion_models/flux2/flux2_model.py
@@ -159,7 +159,7 @@ class Flux2Model(BaseModel):
 
         transformer.load_state_dict(transformer_state_dict, assign=True)
 
-        if not self.model_config.layer_offloading:
+        if not self.model_config.low_vram:
             transformer.to(self.quantize_device, dtype=dtype)
 
         if self.model_config.quantize:

--- a/toolkit/util/quantize.py
+++ b/toolkit/util/quantize.py
@@ -253,7 +253,6 @@ def quantize_model(
         network.apply_to(
             None, model_to_quantize, apply_text_encoder=False, apply_unet=True
         )
-
         network.force_to(base_model.device_torch, dtype=base_model.torch_dtype)
         network._update_torch_multiplier()
         network.load_weights(lora_state_dict)

--- a/toolkit/util/quantize.py
+++ b/toolkit/util/quantize.py
@@ -254,12 +254,8 @@ def quantize_model(
             None, model_to_quantize, apply_text_encoder=False, apply_unet=True
         )
 
-        if base_model.model_config.low_vram and base_model.model_config.layer_offloading:
-            network.force_to('cpu')
-        else:
-            network.force_to(base_model.device_torch, dtype=base_model.torch_dtype)
-            network._update_torch_multiplier()
-            
+        network.force_to(base_model.device_torch, dtype=base_model.torch_dtype)
+        network._update_torch_multiplier()
         network.load_weights(lora_state_dict)
         network.eval()
         network.is_active = True

--- a/toolkit/util/quantize.py
+++ b/toolkit/util/quantize.py
@@ -253,8 +253,8 @@ def quantize_model(
         network.apply_to(
             None, model_to_quantize, apply_text_encoder=False, apply_unet=True
         )
-    
-        if base_model.model_config.low_vram:
+
+        if base_model.model_config.low_vram and base_model.model_config.layer_offloading:
             network.force_to('cpu')
         else:
             network.force_to(base_model.device_torch, dtype=base_model.torch_dtype)

--- a/toolkit/util/quantize.py
+++ b/toolkit/util/quantize.py
@@ -253,8 +253,13 @@ def quantize_model(
         network.apply_to(
             None, model_to_quantize, apply_text_encoder=False, apply_unet=True
         )
-        network.force_to(base_model.device_torch, dtype=base_model.torch_dtype)
-        network._update_torch_multiplier()
+    
+        if base_model.model_config.low_vram:
+            network.force_to('cpu')
+        else:
+            network.force_to(base_model.device_torch, dtype=base_model.torch_dtype)
+            network._update_torch_multiplier()
+            
         network.load_weights(lora_state_dict)
         network.eval()
         network.is_active = True


### PR DESCRIPTION
### Summary
Changes to flux2-klein and shared flux2 code that more aggressively offloads models to CPU memory when the low_vram and layer_offloading job config options are set. I needed these changes to train a klein-9b (fp8 quantized) LoRA on 16gb of vram on windows. I haven't been able to test on other OS/hardware, but the changes are small and should only affect jobs that are using low_vram and/or layer_offloading.

### Testing
Windows 11 + 5070ti , klein 9b lora was able to be trained @ 60% transformer offload and 100% TE offload without oom, cache latents and blank prompt preservation were the only other options enabled from the defaults.

I will try to do more testing as I can but don't have access to much hardware. The code changes improved things a lot for me so I wanted to share.