### PR TITLE
Fix UI dataset list to recognize symbolic links

### DIFF
--- a/ui/src/app/api/datasets/list/route.ts
+++ b/ui/src/app/api/datasets/list/route.ts
@@ -11,10 +11,22 @@ export async function GET() {
       fs.mkdirSync(datasetsPath);
     }
 
-    // find all the folders in the datasets folder
+    // find all the folders in the datasets folder (including symlinks)
     let folders = fs
       .readdirSync(datasetsPath, { withFileTypes: true })
-      .filter(dirent => dirent.isDirectory())
+      .filter(dirent => {
+        // Check if it's a directory or a symlink pointing to a directory
+        if (dirent.isDirectory()) return true;
+        if (dirent.isSymbolicLink()) {
+          const fullPath = `${datasetsPath}/${dirent.name}`;
+          try {
+            return fs.statSync(fullPath).isDirectory();
+          } catch {
+            return false;
+          }
+        }
+        return false;
+      })
       .filter(dirent => !dirent.name.startsWith('.'))
       .map(dirent => dirent.name);
 


### PR DESCRIPTION
## Description
This PR fixes the dataset scanner in the UI to recognize symbolic links pointing to directories.

## Problem
The current implementation only checks for regular directories using `isDirectory()`, which doesn't follow symbolic links. This prevents users from organizing datasets using symlinks without duplicating data.

## Solution
- Check if a dirent is a symbolic link
- Use `fs.statSync()` to verify the symlink points to a directory  
- Gracefully handle broken symlinks with try/catch

## Changes
- Modified `ui/src/app/api/datasets/list/route.ts` to detect both regular directories and symbolic links

## Testing
Tested with symbolic links on Windows and they now appear correctly in the dataset list.