### PR TITLE
Adds support for user-provided safetensor/comfyui checkpoints for Z-Image Turbo

### DIFF
--- a/extensions_built_in/diffusion_models/wan22/wan22_14b_i2v_model.py
+++ b/extensions_built_in/diffusion_models/wan22/wan22_14b_i2v_model.py
@@ -15,18 +15,7 @@ from .wan22_14b_model import Wan2214bModel
 class Wan2214bI2VModel(Wan2214bModel):
     arch = "wan22_14b_i2v"
     
-    def get_model_has_grad(self):
-        # Check if the transformers have gradients enabled
-        # We need to check both transformers since this is a dual model
-        transformer_1_has_grad = self.model.transformer_1.proj_out.weight.requires_grad
-        transformer_2_has_grad = self.model.transformer_2.proj_out.weight.requires_grad
-        return transformer_1_has_grad or transformer_2_has_grad
 
-    def get_te_has_grad(self):
-        # Check if the text encoder has gradients enabled
-        return self.text_encoder.encoder.block[0].layer[0].SelfAttention.q.weight.requires_grad
-    
-    
     def generate_single_image(
         self,
         pipeline: Wan22Pipeline,

--- a/extensions_built_in/diffusion_models/wan22/wan22_14b_i2v_model.py
+++ b/extensions_built_in/diffusion_models/wan22/wan22_14b_i2v_model.py
@@ -15,7 +15,7 @@ from .wan22_14b_model import Wan2214bModel
 class Wan2214bI2VModel(Wan2214bModel):
     arch = "wan22_14b_i2v"
     
-
+    
     def generate_single_image(
         self,
         pipeline: Wan22Pipeline,

--- a/extensions_built_in/diffusion_models/wan22/wan22_14b_i2v_model.py
+++ b/extensions_built_in/diffusion_models/wan22/wan22_14b_i2v_model.py
@@ -14,8 +14,8 @@ from .wan22_14b_model import Wan2214bModel
 
 class Wan2214bI2VModel(Wan2214bModel):
     arch = "wan22_14b_i2v"
-
     
+
     def generate_single_image(
         self,
         pipeline: Wan22Pipeline,

--- a/extensions_built_in/diffusion_models/wan22/wan22_14b_i2v_model.py
+++ b/extensions_built_in/diffusion_models/wan22/wan22_14b_i2v_model.py
@@ -15,6 +15,17 @@ from .wan22_14b_model import Wan2214bModel
 class Wan2214bI2VModel(Wan2214bModel):
     arch = "wan22_14b_i2v"
     
+    def get_model_has_grad(self):
+        # Check if the transformers have gradients enabled
+        # We need to check both transformers since this is a dual model
+        transformer_1_has_grad = self.model.transformer_1.proj_out.weight.requires_grad
+        transformer_2_has_grad = self.model.transformer_2.proj_out.weight.requires_grad
+        return transformer_1_has_grad or transformer_2_has_grad
+
+    def get_te_has_grad(self):
+        # Check if the text encoder has gradients enabled
+        return self.text_encoder.encoder.block[0].layer[0].SelfAttention.q.weight.requires_grad
+    
     
     def generate_single_image(
         self,

--- a/extensions_built_in/diffusion_models/wan22/wan22_14b_i2v_model.py
+++ b/extensions_built_in/diffusion_models/wan22/wan22_14b_i2v_model.py
@@ -14,8 +14,8 @@ from .wan22_14b_model import Wan2214bModel
 
 class Wan2214bI2VModel(Wan2214bModel):
     arch = "wan22_14b_i2v"
-    
 
+    
     def generate_single_image(
         self,
         pipeline: Wan22Pipeline,

--- a/extensions_built_in/diffusion_models/z_image/z_image.py
+++ b/extensions_built_in/diffusion_models/z_image/z_image.py
@@ -372,11 +372,7 @@ class ZImageModel(BaseModel):
 
         flush()
 
-        # Load text encoder and tokenizer from base_model_path
-        # Using subfolder parameter ensures ONLY the text_encoder and tokenizer subfolders
-        # are downloaded, NOT the transformer folder (which is loaded from safetensors file)
         self.print_and_status_update("Text Encoder")
-        self.print_and_status_update(f"Downloading text encoder and tokenizer from: {base_model_path}")
         tokenizer = AutoTokenizer.from_pretrained(
             base_model_path, subfolder="tokenizer", torch_dtype=dtype
         )
@@ -403,11 +399,7 @@ class ZImageModel(BaseModel):
             freeze(text_encoder)
             flush()
 
-        # Load VAE from base_model_path
-        # Using subfolder parameter ensures ONLY the vae subfolder is downloaded,
-        # NOT the transformer folder (which is loaded from safetensors file)
         self.print_and_status_update("Loading VAE")
-        self.print_and_status_update(f"Downloading VAE from: {base_model_path}")
         vae = AutoencoderKL.from_pretrained(
             base_model_path, subfolder="vae", torch_dtype=dtype
         )

--- a/ui/src/app/jobs/new/options.ts
+++ b/ui/src/app/jobs/new/options.ts
@@ -597,6 +597,7 @@ export const modelArchs: ModelArch[] = [
     defaults: {
       // default updates when [selected, unselected] in the UI
       'config.process[0].model.name_or_path': ['Tongyi-MAI/Z-Image-Turbo', defaultNameOrPath],
+      'config.process[0].model.extras_name_or_path': ['Tongyi-MAI/Z-Image-Turbo', undefined],
       'config.process[0].model.quantize': [true, false],
       'config.process[0].model.quantize_te': [true, false],
       'config.process[0].model.low_vram': [true, false],

--- a/ui/src/docs.tsx
+++ b/ui/src/docs.tsx
@@ -47,8 +47,8 @@ const docs: { [key: string]: ConfigDoc } = {
     description: (
       <>
         The name of a diffusers repo on Huggingface or the local path to the base model you want to train from. The
-        folder needs to be in diffusers format for most models. For some models, such as SDXL and SD1, you can put the
-        path to an all in one safetensors checkpoint here.
+        folder needs to be in diffusers format for most models. For some models, such as Z-Image Turbo, SDXL and SD1, you can put the
+        path to a safetensors checkpoint here.
       </>
     ),
   },


### PR DESCRIPTION
This PR adds support for locally uploaded *.safetensor files while training on Z-Image Turbo, by converting safetensors files to Diffusers Format during the training job.

I've reused the precedent to use `extras_name_or_path` to supply the Huggingface repo in cases where the user supplies a local `name_or_path` pointing to a safetensors file. 

The conversion code has been based off [notes in another huggingface repo](https://huggingface.co/linoyts/beyond-reality-z-image-diffusers/blob/main/README.md) for a converted ZIT model