### PR TITLE
Fix onChange path for EMA Decay input

### DIFF
--- a/ui/src/app/jobs/new/SimpleJob.tsx
+++ b/ui/src/app/jobs/new/SimpleJob.tsx
@@ -566,7 +566,7 @@ export default function SimpleJob({
                     label="EMA Decay"
                     className="pt-2"
                     value={jobConfig.config.process[0].train.ema_config?.ema_decay as number}
-                    onChange={value => setJobConfig(value, 'config.process[0].train.ema_config?.ema_decay')}
+                    onChange={value => setJobConfig(value, 'config.process[0].train.ema_config.ema_decay')}
                     placeholder="eg. 0.99"
                     min={0}
                   />


### PR DESCRIPTION
Changes to the EMA Decay input don't get preserved when switching back and forth between Advanced and Simple view. I believe the onChange is not writing it correctly here; it updates correctly in the UI with this change.