### PR TITLE
install loras directly to file path

### DIFF
--- a/ui/src/app/api/files/install/route.ts
+++ b/ui/src/app/api/files/install/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+import { getDatasetsRoot, getTrainingFolder, getLoraInstallPath } from '@/server/settings';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { filePath } = body;
+
+    if (!filePath || typeof filePath !== 'string') {
+      return NextResponse.json({ error: 'filePath is required' }, { status: 400 });
+    }
+
+    const loraInstallPath = await getLoraInstallPath();
+    if (!loraInstallPath) {
+      return NextResponse.json({ error: 'LoRA Install Path is not configured in settings' }, { status: 400 });
+    }
+
+    // Security check: ensure source path is in allowed directories
+    const datasetRoot = await getDatasetsRoot();
+    const trainingRoot = await getTrainingFolder();
+    const allowedDirs = [datasetRoot, trainingRoot];
+
+    const isAllowed =
+      allowedDirs.some(allowedDir => filePath.startsWith(allowedDir)) && !filePath.includes('..');
+
+    if (!isAllowed) {
+      return NextResponse.json({ error: 'Access denied' }, { status: 403 });
+    }
+
+    // Verify source file exists
+    if (!fs.existsSync(filePath)) {
+      return NextResponse.json({ error: 'Source file not found' }, { status: 404 });
+    }
+
+    const stat = fs.statSync(filePath);
+    if (!stat.isFile()) {
+      return NextResponse.json({ error: 'Source path is not a file' }, { status: 400 });
+    }
+
+    // Verify destination directory exists
+    if (!fs.existsSync(loraInstallPath)) {
+      return NextResponse.json({ error: `Install directory does not exist: ${loraInstallPath}` }, { status: 400 });
+    }
+
+    const destStat = fs.statSync(loraInstallPath);
+    if (!destStat.isDirectory()) {
+      return NextResponse.json({ error: 'Install path is not a directory' }, { status: 400 });
+    }
+
+    const fileName = path.basename(filePath);
+    const destPath = path.join(loraInstallPath, fileName);
+
+    await fs.promises.copyFile(filePath, destPath);
+
+    return NextResponse.json({ success: true, destPath });
+  } catch (error) {
+    console.error('Error installing file:', error);
+    return NextResponse.json({ error: 'Failed to install file' }, { status: 500 });
+  }
+}

--- a/ui/src/app/api/settings/route.ts
+++ b/ui/src/app/api/settings/route.ts
@@ -29,9 +29,9 @@ export async function GET() {
 export async function POST(request: Request) {
   try {
     const body = await request.json();
-    const { HF_TOKEN, TRAINING_FOLDER, DATASETS_FOLDER } = body;
+    const { HF_TOKEN, TRAINING_FOLDER, DATASETS_FOLDER, LORA_INSTALL_PATH } = body;
 
-    // Upsert both settings
+    // Upsert all settings
     await Promise.all([
       prisma.settings.upsert({
         where: { key: 'HF_TOKEN' },
@@ -47,6 +47,11 @@ export async function POST(request: Request) {
         where: { key: 'DATASETS_FOLDER' },
         update: { value: DATASETS_FOLDER },
         create: { key: 'DATASETS_FOLDER', value: DATASETS_FOLDER },
+      }),
+      prisma.settings.upsert({
+        where: { key: 'LORA_INSTALL_PATH' },
+        update: { value: LORA_INSTALL_PATH || '' },
+        create: { key: 'LORA_INSTALL_PATH', value: LORA_INSTALL_PATH || '' },
       }),
     ]);
 

--- a/ui/src/app/settings/page.tsx
+++ b/ui/src/app/settings/page.tsx
@@ -108,6 +108,24 @@ export default function Settings() {
                     placeholder="Enter datasets folder path"
                   />
                 </div>
+                <div>
+                  <label htmlFor="LORA_INSTALL_PATH" className="block text-sm font-medium mb-2">
+                    LoRA Install Path
+                    <div className="text-gray-500 text-sm ml-1">
+                      Directory where LoRA files will be copied when using the Install button on checkpoints. Leave blank
+                      to hide the Install button.
+                    </div>
+                  </label>
+                  <input
+                    type="text"
+                    id="LORA_INSTALL_PATH"
+                    name="LORA_INSTALL_PATH"
+                    value={settings.LORA_INSTALL_PATH}
+                    onChange={handleChange}
+                    className="w-full px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg focus:ring-2 focus:ring-gray-600 focus:border-transparent"
+                    placeholder="Enter LoRA install path"
+                  />
+                </div>
               </div>
             </div>
           </div>

--- a/ui/src/hooks/useSettings.tsx
+++ b/ui/src/hooks/useSettings.tsx
@@ -7,6 +7,7 @@ export interface Settings {
   HF_TOKEN: string;
   TRAINING_FOLDER: string;
   DATASETS_FOLDER: string;
+  LORA_INSTALL_PATH: string;
 }
 
 export default function useSettings() {
@@ -14,6 +15,7 @@ export default function useSettings() {
     HF_TOKEN: '',
     TRAINING_FOLDER: '',
     DATASETS_FOLDER: '',
+    LORA_INSTALL_PATH: '',
   });
   const [isSettingsLoaded, setIsLoaded] = useState(false);
   useEffect(() => {
@@ -26,6 +28,7 @@ export default function useSettings() {
           HF_TOKEN: data.HF_TOKEN || '',
           TRAINING_FOLDER: data.TRAINING_FOLDER || '',
           DATASETS_FOLDER: data.DATASETS_FOLDER || '',
+          LORA_INSTALL_PATH: data.LORA_INSTALL_PATH || '',
         });
         setIsLoaded(true);
       })

--- a/ui/src/server/settings.ts
+++ b/ui/src/server/settings.ts
@@ -67,6 +67,25 @@ export const getHFToken = async () => {
   return token;
 };
 
+export const getLoraInstallPath = async () => {
+  const key = 'LORA_INSTALL_PATH';
+  let loraPath = myCache.get(key) as string;
+  if (loraPath !== undefined) {
+    return loraPath;
+  }
+  let row = await prisma.settings.findFirst({
+    where: {
+      key: key,
+    },
+  });
+  loraPath = '';
+  if (row?.value && row.value !== '') {
+    loraPath = row.value;
+  }
+  myCache.set(key, loraPath);
+  return loraPath;
+};
+
 export const getDataRoot = async () => {
   const key = 'DATA_ROOT';
   let dataRoot = myCache.get(key) as string;


### PR DESCRIPTION
 The change allows you to put in a lora install path in the settings page. If that path is not empty a new install icon appears next to completed loras next to the download button. This allows you to 1click install your loras to test them directly. This is useful for people who run ai-toolkit on the same servers as their inferencing tools like ComfyUI or other. 

new settings field
<img width="1428" height="230" alt="image" src="https://github.com/user-attachments/assets/b4642583-f657-4ac2-b099-46b49a4e7ec8" />


new install icon
<img width="175" height="174" alt="image" src="https://github.com/user-attachments/assets/1bc66a53-d1f6-4d79-9969-689315261c7d" />
