### PR TITLE
Training, Optimizers, Device Handling & Z-Image Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,7 @@ cython_debug/
 aitk_db.db
 /notes.md
 /data
+
+# ide
+.cursor
+.continue

--- a/config/examples/WARMUP_SCHEDULER_GUIDE.md
+++ b/config/examples/WARMUP_SCHEDULER_GUIDE.md
@@ -1,0 +1,299 @@
+# Learning Rate Scheduler Warmup Guide
+
+## Overview
+
+This guide explains how to use the warmup functionality for learning rate schedulers in the AI Toolkit. Warmup gradually increases the learning rate from near-zero to the target learning rate over a specified number of steps, which can help stabilize training in the early stages.
+
+## Supported Schedulers
+
+Warmup is supported for the following schedulers:
+- `cosine` - Cosine annealing scheduler
+- `cosine_with_restarts` - Cosine annealing with warm restarts (SGDR)
+
+## How It Works
+
+When you specify `warmup_steps > 0`, the scheduler automatically creates a composite scheduler using PyTorch's `SequentialLR`:
+
+1. **Warmup Phase** (steps 0 to `warmup_steps`):
+   - Uses `LinearLR` to gradually increase learning rate from ~0 to the target LR
+   - Learning rate increases linearly: `lr = target_lr * (current_step / warmup_steps)`
+
+2. **Main Phase** (steps `warmup_steps` to `total_steps`):
+   - Uses the specified scheduler (cosine or cosine_with_restarts)
+   - `total_iters` specifies the TOTAL number of training iterations (including warmup)
+   - `T_0`/`T_max` specify iterations for the MAIN scheduler phase (after warmup)
+   - If T_0/T_max is specified, it takes priority over calculated value from total_iters
+   - Main scheduler iterations = total_iters - warmup_steps (or T_0/T_max if specified)
+
+### Learning Rate Progression
+
+```
+LR |
+   |    _/--\      /\        /\
+   |   /     \    /  \      /  \
+   |  /       \  /    \    /    \
+   | /         \/      \  /      \
+   |/                   \/        \
+   +----------------------------> steps
+   |<-warmup->|<-- cosine restarts -->
+```
+
+## Parameter Semantics
+
+### Key concepts
+
+- **`total_iters`**: TOTAL training iterations (including warmup)
+- **`T_0`/`T_max`**: Main scheduler iterations (after warmup), overrides calculation from total_iters
+
+### Example: Training with 1000 total steps
+
+**Config 1: Using total_iters (automatic calculation)**
+
+```yaml
+train:
+  steps: 1000  # Will be used as total_iters by BaseSDTrainProcess
+  lr_scheduler: "cosine_with_restarts"
+  lr_scheduler_params:
+    warmup_steps: 100
+    # total_iters will be auto-set to 1000 by BaseSDTrainProcess
+    T_mult: 2
+```
+
+**Result:**
+- Steps 0-100: Linear warmup
+- Steps 100-1000: Cosine with restarts (900 iterations = 1000 - 100)
+- Total: 1000 steps ✓
+
+**Config 2: Using T_0 explicitly (overrides calculation)**
+
+```yaml
+train:
+  steps: 1000
+  lr_scheduler: "cosine_with_restarts"
+  lr_scheduler_params:
+    warmup_steps: 100
+    total_iters: 1000
+    T_0: 500  # Overrides default calculation (1000 - 100)
+    T_mult: 2
+```
+
+**Result:**
+- Steps 0-100: Linear warmup
+- Steps 100-600: Cosine with restarts (500 iterations from T_0)
+- Total: 600 steps (less than total_iters!)
+
+**Priority:** If both `T_0` and `total_iters` are specified, `T_0` takes priority and determines main scheduler length.
+
+## Configuration Examples
+
+### Example 1: Cosine with Restarts + Warmup
+
+```yaml
+train:
+  steps: 2000
+  lr: 1e-4
+  lr_scheduler: "cosine_with_restarts"
+  lr_scheduler_params:
+    warmup_steps: 100      # Warmup for first 100 steps
+    T_mult: 2              # Double restart period each cycle
+    eta_min: 1e-7          # Minimum learning rate
+```
+
+### Example 2: Cosine + Warmup
+
+```yaml
+train:
+  steps: 2000
+  lr: 1e-4
+  lr_scheduler: "cosine"
+  lr_scheduler_params:
+    warmup_steps: 100      # Warmup for first 100 steps
+    eta_min: 1e-7          # Minimum learning rate
+```
+
+### Example 3: Without Warmup (Backward Compatible)
+
+```yaml
+train:
+  steps: 2000
+  lr: 1e-4
+  lr_scheduler: "cosine_with_restarts"
+  lr_scheduler_params:
+    T_mult: 2
+    eta_min: 1e-7
+    # No warmup_steps specified = no warmup
+```
+
+### Example 4: Explicitly Disable Warmup
+
+```yaml
+train:
+  steps: 2000
+  lr: 1e-4
+  lr_scheduler: "cosine_with_restarts"
+  lr_scheduler_params:
+    warmup_steps: 0        # Explicitly disable warmup
+    T_mult: 2
+    eta_min: 1e-7
+```
+
+## Parameters
+
+### Common Parameters
+
+- **`warmup_steps`** (optional, default: 0)
+  - Number of steps for the warmup phase
+  - Set to 0 or omit to disable warmup
+  - Typical values: 50-500 depending on total training steps
+  - Rule of thumb: 5-10% of total steps
+
+### Cosine Scheduler Parameters
+
+- **`eta_min`** (optional, default: 0)
+  - Minimum learning rate
+
+### Cosine with Restarts Parameters
+
+- **`T_mult`** (optional, default: 1)
+  - Factor to increase the restart period after each restart
+  - `T_mult=1`: equal restart periods
+  - `T_mult=2`: double the period each time
+  
+- **`eta_min`** (optional, default: 0)
+  - Minimum learning rate
+
+## Choosing Warmup Steps
+
+### General Guidelines
+
+1. **Small datasets (< 1000 images)**
+   - Warmup steps: 50-100
+   - Helps prevent overfitting to early batches
+
+2. **Medium datasets (1000-10000 images)**
+   - Warmup steps: 100-250
+   - Balances stability and training time
+
+3. **Large datasets (> 10000 images)**
+   - Warmup steps: 250-500
+   - More warmup helps with stability
+
+4. **Percentage-based approach**
+   - Use 5-10% of total training steps
+   - Example: 2000 steps → 100-200 warmup steps
+
+### When to Use Warmup
+
+✅ **Use warmup when:**
+- Training from scratch or with random initialization
+- Using high learning rates (> 1e-4)
+- Experiencing unstable early training
+- Training large models or with large batch sizes
+- Using aggressive optimizers (Adam with high β values)
+
+❌ **Skip warmup when:**
+- Fine-tuning from a well-trained checkpoint
+- Using very low learning rates (< 1e-5)
+- Training is already stable without warmup
+- Total training steps are very small (< 500)
+
+## Implementation Details
+
+### Under the Hood
+
+The implementation uses PyTorch's built-in schedulers:
+
+```python
+# Warmup phase
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
+    optimizer,
+    start_factor=1e-10,  # Start almost at 0
+    end_factor=1.0,      # End at full LR
+    total_iters=warmup_steps
+)
+
+# Main phase (example for cosine_with_restarts)
+main_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
+    optimizer,
+    T_0=total_iters - warmup_steps,  # Calculated from total iterations
+    # Or explicitly specify main scheduler iterations:
+    # T_0=900,  # Direct specification (ignores total_iters calculation)
+    T_mult=2,
+    eta_min=1e-7
+)
+
+# Combined scheduler
+combined_scheduler = torch.optim.lr_scheduler.SequentialLR(
+    optimizer,
+    schedulers=[warmup_scheduler, main_scheduler],
+    milestones=[warmup_steps]
+)
+```
+
+### Backward Compatibility
+
+- All existing configurations continue to work without changes
+- Warmup is only activated when `warmup_steps > 0` is explicitly specified
+- Default behavior (no warmup) is preserved when `warmup_steps` is not specified
+
+## Testing
+
+A test script is provided to verify the warmup functionality:
+
+```bash
+# Activate your virtual environment
+.\venv\Scripts\activate.ps1  # Windows PowerShell
+# or
+source venv/bin/activate      # Linux/Mac
+
+# Run tests
+python test_scheduler_warmup.py
+```
+
+The test script verifies:
+1. Backward compatibility (schedulers work without warmup)
+2. Warmup functionality (SequentialLR is created when warmup_steps > 0)
+3. Learning rate progression (LR increases during warmup, then follows main scheduler)
+
+## Full Configuration Example
+
+See `config/examples/train_lora_flux_with_warmup.yaml` for a complete working example.
+
+## Troubleshooting
+
+### Issue: Learning rate doesn't increase during warmup
+
+**Solution:** Make sure `warmup_steps` is specified in `lr_scheduler_params`, not at the top level of `train`.
+
+```yaml
+# ❌ Wrong
+train:
+  warmup_steps: 100
+  lr_scheduler_params:
+    T_mult: 2
+
+# ✅ Correct
+train:
+  lr_scheduler_params:
+    warmup_steps: 100
+    T_mult: 2
+```
+
+### Issue: Training is unstable even with warmup
+
+**Possible solutions:**
+1. Increase `warmup_steps` (try 10-15% of total steps)
+2. Reduce base learning rate
+3. Use gradient clipping (`max_grad_norm`)
+4. Reduce batch size
+
+### Issue: Warmup takes too long
+
+**Solution:** Reduce `warmup_steps`. Remember, warmup is just the initial phase. If warmup is more than 10-15% of total training, it might be too long.
+
+## References
+
+- [PyTorch CosineAnnealingLR](https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.CosineAnnealingLR.html)
+- [PyTorch CosineAnnealingWarmRestarts](https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.CosineAnnealingWarmRestarts.html)
+- [PyTorch SequentialLR](https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.SequentialLR.html)
+- [SGDR: Stochastic Gradient Descent with Warm Restarts](https://arxiv.org/abs/1608.03983)

--- a/config/examples/train_lora_flux_with_warmup.yaml
+++ b/config/examples/train_lora_flux_with_warmup.yaml
@@ -1,0 +1,79 @@
+---
+# Example configuration demonstrating warmup support for cosine_with_restarts scheduler
+# This is based on train_lora_flux_24gb.yaml with added warmup configuration
+
+job: extension
+config:
+  name: "flux_lora_with_warmup_v1"
+  process:
+    - type: 'sd_trainer'
+      training_folder: "output"
+      device: cuda:0
+      
+      network:
+        type: "lora"
+        linear: 16
+        linear_alpha: 16
+      
+      save:
+        dtype: float16
+        save_every: 250
+        max_step_saves_to_keep: 4
+        push_to_hub: false
+      
+      datasets:
+        - folder_path: "/path/to/images/folder"
+          caption_ext: "txt"
+          caption_dropout_rate: 0.05
+          shuffle_tokens: false
+          cache_latents_to_disk: true
+          resolution: [ 512, 768, 1024 ]
+      
+      train:
+        batch_size: 1
+        steps: 2000
+        gradient_accumulation_steps: 1
+        train_unet: true
+        train_text_encoder: false
+        gradient_checkpointing: true
+        noise_scheduler: "flowmatch"
+        optimizer: "adamw8bit"
+        lr: 1e-4
+        
+        # Learning rate scheduler with warmup
+        lr_scheduler: "cosine_with_restarts"
+        lr_scheduler_params:
+          warmup_steps: 100      # Linear warmup for first 100 steps (0 → lr)
+          T_mult: 2              # Double the restart period each time
+          eta_min: 1e-7          # Minimum learning rate
+        
+        # Alternative: cosine scheduler with warmup
+        # lr_scheduler: "cosine"
+        # lr_scheduler_params:
+        #   warmup_steps: 100    # Linear warmup for first 100 steps
+        #   eta_min: 1e-7        # Minimum learning rate
+        
+        # For backward compatibility (no warmup):
+        # lr_scheduler: "cosine_with_restarts"
+        # lr_scheduler_params:
+        #   T_mult: 2
+        #   eta_min: 1e-7
+        
+      model:
+        name_or_path: "black-forest-labs/FLUX.1-dev"
+        is_flux: true
+        quantize: true
+      
+      sample:
+        sampler: "flowmatch"
+        sample_every: 250
+        width: 1024
+        height: 1024
+        prompts:
+          - "a photo of a cat"
+          - "a photo of a dog"
+        neg: ""
+        seed: 42
+        walk_seed: true
+        guidance_scale: 4
+        sample_steps: 20

--- a/extensions_built_in/diffusion_models/qwen_image/qwen_image_edit.py
+++ b/extensions_built_in/diffusion_models/qwen_image/qwen_image_edit.py
@@ -16,6 +16,7 @@ from toolkit.samplers.custom_flowmatch_sampler import (
 from toolkit.accelerator import get_accelerator, unwrap_model
 from optimum.quanto import freeze, QTensor
 from toolkit.util.quantize import quantize, get_qtype, quantize_model
+from toolkit.util.device import safe_module_to_device
 import torch.nn.functional as F
 
 from diffusers import (
@@ -89,7 +90,8 @@ class QwenImageEditModel(QwenImageModel):
         generator: torch.Generator,
         extra: dict,
     ):
-        self.model.to(self.device_torch, dtype=self.torch_dtype)
+        if self.model_config.low_vram:
+            safe_module_to_device(self.model, self.device_torch, self.torch_dtype)
         sc = self.get_bucket_divisibility()
         gen_config.width = int(gen_config.width // sc * sc)
         gen_config.height = int(gen_config.height // sc * sc)

--- a/extensions_built_in/diffusion_models/qwen_image/qwen_image_edit_plus.py
+++ b/extensions_built_in/diffusion_models/qwen_image/qwen_image_edit_plus.py
@@ -16,6 +16,7 @@ from toolkit.samplers.custom_flowmatch_sampler import (
 from toolkit.accelerator import get_accelerator, unwrap_model
 from optimum.quanto import freeze, QTensor
 from toolkit.util.quantize import quantize, get_qtype, quantize_model
+from toolkit.util.device import safe_module_to_device
 import torch.nn.functional as F
 
 from diffusers import (
@@ -97,7 +98,8 @@ class QwenImageEditPlusModel(QwenImageModel):
         generator: torch.Generator,
         extra: dict,
     ):
-        self.model.to(self.device_torch, dtype=self.torch_dtype)
+        if self.model_config.low_vram:
+            safe_module_to_device(self.model, self.device_torch, self.torch_dtype)
         sc = self.get_bucket_divisibility()
         gen_config.width = int(gen_config.width // sc * sc)
         gen_config.height = int(gen_config.height // sc * sc)

--- a/extensions_built_in/sd_trainer/SDTrainer.py
+++ b/extensions_built_in/sd_trainer/SDTrainer.py
@@ -1526,11 +1526,18 @@ class SDTrainer(BaseSDTrainProcess):
                                     self.device_torch, dtype=dtype
                                 )
                             else:
-                                embeds_to_use = self.cached_blank_embeds.clone().detach().to(
-                                    self.device_torch, dtype=dtype
-                                )
+                                # No cache on disk: use trigger_word instead of blank embedding
                                 if self.cached_trigger_embeds is not None and not is_reg:
                                     embeds_to_use = self.cached_trigger_embeds.clone().detach().to(
+                                        self.device_torch, dtype=dtype
+                                    )
+                                else:
+                                    if self.is_caching_text_embeddings:
+                                        raise ValueError(
+                                            "cache_text_embeddings is enabled but no cached embeds in batch. "
+                                            "Set trigger_word when using cache_text_embeddings so fallback is available when cache is missing."
+                                        )
+                                    embeds_to_use = self.cached_blank_embeds.clone().detach().to(
                                         self.device_torch, dtype=dtype
                                     )
                                 conditional_embeds = concat_prompt_embeds(

--- a/extensions_built_in/sd_trainer/SDTrainer.py
+++ b/extensions_built_in/sd_trainer/SDTrainer.py
@@ -6,7 +6,6 @@ from typing import Union, Literal, List, Optional
 import numpy as np
 from diffusers import T2IAdapter, AutoencoderTiny, ControlNetModel
 
-import torch.functional as F
 from safetensors.torch import load_file
 from torch.utils.data import DataLoader, ConcatDataset
 
@@ -112,6 +111,9 @@ class SDTrainer(BaseSDTrainProcess):
             self._guidance_loss_target_batch = float(self.train_config.guidance_loss_target[0])
         else:
             raise ValueError(f"Unknown guidance loss target type {type(self.train_config.guidance_loss_target)}")
+        
+        # store differential guidance norm metric for logging
+        self.diff_guidance_norm = None
 
 
     def before_model_load(self):
@@ -708,11 +710,14 @@ class SDTrainer(BaseSDTrainProcess):
                 
                 unconditional_target = unconditional_target * alpha
                 target = unconditional_target + guidance_scale * (target - unconditional_target)
-
-            if self.train_config.do_differential_guidance:
-                with torch.no_grad():
-                    guidance_scale = self.train_config.differential_guidance_scale
-                    target = noise_pred + guidance_scale * (target - noise_pred)
+                
+        if self.train_config.do_differential_guidance:
+            with torch.no_grad():
+                guidance_scale = self.train_config.differential_guidance_scale
+                diff_correction = guidance_scale * (target - noise_pred)
+                # Calculate L2 norm for monitoring
+                self.diff_guidance_norm = torch.norm(diff_correction).item()
+                target = noise_pred + diff_correction
             
         if target is None:
             target = noise
@@ -784,6 +789,22 @@ class SDTrainer(BaseSDTrainProcess):
                     v2=self.train_config.linear_timesteps2,
                     timestep_type=self.train_config.timestep_type
                 ).to(loss.device, dtype=loss.dtype)
+                if len(loss.shape) == 4:
+                    timestep_weight = timestep_weight.view(-1, 1, 1, 1).detach()
+                elif len(loss.shape) == 5:
+                    timestep_weight = timestep_weight.view(-1, 1, 1, 1, 1).detach()
+                loss = loss * timestep_weight
+            elif self.train_config.content_or_style == 'fixed_cycle' and self.train_config.fixed_cycle_weight_peak_timesteps:
+                # fixed_cycle: weight loss by Gaussian peaks at fixed_cycle_weight_peak_timesteps (e.g. 500, 375), mean-normalized
+                peaks = self.train_config.fixed_cycle_weight_peak_timesteps
+                sigma = self.train_config.fixed_cycle_weight_sigma
+                peaks_t = torch.tensor(peaks, device=timesteps.device, dtype=timesteps.dtype)
+                diff = timesteps.unsqueeze(1).float() - peaks_t.unsqueeze(0)
+                weight_per_timestep = torch.exp(-(diff / sigma) ** 2).max(dim=1)[0]
+                cycle_ts = torch.tensor(self.train_config.fixed_cycle_timesteps, device=timesteps.device, dtype=timesteps.dtype)
+                diff_cycle = cycle_ts.unsqueeze(1).float() - peaks_t.unsqueeze(0)
+                mean_w = torch.exp(-(diff_cycle / sigma) ** 2).max(dim=1)[0].mean().clamp(min=1e-8)
+                timestep_weight = (weight_per_timestep / mean_w).to(loss.device, dtype=loss.dtype)
                 if len(loss.shape) == 4:
                     timestep_weight = timestep_weight.view(-1, 1, 1, 1).detach()
                 elif len(loss.shape) == 5:
@@ -1983,15 +2004,19 @@ class SDTrainer(BaseSDTrainProcess):
                             prior_pred=prior_to_calculate_loss,
                         )
                     
-                    if self.train_config.diff_output_preservation or self.train_config.blank_prompt_preservation:
-                        # send the loss backwards otherwise checkpointing will fail
-                        self.accelerator.backward(loss)
-                        normal_loss = loss.detach() # dont send backward again
-                        
+                    # Determine if we should run BPP this step
+                    should_run_bpp = False
+                    if self.train_config.blank_prompt_preservation:
+                        should_run_bpp = random.random() < self.train_config.blank_prompt_probability
+                    
+                    # Flag to track if backward was already performed in preservation block
+                    backward_done = False
+                    
+                    if self.train_config.diff_output_preservation or should_run_bpp:
                         with torch.no_grad():
                             if self.train_config.diff_output_preservation:
                                 preservation_embeds = self.diff_output_preservation_embeds.expand_to_batch(noisy_latents.shape[0])
-                            elif self.train_config.blank_prompt_preservation:
+                            elif should_run_bpp:
                                 blank_embeds = self.cached_blank_embeds.clone().detach().to(
                                     self.device_torch, dtype=dtype
                                 )
@@ -2008,12 +2033,14 @@ class SDTrainer(BaseSDTrainProcess):
                         )
                         multiplier = self.train_config.diff_output_preservation_multiplier if self.train_config.diff_output_preservation else self.train_config.blank_prompt_preservation_multiplier
                         preservation_loss = torch.nn.functional.mse_loss(preservation_pred, prior_pred) * multiplier
-                        self.accelerator.backward(preservation_loss)
-
-                        loss = normal_loss + preservation_loss
-                        loss = loss.clone().detach()
-                        # require grad again so the backward wont fail
-                        loss.requires_grad_(True)
+                        
+                        # Combine main loss and preservation loss with loss_multiplier applied
+                        total_loss = loss * loss_multiplier.mean() + preservation_loss
+                        self.accelerator.backward(total_loss)
+                        
+                        # Detach total loss for logging and nan checks
+                        loss = total_loss.detach()
+                        backward_done = True
                         
                 # check if nan
                 if torch.isnan(loss):
@@ -2021,18 +2048,20 @@ class SDTrainer(BaseSDTrainProcess):
                     loss = torch.zeros_like(loss).requires_grad_(True)
 
                 with self.timer('backward'):
-                    # todo we have multiplier seperated. works for now as res are not in same batch, but need to change
-                    loss = loss * loss_multiplier.mean()
-                    # IMPORTANT if gradient checkpointing do not leave with network when doing backward
-                    # it will destroy the gradients. This is because the network is a context manager
-                    # and will change the multipliers back to 0.0 when exiting. They will be
-                    # 0.0 for the backward pass and the gradients will be 0.0
-                    # I spent weeks on fighting this. DON'T DO IT
-                    # with fsdp_overlap_step_with_backward():
-                    # if self.is_bfloat:
-                    # loss.backward()
-                    # else:
-                    self.accelerator.backward(loss)
+                    # Only perform backward if not already done in preservation block
+                    if not backward_done:
+                        # todo we have multiplier seperated. works for now as res are not in same batch, but need to change
+                        loss = loss * loss_multiplier.mean()
+                        # IMPORTANT if gradient checkpointing do not leave with network when doing backward
+                        # it will destroy the gradients. This is because the network is a context manager
+                        # and will change the multipliers back to 0.0 when exiting. They will be
+                        # 0.0 for the backward pass and the gradients will be 0.0
+                        # I spent weeks on fighting this. DON'T DO IT
+                        # with fsdp_overlap_step_with_backward():
+                        # if self.is_bfloat:
+                        # loss.backward()
+                        # else:
+                        self.accelerator.backward(loss)
 
         return loss.detach()
         # flush()

--- a/extensions_built_in/sd_trainer/config/train.example.yaml
+++ b/extensions_built_in/sd_trainer/config/train.example.yaml
@@ -76,6 +76,7 @@ config:
         log_every: 10 # log every this many steps
         use_wandb: false # not supported yet
         verbose: false
+        debug: false # enable to log CUDA memory around text encoder unload
 
 # You can put any information you want here, and it will be saved in the model.
 # The below is an example, but you can put your grocery list in it if you want.

--- a/toolkit/config_modules.py
+++ b/toolkit/config_modules.py
@@ -6,6 +6,7 @@ import random
 import torch
 import torchaudio
 
+from toolkit.paths import normalize_path
 from toolkit.prompt_utils import PromptEmbeds
 
 ImgExt = Literal['jpg', 'png', 'webp']
@@ -36,6 +37,7 @@ class LoggingConfig:
         self.verbose: bool = kwargs.get('verbose', False)
         self.use_wandb: bool = kwargs.get('use_wandb', False)
         self.use_ui_logger: bool = kwargs.get('use_ui_logger', False)
+        self.debug: bool = kwargs.get('debug', False)
         self.project_name: str = kwargs.get('project_name', 'ai-toolkit')
         self.run_name: str = kwargs.get('run_name', None)
 
@@ -219,7 +221,7 @@ class NetworkConfig:
         self.layer_offloading = kwargs.get('layer_offloading', False)
         
         # start from a pretrained lora
-        self.pretrained_lora_path = kwargs.get('pretrained_lora_path', None)
+        self.pretrained_lora_path = normalize_path(kwargs.get('pretrained_lora_path', None))
 
 
 AdapterTypes = Literal['t2i', 'ip', 'ip+', 'clip', 'ilora', 'photo_maker', 'control_net', 'control_lora', 'i2v']

--- a/toolkit/config_modules.py
+++ b/toolkit/config_modules.py
@@ -685,6 +685,9 @@ class ModelConfig:
         # for models that support it (e.g., zimage), a separate model path for sampling/inference
         # training uses name_or_path, sampling uses sampling_name_or_path if set
         self.sampling_name_or_path: Optional[str] = kwargs.get("sampling_name_or_path", None)
+
+        # enable debug logging for safetensors load (path, size, duration) to diagnose mmap/load differences
+        self.debug_zimage_load: bool = kwargs.get("debug_zimage_load", False)
         
         # path to an accuracy recovery adapter, either local or remote
         self.accuracy_recovery_adapter = kwargs.get("accuracy_recovery_adapter", None)

--- a/toolkit/data_loader.py
+++ b/toolkit/data_loader.py
@@ -598,7 +598,10 @@ class AiToolkitDataset(LatentCachingMixin, ControlCachingMixin, CLIPCachingMixin
 
     def _get_single_item(self, index) -> 'FileItemDTO':
         file_item: 'FileItemDTO' = copy.deepcopy(self.file_list[index])
+        file_item._current_epoch_num = getattr(self, '_epoch_num', 0)
         file_item.load_and_process_image(self.transform)
+        if file_item.is_text_embedding_cached and file_item.prompt_embeds is not None:
+            self.file_list[index].prompt_embeds = file_item.prompt_embeds
         file_item.load_caption(self.caption_dict)
         return file_item
 

--- a/toolkit/dataloader_mixins.py
+++ b/toolkit/dataloader_mixins.py
@@ -415,8 +415,9 @@ class CaptionProcessingDTOMixin:
                         new_token_list.append(token)
             token_list = new_token_list
 
-        if self.dataset_config.shuffle_tokens:
-            random.shuffle(token_list)
+        # Redundant code. Shuffling is performed in the code below.
+        # if self.dataset_config.shuffle_tokens:
+        #     random.shuffle(token_list)
 
         # join back together
         caption = ', '.join(token_list)
@@ -436,14 +437,17 @@ class CaptionProcessingDTOMixin:
                 #     trigger = self.dataset_config.random_triggers[int(random.random() * (len(self.dataset_config.random_triggers)))]
                 #     caption = caption + ', ' + trigger
 
-        if self.dataset_config.shuffle_tokens:
-            # shuffle again
+        if self.dataset_config.shuffle_tokens and not self.dataset_config.cache_text_embeddings:
+            # shuffle, keep first segment (until first comma) in place
             token_list = caption.split(',')
             # trim whitespace
             token_list = [x.strip() for x in token_list]
             # remove empty strings
             token_list = [x for x in token_list if x]
-            random.shuffle(token_list)
+            if len(token_list) > 1:
+                rest = token_list[1:]
+                random.shuffle(rest)
+                token_list = [token_list[0]] + rest
             caption = ', '.join(token_list)
         if caption == '':
             pass
@@ -1965,6 +1969,9 @@ class TextEmbeddingFileItemDTOMixin:
         if self.prompt_embeds is None:
             # load it from disk
             self.prompt_embeds = PromptEmbeds.load(self.get_text_embedding_path())
+            if getattr(self, '_current_epoch_num', 0) > 0 and getattr(self.dataset_config, 'shuffle_tokens', False):
+                self.prompt_embeds.shuffle_sequence()
+                print_acc(f"Cached text embedding tokens shuffled (epoch {getattr(self, '_current_epoch_num', 0)})")
 
 class TextEmbeddingCachingMixin:
     def __init__(self: 'AiToolkitDataset', **kwargs):
@@ -1972,6 +1979,19 @@ class TextEmbeddingCachingMixin:
         if hasattr(super(), '__init__'):
             super().__init__(**kwargs)
         self.is_caching_text_embeddings = self.dataset_config.cache_text_embeddings
+        self._epoch_num: int = 0
+
+    def set_epoch_num(self: 'AiToolkitDataset', epoch_num: int) -> None:
+        self._epoch_num = epoch_num
+        if epoch_num > 0 and self.is_caching_text_embeddings and self.dataset_config.shuffle_tokens:
+            for file_item in self.file_list:
+                if getattr(file_item, 'prompt_embeds', None) is not None:
+                    file_item.prompt_embeds.shuffle_sequence()
+            print_acc(f"\nCached text embedding tokens shuffled (epoch {epoch_num})\n")
+
+    def clear_cached_embeddings_memory(self: 'AiToolkitDataset') -> None:
+        for file_item in self.file_list:
+            file_item.cleanup_text_embedding()
 
     def cache_text_embeddings(self: 'AiToolkitDataset'):
         with accelerator.main_process_first():

--- a/toolkit/dataloader_mixins.py
+++ b/toolkit/dataloader_mixins.py
@@ -578,6 +578,8 @@ class ImageProcessingDTOMixin:
                     img = img.transpose(Image.FLIP_TOP_BOTTOM)
                 
                 # Apply bucketing
+                if self.scale_to_width <= 0 or self.scale_to_height <= 0:
+                    raise ValueError(f"Invalid scale dimensions for video {self.path}: scale_to_width={self.scale_to_width}, scale_to_height={self.scale_to_height}")
                 img = img.resize((self.scale_to_width, self.scale_to_height), Image.BICUBIC)
                 img = img.crop((
                     self.crop_x,
@@ -780,6 +782,8 @@ class ImageProcessingDTOMixin:
 
         if self.dataset_config.buckets:
             # scale and crop based on file item
+            if self.scale_to_width <= 0 or self.scale_to_height <= 0:
+                raise ValueError(f"Invalid scale dimensions for image {self.path}: scale_to_width={self.scale_to_width}, scale_to_height={self.scale_to_height}")
             img = img.resize((self.scale_to_width, self.scale_to_height), Image.BICUBIC)
             # crop to x_crop, y_crop, x_crop + crop_width, y_crop + crop_height
             if img.width < self.crop_x + self.crop_width or img.height < self.crop_y + self.crop_height:

--- a/toolkit/lora_special.py
+++ b/toolkit/lora_special.py
@@ -279,12 +279,15 @@ class LoRASpecialNetwork(ToolkitNetworkMixin, LoRANetwork):
             if self.network_type.lower() != "lokr" or not self.use_old_lokr_format:
                 self.peft_format = True
 
-        if self.peft_format:
-            # no alpha for peft
-            self.alpha = self.lora_dim
-            alpha = self.alpha
-            self.conv_alpha = self.conv_lora_dim
-            conv_alpha = self.conv_alpha
+        # Allow alpha for peft
+        # Todo: Folding Alpha on save
+        # 
+        # if self.peft_format:
+        #     # no alpha for peft
+        #     self.alpha = self.lora_dim
+        #     alpha = self.alpha
+        #     self.conv_alpha = self.conv_lora_dim
+        #     conv_alpha = self.conv_alpha
 
         self.full_train_in_out = full_train_in_out
 

--- a/toolkit/lora_special.py
+++ b/toolkit/lora_special.py
@@ -14,6 +14,7 @@ from toolkit.models.lokr import LokrModule
 from .config_modules import NetworkConfig
 from .lorm import count_parameters
 from .network_mixins import ToolkitNetworkMixin, ToolkitModuleMixin, ExtractableModuleMixin
+from toolkit.util.debug import memory_debug
 
 from toolkit.kohya_lora import LoRANetwork
 from toolkit.models.DoRA import DoRAModule
@@ -291,237 +292,238 @@ class LoRASpecialNetwork(ToolkitNetworkMixin, LoRANetwork):
 
         self.full_train_in_out = full_train_in_out
 
-        if modules_dim is not None:
-            print(f"create LoRA network from weights")
-        elif block_dims is not None:
-            print(f"create LoRA network from block_dims")
-            print(
-                f"neuron dropout: p={self.dropout}, rank dropout: p={self.rank_dropout}, module dropout: p={self.module_dropout}")
-            print(f"block_dims: {block_dims}")
-            print(f"block_alphas: {block_alphas}")
-            if conv_block_dims is not None:
-                print(f"conv_block_dims: {conv_block_dims}")
-                print(f"conv_block_alphas: {conv_block_alphas}")
-        else:
-            print(f"create LoRA network. base dim (rank): {lora_dim}, alpha: {alpha}")
-            print(
-                f"neuron dropout: p={self.dropout}, rank dropout: p={self.rank_dropout}, module dropout: p={self.module_dropout}")
-            if self.conv_lora_dim is not None:
+        with memory_debug(print, "create LoRA network"):
+            if modules_dim is not None:
+                print(f"create LoRA network from weights")
+            elif block_dims is not None:
+                print(f"create LoRA network from block_dims")
                 print(
-                    f"apply LoRA to Conv2d with kernel size (3,3). dim (rank): {self.conv_lora_dim}, alpha: {self.conv_alpha}")
+                    f"neuron dropout: p={self.dropout}, rank dropout: p={self.rank_dropout}, module dropout: p={self.module_dropout}")
+                print(f"block_dims: {block_dims}")
+                print(f"block_alphas: {block_alphas}")
+                if conv_block_dims is not None:
+                    print(f"conv_block_dims: {conv_block_dims}")
+                    print(f"conv_block_alphas: {conv_block_alphas}")
+            else:
+                print(f"create LoRA network. base dim (rank): {lora_dim}, alpha: {alpha}")
+                print(
+                    f"neuron dropout: p={self.dropout}, rank dropout: p={self.rank_dropout}, module dropout: p={self.module_dropout}")
+                if self.conv_lora_dim is not None:
+                    print(
+                        f"apply LoRA to Conv2d with kernel size (3,3). dim (rank): {self.conv_lora_dim}, alpha: {self.conv_alpha}")
 
-        # create module instances
-        def create_modules(
+            # create module instances
+            def create_modules(
                 is_unet: bool,
                 text_encoder_idx: Optional[int],  # None, 1, 2
                 root_module: torch.nn.Module,
                 target_replace_modules: List[torch.nn.Module],
-        ) -> List[LoRAModule]:
-            unet_prefix = self.LORA_PREFIX_UNET
-            if self.peft_format:
-                unet_prefix = self.PEFT_PREFIX_UNET
-            if is_pixart or is_v3 or is_auraflow or is_flux or is_lumina2 or self.is_transformer:
-                unet_prefix = f"lora_transformer"
+            ) -> List[LoRAModule]:
+                unet_prefix = self.LORA_PREFIX_UNET
                 if self.peft_format:
-                    unet_prefix = "transformer"
+                    unet_prefix = self.PEFT_PREFIX_UNET
+                if is_pixart or is_v3 or is_auraflow or is_flux or is_lumina2 or self.is_transformer:
+                    unet_prefix = f"lora_transformer"
+                    if self.peft_format:
+                        unet_prefix = "transformer"
 
-            prefix = (
-                unet_prefix
-                if is_unet
-                else (
-                    self.LORA_PREFIX_TEXT_ENCODER
-                    if text_encoder_idx is None
-                    else (self.LORA_PREFIX_TEXT_ENCODER1 if text_encoder_idx == 1 else self.LORA_PREFIX_TEXT_ENCODER2)
+                prefix = (
+                    unet_prefix
+                    if is_unet
+                    else (
+                        self.LORA_PREFIX_TEXT_ENCODER
+                        if text_encoder_idx is None
+                        else (self.LORA_PREFIX_TEXT_ENCODER1 if text_encoder_idx == 1 else self.LORA_PREFIX_TEXT_ENCODER2)
+                    )
                 )
-            )
-            loras = []
-            skipped = []
-            attached_modules = []
-            lora_shape_dict = {}
-            for name, module in root_module.named_modules():
-                if module.__class__.__name__ in target_replace_modules:
-                    for child_name, child_module in module.named_modules():
-                        is_linear = child_module.__class__.__name__ in LINEAR_MODULES
-                        is_conv2d = child_module.__class__.__name__ in CONV_MODULES
-                        is_conv2d_1x1 = is_conv2d and child_module.kernel_size == (1, 1)
+                loras = []
+                skipped = []
+                attached_modules = []
+                lora_shape_dict = {}
+                for name, module in root_module.named_modules():
+                    if module.__class__.__name__ in target_replace_modules:
+                        for child_name, child_module in module.named_modules():
+                            is_linear = child_module.__class__.__name__ in LINEAR_MODULES
+                            is_conv2d = child_module.__class__.__name__ in CONV_MODULES
+                            is_conv2d_1x1 = is_conv2d and child_module.kernel_size == (1, 1)
 
 
-                        lora_name = [prefix, name, child_name]
-                        # filter out blank
-                        lora_name = [x for x in lora_name if x and x != ""]
-                        lora_name = ".".join(lora_name)
-                        # if it doesnt have a name, it wil have two dots
-                        lora_name.replace("..", ".")
-                        clean_name = lora_name
-                        if self.peft_format:
-                            # we replace this on saving
-                            lora_name = lora_name.replace(".", "$$")
-                        else:
-                            lora_name = lora_name.replace(".", "_")
-
-                        skip = False
-                        if any([word in clean_name for word in self.ignore_if_contains]):
-                            skip = True
-
-                        # see if it is over threshold
-                        if count_parameters(child_module) < parameter_threshold:
-                            skip = True
-                        
-                        if self.transformer_only and is_unet:
-                            transformer_block_names = None
-                            if base_model is not None:
-                                transformer_block_names = base_model.get_transformer_block_names()
-                            
-                            if transformer_block_names is not None:
-                                if not any([name in lora_name for name in transformer_block_names]):
-                                    skip = True
+                            lora_name = [prefix, name, child_name]
+                            # filter out blank
+                            lora_name = [x for x in lora_name if x and x != ""]
+                            lora_name = ".".join(lora_name)
+                            # if it doesnt have a name, it wil have two dots
+                            lora_name.replace("..", ".")
+                            clean_name = lora_name
+                            if self.peft_format:
+                                # we replace this on saving
+                                lora_name = lora_name.replace(".", "$$")
                             else:
-                                if self.is_pixart:
-                                    if "transformer_blocks" not in lora_name:
-                                        skip = True
-                                if self.is_flux:
-                                    if "transformer_blocks" not in lora_name:
-                                        skip = True
-                                if self.is_lumina2:
-                                    if "layers$$" not in lora_name and "noise_refiner$$" not in lora_name and "context_refiner$$" not in lora_name:
-                                        skip = True
-                                if  self.is_v3:
-                                    if "transformer_blocks" not in lora_name:
-                                        skip = True
+                                lora_name = lora_name.replace(".", "_")
+
+                            skip = False
+                            if any([word in clean_name for word in self.ignore_if_contains]):
+                                skip = True
+
+                            # see if it is over threshold
+                            if count_parameters(child_module) < parameter_threshold:
+                                skip = True
+                            
+                            if self.transformer_only and is_unet:
+                                transformer_block_names = None
+                                if base_model is not None:
+                                    transformer_block_names = base_model.get_transformer_block_names()
                                 
-                                # handle custom models
-                                if hasattr(root_module, 'transformer_blocks'):
-                                    if "transformer_blocks" not in lora_name:
+                                if transformer_block_names is not None:
+                                    if not any([name in lora_name for name in transformer_block_names]):
                                         skip = True
-                                        
-                                if hasattr(root_module, 'blocks'):
-                                    if "blocks" not in lora_name:
-                                        skip = True
-                                
-                                if hasattr(root_module, 'single_blocks'):
-                                    if "single_blocks" not in lora_name and "double_blocks" not in lora_name:
-                                        skip = True
-
-                        if (is_linear or is_conv2d) and not skip:
-
-                            if self.only_if_contains is not None:
-                                if not any([word in clean_name for word in self.only_if_contains]) and not any([word in lora_name for word in self.only_if_contains]):
-                                    continue
-
-                            dim = None
-                            alpha = None
-
-                            if modules_dim is not None:
-                                # モジュール指定あり
-                                if lora_name in modules_dim:
-                                    dim = modules_dim[lora_name]
-                                    alpha = modules_alpha[lora_name]
-                            else:
-                                # 通常、すべて対象とする
-                                if is_linear or is_conv2d_1x1:
-                                    dim = self.lora_dim
-                                    alpha = self.alpha
-                                elif self.conv_lora_dim is not None:
-                                    dim = self.conv_lora_dim
-                                    alpha = self.conv_alpha
-
-                            if dim is None or dim == 0:
-                                # skipした情報を出力
-                                if is_linear or is_conv2d_1x1 or (
-                                        self.conv_lora_dim is not None or conv_block_dims is not None):
-                                    skipped.append(lora_name)
-                                continue
-                            
-                            module_kwargs = {}
-                            
-                            if self.network_type.lower() == "lokr":
-                                module_kwargs["factor"] = self.network_config.lokr_factor
-                            
-                            if self.is_ara:
-                                module_kwargs["is_ara"] = True
-
-                            lora = module_class(
-                                lora_name,
-                                child_module,
-                                self.multiplier,
-                                dim,
-                                alpha,
-                                dropout=dropout,
-                                rank_dropout=rank_dropout,
-                                module_dropout=module_dropout,
-                                network=self,
-                                parent=module,
-                                use_bias=use_bias,
-                                **module_kwargs
-                            )
-                            loras.append(lora)
-                            if self.network_type.lower() == "lokr":
-                                try:
-                                    lora_shape_dict[lora_name] = [list(lora.lokr_w1.weight.shape), list(lora.lokr_w2.weight.shape)]
-                                except:
-                                    pass
-                            else:
-                                if self.full_rank:
-                                    lora_shape_dict[lora_name] = [list(lora.lora_down.weight.shape)]
                                 else:
-                                    lora_shape_dict[lora_name] = [list(lora.lora_down.weight.shape), list(lora.lora_up.weight.shape)]
-            return loras, skipped
+                                    if self.is_pixart:
+                                        if "transformer_blocks" not in lora_name:
+                                            skip = True
+                                    if self.is_flux:
+                                        if "transformer_blocks" not in lora_name:
+                                            skip = True
+                                    if self.is_lumina2:
+                                        if "layers$$" not in lora_name and "noise_refiner$$" not in lora_name and "context_refiner$$" not in lora_name:
+                                            skip = True
+                                    if  self.is_v3:
+                                        if "transformer_blocks" not in lora_name:
+                                            skip = True
+                                    
+                                    # handle custom models
+                                    if hasattr(root_module, 'transformer_blocks'):
+                                        if "transformer_blocks" not in lora_name:
+                                            skip = True
+                                            
+                                    if hasattr(root_module, 'blocks'):
+                                        if "blocks" not in lora_name:
+                                            skip = True
+                                    
+                                    if hasattr(root_module, 'single_blocks'):
+                                        if "single_blocks" not in lora_name and "double_blocks" not in lora_name:
+                                            skip = True
 
-        text_encoders = text_encoder if type(text_encoder) == list else [text_encoder]
+                            if (is_linear or is_conv2d) and not skip:
 
-        # create LoRA for text encoder
-        # 毎回すべてのモジュールを作るのは無駄なので要検討
-        self.text_encoder_loras = []
-        skipped_te = []
-        if train_text_encoder:
-            for i, text_encoder in enumerate(text_encoders):
-                if not use_text_encoder_1 and i == 0:
-                    continue
-                if not use_text_encoder_2 and i == 1:
-                    continue
-                if len(text_encoders) > 1:
-                    index = i + 1
-                    print(f"create LoRA for Text Encoder {index}:")
-                else:
-                    index = None
-                    print(f"create LoRA for Text Encoder:")
+                                if self.only_if_contains is not None:
+                                    if not any([word in clean_name for word in self.only_if_contains]) and not any([word in lora_name for word in self.only_if_contains]):
+                                        continue
 
-                replace_modules = LoRANetwork.TEXT_ENCODER_TARGET_REPLACE_MODULE
+                                dim = None
+                                alpha = None
 
-                if self.is_pixart:
-                    replace_modules = ["T5EncoderModel"]
+                                if modules_dim is not None:
+                                    # モジュール指定あり
+                                    if lora_name in modules_dim:
+                                        dim = modules_dim[lora_name]
+                                        alpha = modules_alpha[lora_name]
+                                else:
+                                    # 通常、すべて対象とする
+                                    if is_linear or is_conv2d_1x1:
+                                        dim = self.lora_dim
+                                        alpha = self.alpha
+                                    elif self.conv_lora_dim is not None:
+                                        dim = self.conv_lora_dim
+                                        alpha = self.conv_alpha
 
-                text_encoder_loras, skipped = create_modules(False, index, text_encoder, replace_modules)
-                self.text_encoder_loras.extend(text_encoder_loras)
-                skipped_te += skipped
-        print(f"create LoRA for Text Encoder: {len(self.text_encoder_loras)} modules.")
+                                if dim is None or dim == 0:
+                                    # skipした情報を出力
+                                    if is_linear or is_conv2d_1x1 or (
+                                            self.conv_lora_dim is not None or conv_block_dims is not None):
+                                        skipped.append(lora_name)
+                                    continue
+                                
+                                module_kwargs = {}
+                                
+                                if self.network_type.lower() == "lokr":
+                                    module_kwargs["factor"] = self.network_config.lokr_factor
+                                
+                                if self.is_ara:
+                                    module_kwargs["is_ara"] = True
 
-        # extend U-Net target modules if conv2d 3x3 is enabled, or load from weights
-        target_modules = target_lin_modules
-        if modules_dim is not None or self.conv_lora_dim is not None or conv_block_dims is not None:
-            target_modules += target_conv_modules
+                                lora = module_class(
+                                    lora_name,
+                                    child_module,
+                                    self.multiplier,
+                                    dim,
+                                    alpha,
+                                    dropout=dropout,
+                                    rank_dropout=rank_dropout,
+                                    module_dropout=module_dropout,
+                                    network=self,
+                                    parent=module,
+                                    use_bias=use_bias,
+                                    **module_kwargs
+                                )
+                                loras.append(lora)
+                                if self.network_type.lower() == "lokr":
+                                    try:
+                                        lora_shape_dict[lora_name] = [list(lora.lokr_w1.weight.shape), list(lora.lokr_w2.weight.shape)]
+                                    except:
+                                        pass
+                                else:
+                                    if self.full_rank:
+                                        lora_shape_dict[lora_name] = [list(lora.lora_down.weight.shape)]
+                                    else:
+                                        lora_shape_dict[lora_name] = [list(lora.lora_down.weight.shape), list(lora.lora_up.weight.shape)]
+                return loras, skipped
 
-        if is_v3:
-            target_modules = ["SD3Transformer2DModel"]
+            text_encoders = text_encoder if type(text_encoder) == list else [text_encoder]
 
-        if is_pixart:
-            target_modules = ["PixArtTransformer2DModel"]
+            # create LoRA for text encoder
+            # 毎回すべてのモジュールを作るのは無駄なので要検討
+            self.text_encoder_loras = []
+            skipped_te = []
+            if train_text_encoder:
+                for i, text_encoder in enumerate(text_encoders):
+                    if not use_text_encoder_1 and i == 0:
+                        continue
+                    if not use_text_encoder_2 and i == 1:
+                        continue
+                    if len(text_encoders) > 1:
+                        index = i + 1
+                        print(f"create LoRA for Text Encoder {index}:")
+                    else:
+                        index = None
+                        print(f"create LoRA for Text Encoder:")
 
-        if is_auraflow:
-            target_modules = ["AuraFlowTransformer2DModel"]
+                    replace_modules = LoRANetwork.TEXT_ENCODER_TARGET_REPLACE_MODULE
 
-        if is_flux:
-            target_modules = ["FluxTransformer2DModel"]
-        
-        if is_lumina2:
-            target_modules = ["Lumina2Transformer2DModel"]
+                    if self.is_pixart:
+                        replace_modules = ["T5EncoderModel"]
 
-        if train_unet:
-            self.unet_loras, skipped_un = create_modules(True, None, unet, target_modules)
-        else:
-            self.unet_loras = []
-            skipped_un = []
-        print(f"create LoRA for U-Net: {len(self.unet_loras)} modules.")
+                    text_encoder_loras, skipped = create_modules(False, index, text_encoder, replace_modules)
+                    self.text_encoder_loras.extend(text_encoder_loras)
+                    skipped_te += skipped
+            print(f"create LoRA for Text Encoder: {len(self.text_encoder_loras)} modules.")
+
+            # extend U-Net target modules if conv2d 3x3 is enabled, or load from weights
+            target_modules = target_lin_modules
+            if modules_dim is not None or self.conv_lora_dim is not None or conv_block_dims is not None:
+                target_modules += target_conv_modules
+
+            if is_v3:
+                target_modules = ["SD3Transformer2DModel"]
+
+            if is_pixart:
+                target_modules = ["PixArtTransformer2DModel"]
+
+            if is_auraflow:
+                target_modules = ["AuraFlowTransformer2DModel"]
+
+            if is_flux:
+                target_modules = ["FluxTransformer2DModel"]
+            
+            if is_lumina2:
+                target_modules = ["Lumina2Transformer2DModel"]
+
+            if train_unet:
+                self.unet_loras, skipped_un = create_modules(True, None, unet, target_modules)
+            else:
+                self.unet_loras = []
+                skipped_un = []
+            print(f"create LoRA for U-Net: {len(self.unet_loras)} modules.")
 
         skipped = skipped_te + skipped_un
         if varbose and len(skipped) > 0:
@@ -579,6 +581,31 @@ class LoRASpecialNetwork(ToolkitNetworkMixin, LoRANetwork):
                 self.unet_conv_out = copy.deepcopy(unet_conv_out)
                 unet.conv_in = self.unet_conv_in
                 unet.conv_out = self.unet_conv_out
+
+    def share_parameters_with(self, other: "LoRASpecialNetwork") -> None:
+        """
+        Share all trainable parameters with another network of the same structure.
+        Used so sampling_network uses the same LoRA weights as the training network
+        (one LoRA for both training and sampling, no copy/sync).
+        """
+        assert len(self.unet_loras) == len(other.unet_loras), "unet_loras length mismatch"
+        assert len(self.text_encoder_loras) == len(other.text_encoder_loras), "text_encoder_loras length mismatch"
+
+        def _share_lora_pair(my_lora: torch.nn.Module, other_lora: torch.nn.Module) -> None:
+            assert getattr(my_lora, "lora_name", None) == getattr(other_lora, "lora_name", None), (
+                f"lora name mismatch: {getattr(my_lora, 'lora_name', None)} vs {getattr(other_lora, 'lora_name', None)}"
+            )
+            for name, param in other_lora.named_parameters():
+                parts = name.split(".")
+                obj = my_lora
+                for p in parts[:-1]:
+                    obj = getattr(obj, p)
+                setattr(obj, parts[-1], param)
+
+        for my_lora, other_lora in zip(self.unet_loras, other.unet_loras):
+            _share_lora_pair(my_lora, other_lora)
+        for my_lora, other_lora in zip(self.text_encoder_loras, other.text_encoder_loras):
+            _share_lora_pair(my_lora, other_lora)
 
     def prepare_optimizer_params(self, text_encoder_lr, unet_lr, default_lr):
         # call Lora prepare_optimizer_params

--- a/toolkit/models/base_model.py
+++ b/toolkit/models/base_model.py
@@ -41,6 +41,7 @@ from torchvision.transforms import functional as TF
 from toolkit.accelerator import get_accelerator, unwrap_model
 from typing import TYPE_CHECKING
 from toolkit.print import print_acc
+from toolkit.util.debug import is_debug_enabled
 
 if TYPE_CHECKING:
     from toolkit.lora_special import LoRASpecialNetwork
@@ -410,6 +411,7 @@ class BaseModel:
         rng_state = torch.get_rng_state()
         cuda_rng_state = torch.cuda.get_rng_state() if torch.cuda.is_available() else None
 
+        pipeline_created = (pipeline is None)
         if pipeline is None:
             pipeline = self.get_generation_pipeline()
             try:
@@ -423,267 +425,277 @@ class BaseModel:
 
         # pipeline.to(self.device_torch)
 
-        with network:
-            with torch.no_grad():
-                if network is not None:
-                    assert network.is_active
-
-                # Load sampling transformer onto device if it exists
-                if self._sampling_transformer is not None:
-                    self.model.to("cpu")
-                    self._sampling_transformer.to(self.device_torch, dtype=self.torch_dtype)
-                else:
-                    self.model.to(self.device_torch, dtype=self.torch_dtype)
-
-                for i in tqdm(range(len(image_configs)), desc=f"Generating Images", leave=False):
-                    gen_config = image_configs[i]
-
-                    extra = {}
-
-                    validation_image = None
-                    if self.adapter is not None and gen_config.adapter_image_path is not None:
-                        validation_image = Image.open(gen_config.adapter_image_path)
-                        if ".inpaint." not in gen_config.adapter_image_path:
-                            validation_image = validation_image.convert("RGB")
-                        else:
-                            # make sure it has an alpha
-                            if validation_image.mode != "RGBA":
-                                raise ValueError("Inpainting images must have an alpha channel")
-                        if isinstance(self.adapter, T2IAdapter):
-                            # not sure why this is double??
-                            validation_image = validation_image.resize(
-                                (gen_config.width * 2, gen_config.height * 2))
-                            extra['image'] = validation_image
-                            extra['adapter_conditioning_scale'] = gen_config.adapter_conditioning_scale
-                        if isinstance(self.adapter, ControlNetModel):
-                            validation_image = validation_image.resize(
-                                (gen_config.width, gen_config.height))
-                            extra['image'] = validation_image
-                            extra['controlnet_conditioning_scale'] = gen_config.adapter_conditioning_scale
-                        if isinstance(self.adapter, CustomAdapter) and self.adapter.control_lora is not None:
-                            validation_image = validation_image.resize((gen_config.width, gen_config.height))
-                            extra['control_image'] = validation_image
-                            extra['control_image_idx'] = gen_config.ctrl_idx
-                        if isinstance(self.adapter, IPAdapter) or isinstance(self.adapter, ClipVisionAdapter):
-                            transform = transforms.Compose([
-                                transforms.ToTensor(),
-                            ])
-                            validation_image = transform(validation_image)
-                        if isinstance(self.adapter, CustomAdapter):
-                            # todo allow loading multiple
-                            transform = transforms.Compose([
-                                transforms.ToTensor(),
-                            ])
-                            validation_image = transform(validation_image)
-                            self.adapter.num_images = 1
-                        if isinstance(self.adapter, ReferenceAdapter):
-                            # need -1 to 1
-                            validation_image = transforms.ToTensor()(validation_image)
-                            validation_image = validation_image * 2.0 - 1.0
-                            validation_image = validation_image.unsqueeze(0)
-                            self.adapter.set_reference_images(validation_image)
-
+        try:
+            with network:
+                with torch.no_grad():
                     if network is not None:
-                        network.multiplier = gen_config.network_multiplier
-                    torch.manual_seed(gen_config.seed)
-                    torch.cuda.manual_seed(gen_config.seed)
+                        assert network.is_active
 
-                    generator = torch.manual_seed(gen_config.seed)
-
-                    if self.adapter is not None and isinstance(self.adapter, ClipVisionAdapter) \
-                            and gen_config.adapter_image_path is not None:
-                        # run through the adapter to saturate the embeds
-                        conditional_clip_embeds = self.adapter.get_clip_image_embeds_from_tensors(
-                            validation_image)
-                        self.adapter(conditional_clip_embeds)
-
-                    if self.adapter is not None and isinstance(self.adapter, CustomAdapter):
-                        # handle condition the prompts
-                        gen_config.prompt = self.adapter.condition_prompt(
-                            gen_config.prompt,
-                            is_unconditional=False,
-                        )
-                        gen_config.prompt_2 = gen_config.prompt
-                        gen_config.negative_prompt = self.adapter.condition_prompt(
-                            gen_config.negative_prompt,
-                            is_unconditional=True,
-                        )
-                        gen_config.negative_prompt_2 = gen_config.negative_prompt
-
-                    if self.adapter is not None and isinstance(self.adapter, CustomAdapter) and validation_image is not None:
-                        self.adapter.trigger_pre_te(
-                            tensors_0_1=validation_image,
-                            is_training=False,
-                            has_been_preprocessed=False,
-                            quad_count=4
-                        )
-
-                    if self.sample_prompts_cache is not None:
-                        conditional_embeds = self.sample_prompts_cache[i]['conditional'].to(self.device_torch, dtype=self.torch_dtype)
-                        unconditional_embeds = self.sample_prompts_cache[i]['unconditional'].to(self.device_torch, dtype=self.torch_dtype)
+                    # Load sampling transformer onto device if it exists
+                    if self._sampling_transformer is not None:
+                        self.model.to("cpu")
+                        self._sampling_transformer.to(self.device_torch, dtype=self.torch_dtype)
                     else:
-                        ctrl_img = None
-                        has_control_images = False
-                        if gen_config.ctrl_img is not None or gen_config.ctrl_img_1 is not None or gen_config.ctrl_img_2 is not None or gen_config.ctrl_img_3 is not None:
-                            has_control_images = True
-                        # load the control image if out model uses it in text encoding
-                        if has_control_images and self.encode_control_in_text_embeddings:
-                            ctrl_img_list = []
-                    
-                            if gen_config.ctrl_img is not None:
-                                ctrl_img = Image.open(gen_config.ctrl_img).convert("RGB")
-                                # convert to 0 to 1 tensor
-                                ctrl_img = (
-                                    TF.to_tensor(ctrl_img)
-                                    .unsqueeze(0)
-                                    .to(self.device_torch, dtype=self.torch_dtype)
-                                )
-                                ctrl_img_list.append(ctrl_img)
-                            
-                            if gen_config.ctrl_img_1 is not None:
-                                ctrl_img_1 = Image.open(gen_config.ctrl_img_1).convert("RGB")
-                                # convert to 0 to 1 tensor
-                                ctrl_img_1 = (
-                                    TF.to_tensor(ctrl_img_1)
-                                    .unsqueeze(0)
-                                    .to(self.device_torch, dtype=self.torch_dtype)
-                                )
-                                ctrl_img_list.append(ctrl_img_1)
-                            if gen_config.ctrl_img_2 is not None:
-                                ctrl_img_2 = Image.open(gen_config.ctrl_img_2).convert("RGB")
-                                # convert to 0 to 1 tensor
-                                ctrl_img_2 = (
-                                    TF.to_tensor(ctrl_img_2)
-                                    .unsqueeze(0)
-                                    .to(self.device_torch, dtype=self.torch_dtype)
-                                )
-                                ctrl_img_list.append(ctrl_img_2)
-                            if gen_config.ctrl_img_3 is not None:
-                                ctrl_img_3 = Image.open(gen_config.ctrl_img_3).convert("RGB")
-                                # convert to 0 to 1 tensor
-                                ctrl_img_3 = (
-                                    TF.to_tensor(ctrl_img_3)
-                                    .unsqueeze(0)
-                                    .to(self.device_torch, dtype=self.torch_dtype)
-                                )
-                                ctrl_img_list.append(ctrl_img_3)
-                            
-                            if self.has_multiple_control_images:
-                                ctrl_img = ctrl_img_list
+                        self.model.to(self.device_torch, dtype=self.torch_dtype)
+
+                    for i in tqdm(range(len(image_configs)), desc=f"Generating Images", leave=False):
+                        gen_config = image_configs[i]
+
+                        extra = {}
+
+                        validation_image = None
+                        if self.adapter is not None and gen_config.adapter_image_path is not None:
+                            validation_image = Image.open(gen_config.adapter_image_path)
+                            if ".inpaint." not in gen_config.adapter_image_path:
+                                validation_image = validation_image.convert("RGB")
                             else:
-                                ctrl_img = ctrl_img_list[0] if len(ctrl_img_list) > 0 else None
-                        # encode the prompt ourselves so we can do fun stuff with embeddings
-                        if isinstance(self.adapter, CustomAdapter):
-                            self.adapter.is_unconditional_run = False
-                        conditional_embeds = self.encode_prompt(
-                            gen_config.prompt, 
-                            gen_config.prompt_2, 
-                            force_all=True,
-                            control_images=ctrl_img
+                                # make sure it has an alpha
+                                if validation_image.mode != "RGBA":
+                                    raise ValueError("Inpainting images must have an alpha channel")
+                            if isinstance(self.adapter, T2IAdapter):
+                                # not sure why this is double??
+                                validation_image = validation_image.resize(
+                                    (gen_config.width * 2, gen_config.height * 2))
+                                extra['image'] = validation_image
+                                extra['adapter_conditioning_scale'] = gen_config.adapter_conditioning_scale
+                            if isinstance(self.adapter, ControlNetModel):
+                                validation_image = validation_image.resize(
+                                    (gen_config.width, gen_config.height))
+                                extra['image'] = validation_image
+                                extra['controlnet_conditioning_scale'] = gen_config.adapter_conditioning_scale
+                            if isinstance(self.adapter, CustomAdapter) and self.adapter.control_lora is not None:
+                                validation_image = validation_image.resize((gen_config.width, gen_config.height))
+                                extra['control_image'] = validation_image
+                                extra['control_image_idx'] = gen_config.ctrl_idx
+                            if isinstance(self.adapter, IPAdapter) or isinstance(self.adapter, ClipVisionAdapter):
+                                transform = transforms.Compose([
+                                    transforms.ToTensor(),
+                                ])
+                                validation_image = transform(validation_image)
+                            if isinstance(self.adapter, CustomAdapter):
+                                # todo allow loading multiple
+                                transform = transforms.Compose([
+                                    transforms.ToTensor(),
+                                ])
+                                validation_image = transform(validation_image)
+                                self.adapter.num_images = 1
+                            if isinstance(self.adapter, ReferenceAdapter):
+                                # need -1 to 1
+                                validation_image = transforms.ToTensor()(validation_image)
+                                validation_image = validation_image * 2.0 - 1.0
+                                validation_image = validation_image.unsqueeze(0)
+                                self.adapter.set_reference_images(validation_image)
+
+                        if network is not None:
+                            network.multiplier = gen_config.network_multiplier
+                        torch.manual_seed(gen_config.seed)
+                        torch.cuda.manual_seed(gen_config.seed)
+
+                        generator = torch.manual_seed(gen_config.seed)
+
+                        if self.adapter is not None and isinstance(self.adapter, ClipVisionAdapter) \
+                                and gen_config.adapter_image_path is not None:
+                            # run through the adapter to saturate the embeds
+                            conditional_clip_embeds = self.adapter.get_clip_image_embeds_from_tensors(
+                                validation_image)
+                            self.adapter(conditional_clip_embeds)
+
+                        if self.adapter is not None and isinstance(self.adapter, CustomAdapter):
+                            # handle condition the prompts
+                            gen_config.prompt = self.adapter.condition_prompt(
+                                gen_config.prompt,
+                                is_unconditional=False,
+                            )
+                            gen_config.prompt_2 = gen_config.prompt
+                            gen_config.negative_prompt = self.adapter.condition_prompt(
+                                gen_config.negative_prompt,
+                                is_unconditional=True,
+                            )
+                            gen_config.negative_prompt_2 = gen_config.negative_prompt
+
+                        if self.adapter is not None and isinstance(self.adapter, CustomAdapter) and validation_image is not None:
+                            self.adapter.trigger_pre_te(
+                                tensors_0_1=validation_image,
+                                is_training=False,
+                                has_been_preprocessed=False,
+                                quad_count=4
+                            )
+
+                        if self.sample_prompts_cache is not None:
+                            conditional_embeds = self.sample_prompts_cache[i]['conditional'].to(self.device_torch, dtype=self.torch_dtype)
+                            unconditional_embeds = self.sample_prompts_cache[i]['unconditional'].to(self.device_torch, dtype=self.torch_dtype)
+                        else:
+                            ctrl_img = None
+                            has_control_images = False
+                            if gen_config.ctrl_img is not None or gen_config.ctrl_img_1 is not None or gen_config.ctrl_img_2 is not None or gen_config.ctrl_img_3 is not None:
+                                has_control_images = True
+                            # load the control image if out model uses it in text encoding
+                            if has_control_images and self.encode_control_in_text_embeddings:
+                                ctrl_img_list = []
+                    
+                                if gen_config.ctrl_img is not None:
+                                    ctrl_img = Image.open(gen_config.ctrl_img).convert("RGB")
+                                    # convert to 0 to 1 tensor
+                                    ctrl_img = (
+                                        TF.to_tensor(ctrl_img)
+                                        .unsqueeze(0)
+                                        .to(self.device_torch, dtype=self.torch_dtype)
+                                    )
+                                    ctrl_img_list.append(ctrl_img)
+                            
+                                if gen_config.ctrl_img_1 is not None:
+                                    ctrl_img_1 = Image.open(gen_config.ctrl_img_1).convert("RGB")
+                                    # convert to 0 to 1 tensor
+                                    ctrl_img_1 = (
+                                        TF.to_tensor(ctrl_img_1)
+                                        .unsqueeze(0)
+                                        .to(self.device_torch, dtype=self.torch_dtype)
+                                    )
+                                    ctrl_img_list.append(ctrl_img_1)
+                                if gen_config.ctrl_img_2 is not None:
+                                    ctrl_img_2 = Image.open(gen_config.ctrl_img_2).convert("RGB")
+                                    # convert to 0 to 1 tensor
+                                    ctrl_img_2 = (
+                                        TF.to_tensor(ctrl_img_2)
+                                        .unsqueeze(0)
+                                        .to(self.device_torch, dtype=self.torch_dtype)
+                                    )
+                                    ctrl_img_list.append(ctrl_img_2)
+                                if gen_config.ctrl_img_3 is not None:
+                                    ctrl_img_3 = Image.open(gen_config.ctrl_img_3).convert("RGB")
+                                    # convert to 0 to 1 tensor
+                                    ctrl_img_3 = (
+                                        TF.to_tensor(ctrl_img_3)
+                                        .unsqueeze(0)
+                                        .to(self.device_torch, dtype=self.torch_dtype)
+                                    )
+                                    ctrl_img_list.append(ctrl_img_3)
+                            
+                                if self.has_multiple_control_images:
+                                    ctrl_img = ctrl_img_list
+                                else:
+                                    ctrl_img = ctrl_img_list[0] if len(ctrl_img_list) > 0 else None
+                            # encode the prompt ourselves so we can do fun stuff with embeddings
+                            if isinstance(self.adapter, CustomAdapter):
+                                self.adapter.is_unconditional_run = False
+                            conditional_embeds = self.encode_prompt(
+                                gen_config.prompt, 
+                                gen_config.prompt_2, 
+                                force_all=True,
+                                control_images=ctrl_img
+                            )
+
+                            if isinstance(self.adapter, CustomAdapter):
+                                self.adapter.is_unconditional_run = True
+                            unconditional_embeds = self.encode_prompt(
+                                gen_config.negative_prompt, 
+                                gen_config.negative_prompt_2, 
+                                force_all=True,
+                                control_images=ctrl_img
+                            )
+                            if isinstance(self.adapter, CustomAdapter):
+                                self.adapter.is_unconditional_run = False
+
+                        # allow any manipulations to take place to embeddings
+                        gen_config.post_process_embeddings(
+                            conditional_embeds,
+                            unconditional_embeds,
                         )
 
-                        if isinstance(self.adapter, CustomAdapter):
-                            self.adapter.is_unconditional_run = True
-                        unconditional_embeds = self.encode_prompt(
-                            gen_config.negative_prompt, 
-                            gen_config.negative_prompt_2, 
-                            force_all=True,
-                            control_images=ctrl_img
+                        if self.decorator is not None:
+                            # apply the decorator to the embeddings
+                            conditional_embeds.text_embeds = self.decorator(
+                                conditional_embeds.text_embeds)
+                            unconditional_embeds.text_embeds = self.decorator(
+                                unconditional_embeds.text_embeds, is_unconditional=True)
+
+                        if self.adapter is not None and isinstance(self.adapter, IPAdapter) \
+                                and gen_config.adapter_image_path is not None:
+                            # apply the image projection
+                            conditional_clip_embeds = self.adapter.get_clip_image_embeds_from_tensors(
+                                validation_image)
+                            unconditional_clip_embeds = self.adapter.get_clip_image_embeds_from_tensors(validation_image,
+                                                                                                        True)
+                            conditional_embeds = self.adapter(
+                                conditional_embeds, conditional_clip_embeds, is_unconditional=False)
+                            unconditional_embeds = self.adapter(
+                                unconditional_embeds, unconditional_clip_embeds, is_unconditional=True)
+
+                        if self.adapter is not None and isinstance(self.adapter, CustomAdapter):
+                            conditional_embeds = self.adapter.condition_encoded_embeds(
+                                tensors_0_1=validation_image,
+                                prompt_embeds=conditional_embeds,
+                                is_training=False,
+                                has_been_preprocessed=False,
+                                is_generating_samples=True,
+                            )
+                            unconditional_embeds = self.adapter.condition_encoded_embeds(
+                                tensors_0_1=validation_image,
+                                prompt_embeds=unconditional_embeds,
+                                is_training=False,
+                                has_been_preprocessed=False,
+                                is_unconditional=True,
+                                is_generating_samples=True,
+                            )
+
+                        if self.adapter is not None and isinstance(self.adapter, CustomAdapter) and len(
+                                gen_config.extra_values) > 0:
+                            extra_values = torch.tensor([gen_config.extra_values], device=self.device_torch,
+                                                        dtype=self.torch_dtype)
+                            # apply extra values to the embeddings
+                            self.adapter.add_extra_values(
+                                extra_values, is_unconditional=False)
+                            self.adapter.add_extra_values(torch.zeros_like(
+                                extra_values), is_unconditional=True)
+                            pass  # todo remove, for debugging
+
+                        if self.refiner_unet is not None and gen_config.refiner_start_at < 1.0:
+                            # if we have a refiner loaded, set the denoising end at the refiner start
+                            extra['denoising_end'] = gen_config.refiner_start_at
+                            extra['output_type'] = 'latent'
+                            if not self.is_xl:
+                                raise ValueError(
+                                    "Refiner is only supported for XL models")
+
+                        conditional_embeds = conditional_embeds.to(
+                            self.device_torch, dtype=self.unet.dtype)
+                        unconditional_embeds = unconditional_embeds.to(
+                            self.device_torch, dtype=self.unet.dtype)
+
+                        img = self.generate_single_image(
+                            pipeline,
+                            gen_config,
+                            conditional_embeds,
+                            unconditional_embeds,
+                            generator,
+                            extra,
                         )
-                        if isinstance(self.adapter, CustomAdapter):
-                            self.adapter.is_unconditional_run = False
 
-                    # allow any manipulations to take place to embeddings
-                    gen_config.post_process_embeddings(
-                        conditional_embeds,
-                        unconditional_embeds,
-                    )
-
-                    if self.decorator is not None:
-                        # apply the decorator to the embeddings
-                        conditional_embeds.text_embeds = self.decorator(
-                            conditional_embeds.text_embeds)
-                        unconditional_embeds.text_embeds = self.decorator(
-                            unconditional_embeds.text_embeds, is_unconditional=True)
-
-                    if self.adapter is not None and isinstance(self.adapter, IPAdapter) \
-                            and gen_config.adapter_image_path is not None:
-                        # apply the image projection
-                        conditional_clip_embeds = self.adapter.get_clip_image_embeds_from_tensors(
-                            validation_image)
-                        unconditional_clip_embeds = self.adapter.get_clip_image_embeds_from_tensors(validation_image,
-                                                                                                    True)
-                        conditional_embeds = self.adapter(
-                            conditional_embeds, conditional_clip_embeds, is_unconditional=False)
-                        unconditional_embeds = self.adapter(
-                            unconditional_embeds, unconditional_clip_embeds, is_unconditional=True)
-
-                    if self.adapter is not None and isinstance(self.adapter, CustomAdapter):
-                        conditional_embeds = self.adapter.condition_encoded_embeds(
-                            tensors_0_1=validation_image,
-                            prompt_embeds=conditional_embeds,
-                            is_training=False,
-                            has_been_preprocessed=False,
-                            is_generating_samples=True,
-                        )
-                        unconditional_embeds = self.adapter.condition_encoded_embeds(
-                            tensors_0_1=validation_image,
-                            prompt_embeds=unconditional_embeds,
-                            is_training=False,
-                            has_been_preprocessed=False,
-                            is_unconditional=True,
-                            is_generating_samples=True,
-                        )
-
-                    if self.adapter is not None and isinstance(self.adapter, CustomAdapter) and len(
-                            gen_config.extra_values) > 0:
-                        extra_values = torch.tensor([gen_config.extra_values], device=self.device_torch,
-                                                    dtype=self.torch_dtype)
-                        # apply extra values to the embeddings
-                        self.adapter.add_extra_values(
-                            extra_values, is_unconditional=False)
-                        self.adapter.add_extra_values(torch.zeros_like(
-                            extra_values), is_unconditional=True)
-                        pass  # todo remove, for debugging
-
-                    if self.refiner_unet is not None and gen_config.refiner_start_at < 1.0:
-                        # if we have a refiner loaded, set the denoising end at the refiner start
-                        extra['denoising_end'] = gen_config.refiner_start_at
-                        extra['output_type'] = 'latent'
-                        if not self.is_xl:
-                            raise ValueError(
-                                "Refiner is only supported for XL models")
-
-                    conditional_embeds = conditional_embeds.to(
-                        self.device_torch, dtype=self.unet.dtype)
-                    unconditional_embeds = unconditional_embeds.to(
-                        self.device_torch, dtype=self.unet.dtype)
-
-                    img = self.generate_single_image(
-                        pipeline,
-                        gen_config,
-                        conditional_embeds,
-                        unconditional_embeds,
-                        generator,
-                        extra,
-                    )
-
-                    gen_config.save_image(img, i)
-                    gen_config.log_image(img, i)
-                    self._after_sample_image(i, len(image_configs))
-                    flush()
+                        gen_config.save_image(img, i)
+                        gen_config.log_image(img, i)
+                        self._after_sample_image(i, len(image_configs))
+                        flush()
 
                 if self.adapter is not None and isinstance(self.adapter, ReferenceAdapter):
                     self.adapter.clear_memory()
 
-        # Unload sampling transformer from GPU and restore main model to device
-        if self._sampling_transformer is not None:
-            self._sampling_transformer.to("cpu")
-            self.model.to(self.device_torch, dtype=self.torch_dtype)
-
-        # clear pipeline and cache to reduce vram usage
-        del pipeline
-        torch.cuda.empty_cache()
+        finally:
+            # Unload sampling transformer from GPU and restore main model to device
+            if self._sampling_transformer is not None:
+                self._sampling_transformer.to("cpu")
+                self.model.to(self.device_torch, dtype=self.torch_dtype)
+                if is_debug_enabled():
+                    print_acc("Unloaded sampling transformer to CPU")
+            # Ensure CUDA work is finished so VRAM is actually released before next use
+            if torch.cuda.is_available():
+                torch.cuda.synchronize()
+            # Clear pipeline and cache to reduce vram usage (only if we created pipeline here)
+            if pipeline_created:
+                try:
+                    del pipeline
+                except NameError:
+                    pass
+            torch.cuda.empty_cache()
 
         # restore training state
         torch.set_rng_state(rng_state)
@@ -695,7 +707,6 @@ class BaseModel:
             network.train()
             network.multiplier = start_multiplier
 
-        self.unet.to(self.device_torch, dtype=self.torch_dtype)
         if network.is_merged_in:
             network.merge_out(merge_multiplier)
         # self.tokenizer.to(original_device_dict['tokenizer'])

--- a/toolkit/network_mixins.py
+++ b/toolkit/network_mixins.py
@@ -641,13 +641,13 @@ class ToolkitNetworkMixin:
                 load_key = load_key.replace('.', '$$')
                 load_key = load_key.replace('$$lora_down$$', '.lora_down.')
                 load_key = load_key.replace('$$lora_up$$', '.lora_up.')
-                
+                if load_key.endswith('$$alpha'):
+                    load_key = load_key[:-7] + '.alpha'
+
                 # patch lokr, not sure why we need to but whatever
                 if self.network_type.lower() == "lokr":
                     load_key = load_key.replace('$$lokr_w1', '.lokr_w1')
                     load_key = load_key.replace('$$lokr_w2', '.lokr_w2')
-                    if load_key.endswith('$$alpha'):
-                        load_key = load_key[:-7] + '.alpha'
             
             if self.network_type.lower() == "lokr":
                 # lora_transformer_transformer_blocks_7_attn_to_v.lokr_w1 to lycoris_transformer_blocks_7_attn_to_v.lokr_w1

--- a/toolkit/network_mixins.py
+++ b/toolkit/network_mixins.py
@@ -547,8 +547,8 @@ class ToolkitNetworkMixin:
             new_save_dict = {}
             for key, value in save_dict.items():
                 # lokr needs alpha
-                if key.endswith('.alpha') and self.network_type.lower() != "lokr":
-                    continue
+                # if key.endswith('.alpha') and self.network_type.lower() != "lokr":
+                #     continue
                 new_key = key
                 new_key = new_key.replace('lora_down', 'lora_A')
                 new_key = new_key.replace('lora_up', 'lora_B')
@@ -633,8 +633,8 @@ class ToolkitNetworkMixin:
                 # lora_down = lora_A
                 # lora_up = lora_B
                 # no alpha
-                if load_key.endswith('.alpha') and self.network_type.lower() != "lokr":
-                    continue
+                # if load_key.endswith('.alpha') and self.network_type.lower() != "lokr":
+                #     continue
                 load_key = load_key.replace('lora_A', 'lora_down')
                 load_key = load_key.replace('lora_B', 'lora_up')
                 # replace all . with $$

--- a/toolkit/network_mixins.py
+++ b/toolkit/network_mixins.py
@@ -713,9 +713,10 @@ class ToolkitNetworkMixin:
             return self.load_weights(file, force_weight_mapping=True)
 
         info = self.load_state_dict(load_sd, False)
-        if len(extra_dict.keys()) == 0:
-            extra_dict = None
-        return extra_dict
+        del load_sd
+        if isinstance(file, str):
+            del weights_sd
+        return None
 
     @torch.no_grad()
     def _update_torch_multiplier(self: Network):

--- a/toolkit/optimizers/adafactor.py
+++ b/toolkit/optimizers/adafactor.py
@@ -32,6 +32,8 @@ class Adafactor(torch.optim.Optimizer):
             Coefficient used to compute running averages of square
         beta1 (`float`, *optional*):
             Coefficient used for computing running averages of gradient
+            (first moment, like in Adam). If not None, enables momentum.
+            Suggested values: 0.9 (default), 0.95 or 0.99 for smoother updates.
         weight_decay (`float`, *optional*, defaults to 0.0):
             Weight decay (L2 penalty)
         scale_parameter (`bool`, *optional*, defaults to `True`):
@@ -40,6 +42,12 @@ class Adafactor(torch.optim.Optimizer):
             If True, time-dependent learning rate is computed instead of external learning rate
         warmup_init (`bool`, *optional*, defaults to `False`):
             Time-dependent learning rate computation depends on whether warm-up initialization is being used
+        min_lr (`float`, *optional*, defaults to `1e-6`):
+            Minimum learning rate multiplier for warmup phase when `warmup_init=True` and `relative_step=True`.
+            Controls the linear growth rate: `lr = min_lr * step` during warmup.
+        max_lr (`float`, *optional*, defaults to `1e-2`):
+            Maximum learning rate cap for relative step mode when `relative_step=True`.
+            Acts as upper bound for `min_step` when `warmup_init=False` or when warmup phase completes.
 
     This implementation handles low-precision (FP16, bfloat) values, but we have not thoroughly tested.
 
@@ -106,13 +114,15 @@ class Adafactor(torch.optim.Optimizer):
         scale_parameter=True,
         relative_step=True,
         warmup_init=False,
-        do_paramiter_swapping=False,
-        paramiter_swapping_factor=0.1,
+        min_lr=1e-6,
+        max_lr=1e-2,
+        do_parameter_swapping=False,
+        parameter_swapping_factor=0.1,
         stochastic_accumulation=True,
         stochastic_rounding=True,
     ):
         self.stochastic_rounding = stochastic_rounding
-        if lr is not None and relative_step:
+        if lr is not None and lr != 0 and relative_step:
             raise ValueError(
                 "Cannot combine manual `lr` and `relative_step=True` options")
         if warmup_init and not relative_step:
@@ -129,11 +139,13 @@ class Adafactor(torch.optim.Optimizer):
             "scale_parameter": scale_parameter,
             "relative_step": relative_step,
             "warmup_init": warmup_init,
+            "min_lr": min_lr,
+            "max_lr": max_lr,
         }
         super().__init__(params, defaults)
         
         self.base_lrs: List[float] = [
-            lr for group in self.param_groups
+            group['lr'] for group in self.param_groups
         ]
 
         self.is_stochastic_rounding_accumulation = False
@@ -148,60 +160,65 @@ class Adafactor(torch.optim.Optimizer):
                             stochastic_grad_accummulation
                         )
     
-        self.do_paramiter_swapping = do_paramiter_swapping
-        self.paramiter_swapping_factor = paramiter_swapping_factor
-        self._total_paramiter_size = 0
-        # count total paramiters
+        self.do_parameter_swapping = do_parameter_swapping
+        self.parameter_swapping_factor = parameter_swapping_factor
+        self._total_parameter_size = 0
+        # count total parameters
         for group in self.param_groups:
             for param in group['params']:
-                self._total_paramiter_size += torch.numel(param)
-        # pretty print total paramiters with comma seperation
-        print(f"Total training paramiters: {self._total_paramiter_size:,}")
+                self._total_parameter_size += torch.numel(param)
+        # pretty print total parameters with comma separation
+        print(f"Total training parameters: {self._total_parameter_size:,}")
         
-        # needs to be enabled to count paramiters
-        if self.do_paramiter_swapping:
-            self.enable_paramiter_swapping(self.paramiter_swapping_factor)
+        # needs to be enabled to count parameters
+        if self.do_parameter_swapping:
+            self.enable_parameter_swapping(self.parameter_swapping_factor)
         
     
-    def enable_paramiter_swapping(self, paramiter_swapping_factor=0.1):
-        self.do_paramiter_swapping = True
-        self.paramiter_swapping_factor = paramiter_swapping_factor
+    def enable_parameter_swapping(self, parameter_swapping_factor=0.1):
+        self.do_parameter_swapping = True
+        self.parameter_swapping_factor = parameter_swapping_factor
         # call it an initial time
-        self.swap_paramiters()
+        self.swap_parameters()
                     
-    def swap_paramiters(self):
+    def swap_parameters(self):
         all_params = []
-        # deactivate all paramiters
+        # deactivate all parameters
         for group in self.param_groups:
             for param in group['params']:
                 param.requires_grad_(False)
                 # remove any grad
                 param.grad = None
                 all_params.append(param)
-        # shuffle all paramiters
+        # shuffle all parameters
         random.shuffle(all_params)
         
-        # keep activating paramiters until we are going to go over the target paramiters
-        target_paramiters = int(self._total_paramiter_size * self.paramiter_swapping_factor)
-        total_paramiters = 0
+        # keep activating parameters until we are going to go over the target parameters
+        target_parameters = max(1, int(self._total_parameter_size * self.parameter_swapping_factor))
+        total_parameters = 0
         for param in all_params:
-            total_paramiters += torch.numel(param)
-            if total_paramiters >= target_paramiters:
+            param.requires_grad_(True)
+            total_parameters += torch.numel(param)
+            if total_parameters >= target_parameters:
                 break
-            else:
-                param.requires_grad_(True)
 
     @staticmethod
     def _get_lr(param_group, param_state):
         rel_step_sz = param_group["lr"]
         if param_group["relative_step"]:
-            min_step = 1e-6 * \
-                param_state["step"] if param_group["warmup_init"] else 1e-2
+            if param_group["warmup_init"]:
+                min_step = param_group["min_lr"] * param_state["step"]
+            else:
+                min_step = param_group["max_lr"]
             rel_step_sz = min(min_step, 1.0 / math.sqrt(param_state["step"]))
         param_scale = 1.0
         if param_group["scale_parameter"]:
             param_scale = max(param_group["eps"][1], param_state["RMS"])
-        return param_scale * rel_step_sz
+        lr = param_scale * rel_step_sz
+        # Ensure learning rate doesn't exceed max_lr when using relative_step
+        if param_group["relative_step"]:
+            lr = min(lr, param_group["max_lr"])
+        return lr
 
     @staticmethod
     def _get_options(param_group, param_shape):
@@ -234,11 +251,20 @@ class Adafactor(torch.optim.Optimizer):
 
     # adafactor manages its own lr
     def get_learning_rates(self):
-        lrs = [
-            self._get_lr(group, self.state[group["params"][0]])
-            for group in self.param_groups
-            if group["params"][0].grad is not None
-        ]
+        lrs = []
+        for group in self.param_groups:
+            # Find first param with initialized state
+            lr = None
+            for param in group["params"]:
+                if param in self.state and len(self.state[param]) > 0:
+                    lr = self._get_lr(group, self.state[param])
+                    break
+            if lr is not None:
+                lrs.append(lr)
+            elif group["lr"] is not None:
+                # Fallback to group lr if state not initialized
+                lrs.append(group["lr"])
+        
         if len(lrs) == 0:
             lrs = self.base_lrs  # if called before stepping
         return lrs
@@ -288,6 +314,7 @@ class Adafactor(torch.optim.Optimizer):
                     if factored:
                         state["exp_avg_sq_row"] = torch.zeros(
                             grad_shape[:-1]).to(grad)
+                        # For 2D tensors, grad_shape[:-2] is empty tuple, which is correct for column stats
                         state["exp_avg_sq_col"] = torch.zeros(
                             grad_shape[:-2] + grad_shape[-1:]).to(grad)
                     else:
@@ -306,8 +333,9 @@ class Adafactor(torch.optim.Optimizer):
                         state["exp_avg_sq"] = state["exp_avg_sq"].to(grad)
 
                 p_data_fp32 = p
+                is_quantized = isinstance(p_data_fp32, QBytesTensor)
                 
-                if isinstance(p_data_fp32, QBytesTensor):
+                if is_quantized:
                     p_data_fp32 = p_data_fp32.dequantize()
                 if p.dtype != torch.float32:
                     p_data_fp32 = p_data_fp32.clone().float()
@@ -356,8 +384,54 @@ class Adafactor(torch.optim.Optimizer):
 
                 p_data_fp32.add_(-update)
 
-                if p.dtype != torch.float32 and self.stochastic_rounding:
+                # Store update RMS for monitoring
+                state["update_rms"] = self._rms(update).item()
+
+                if (p.dtype != torch.float32 or is_quantized) and self.stochastic_rounding:
                     # apply stochastic rounding
                     copy_stochastic(p, p_data_fp32)
 
         return loss
+        
+    def get_avg_learning_rate(self):
+        lrs = self.get_learning_rates()
+        if len(lrs) == 0:
+            return 0.0
+        return sum(lrs) / len(lrs)
+
+    def get_update_rms(self):
+        """
+        Get RMS (root mean square) of weight updates for each parameter group.
+        
+        Returns:
+            List[float]: RMS of weight updates for each parameter group.
+                        Returns 0.0 for groups that haven't been updated yet.
+        """
+        update_rms_list = []
+        for group in self.param_groups:
+            group_rms_sum = 0.0
+            group_count = 0
+            for p in group["params"]:
+                if p in self.state and "update_rms" in self.state[p]:
+                    group_rms_sum += self.state[p]["update_rms"]
+                    group_count += 1
+            if group_count > 0:
+                update_rms_list.append(group_rms_sum / group_count)
+            else:
+                update_rms_list.append(0.0)
+        return update_rms_list
+
+    def get_avg_update_rms(self):
+        """
+        Get average RMS of weight updates across all parameter groups.
+        
+        This metric represents the average magnitude of weight changes per optimization step.
+        Useful for monitoring training stability and convergence.
+        
+        Returns:
+            float: Average RMS of weight updates across all parameter groups.
+        """
+        update_rms_list = self.get_update_rms()
+        if len(update_rms_list) == 0:
+            return 0.0
+        return sum(update_rms_list) / len(update_rms_list)

--- a/toolkit/optimizers/adafactor.py
+++ b/toolkit/optimizers/adafactor.py
@@ -115,7 +115,7 @@ class Adafactor(torch.optim.Optimizer):
         relative_step=True,
         warmup_init=False,
         min_lr=1e-6,
-        max_lr=1e-2,
+        max_lr=1e-4,
         do_parameter_swapping=False,
         parameter_swapping_factor=0.1,
         stochastic_accumulation=True,
@@ -215,9 +215,8 @@ class Adafactor(torch.optim.Optimizer):
         if param_group["scale_parameter"]:
             param_scale = max(param_group["eps"][1], param_state["RMS"])
         lr = param_scale * rel_step_sz
-        # Ensure learning rate doesn't exceed max_lr when using relative_step
-        if param_group["relative_step"]:
-            lr = min(lr, param_group["max_lr"])
+        # Ensure learning rate is between min_lr and max_lr
+        lr = max(param_group["min_lr"], min(lr, param_group["max_lr"]))
         return lr
 
     @staticmethod

--- a/toolkit/paths.py
+++ b/toolkit/paths.py
@@ -25,10 +25,11 @@ def get_path(path):
     return path
 
 
-def normalize_model_path(path: Optional[str]) -> Optional[str]:
-    """Strip trailing path separators so Hugging Face transformers don't get empty basenames.
-    Avoids the 'The module name (originally ) is not a valid Python identifier' warning.
+def normalize_path(path: Optional[str]) -> Optional[str]:
+    """Strip leading/trailing whitespace and trailing path separators.
+    Use for any path: model dirs, LoRA/safetensors files, etc.
     """
-    if isinstance(path, str):
-        return path.rstrip(os.sep).rstrip("/")
-    return path
+    if not isinstance(path, str):
+        return path
+    path = path.strip()
+    return path.rstrip(os.sep).rstrip("/")

--- a/toolkit/paths.py
+++ b/toolkit/paths.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 TOOLKIT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 CONFIG_ROOT = os.path.join(TOOLKIT_ROOT, 'config')
@@ -21,4 +22,13 @@ def get_path(path):
     # we allow absolute paths, but if it is not absolute, we assume it is relative to the toolkit root
     if not os.path.isabs(path):
         path = os.path.join(TOOLKIT_ROOT, path)
+    return path
+
+
+def normalize_model_path(path: Optional[str]) -> Optional[str]:
+    """Strip trailing path separators so Hugging Face transformers don't get empty basenames.
+    Avoids the 'The module name (originally ) is not a valid Python identifier' warning.
+    """
+    if isinstance(path, str):
+        return path.rstrip(os.sep).rstrip("/")
     return path

--- a/toolkit/scheduler.py
+++ b/toolkit/scheduler.py
@@ -3,22 +3,130 @@ from typing import Optional
 from diffusers.optimization import SchedulerType, TYPE_TO_SCHEDULER_FUNCTION, get_constant_schedule_with_warmup
 
 
+class SequentialLRWrapper(torch.optim.lr_scheduler.SequentialLR):
+    """
+    Wrapper for SequentialLR that ignores extra arguments to step().
+    
+    This is needed because the training code calls lr_scheduler.step(step_num),
+    but SequentialLR.step() doesn't accept any arguments.
+    """
+    def step(self, *args, **kwargs):
+        # Ignore all arguments and call parent step() without them
+        super().step()
+
+
+def _create_scheduler_with_warmup(
+        scheduler_type: str,
+        optimizer: torch.optim.Optimizer,
+        **scheduler_kwargs
+):
+    """
+    Creates a scheduler with optional warmup period using SequentialLR.
+    
+    Args:
+        scheduler_type: 'cosine' or 'cosine_with_restarts'
+        optimizer: The optimizer to schedule
+        scheduler_kwargs: Parameters for the scheduler. Can include:
+            - warmup_steps: Number of warmup steps (default: 0, no warmup)
+            - total_iters: TOTAL number of iterations INCLUDING warmup (default: 1000)
+            - T_0/T_max: Iterations for MAIN scheduler, overrides calculation from total_iters
+            - Other scheduler parameters (T_mult, eta_min, etc.)
+    
+    Semantics:
+        - total_iters: Total training iterations (warmup + main scheduler)
+        - T_0/T_max: Main scheduler iterations (if specified, total_iters is ignored)
+        - If only total_iters specified: main_iters = total_iters - warmup_steps
+        - If T_0/T_max specified: main_iters = T_0/T_max (total_iters ignored)
+    
+    Returns:
+        A scheduler (SequentialLR if warmup_steps > 0, otherwise base scheduler)
+    """
+    # Extract warmup_steps (default: 0, no warmup)
+    warmup_steps = scheduler_kwargs.pop('warmup_steps', 0)
+    
+    # Extract total_iters (GENERAL total, including warmup)
+    total_iters = scheduler_kwargs.pop('total_iters', 1000)
+    
+    # Calculate main scheduler iterations
+    # T_0/T_max have priority and specify main scheduler iterations directly
+    if scheduler_type == "cosine":
+        if 'T_max' in scheduler_kwargs:
+            # T_max specifies main scheduler iterations (ignores total_iters)
+            main_total_iters = scheduler_kwargs.pop('T_max')
+        else:
+            # Calculate from total_iters
+            main_total_iters = total_iters - warmup_steps
+    elif scheduler_type == "cosine_with_restarts":
+        if 'T_0' in scheduler_kwargs:
+            # T_0 specifies main scheduler iterations (ignores total_iters)
+            main_total_iters = scheduler_kwargs.pop('T_0')
+        else:
+            # Calculate from total_iters
+            main_total_iters = total_iters - warmup_steps
+    
+    # Validation: warn if configuration seems incorrect
+    if main_total_iters <= 0:
+        raise ValueError(
+            f"Main scheduler iterations must be positive, got {main_total_iters}. "
+            f"Check your total_iters ({total_iters}) and warmup_steps ({warmup_steps})."
+        )
+    if warmup_steps > 0 and warmup_steps >= total_iters:
+        print(f"WARNING: warmup_steps ({warmup_steps}) >= total_iters ({total_iters}). "
+              f"The main scheduler will have very few or no iterations.")
+    
+    if warmup_steps <= 0:
+        # No warmup, create base scheduler directly
+        if scheduler_type == "cosine":
+            return torch.optim.lr_scheduler.CosineAnnealingLR(
+                optimizer, T_max=main_total_iters, **scheduler_kwargs
+            )
+        elif scheduler_type == "cosine_with_restarts":
+            return torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
+                optimizer, T_0=main_total_iters, **scheduler_kwargs
+            )
+    
+    # Create warmup scheduler (linear from ~0 to 1.0)
+    warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
+        optimizer,
+        start_factor=0.1,   # 1/10 of the target LR
+        end_factor=1.0,      # End at full LR
+        total_iters=warmup_steps
+    )
+    
+    # Create main scheduler
+    if scheduler_type == "cosine":
+        main_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+            optimizer, T_max=main_total_iters, **scheduler_kwargs
+        )
+    elif scheduler_type == "cosine_with_restarts":
+        main_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
+            optimizer, T_0=main_total_iters, **scheduler_kwargs
+        )
+    
+    # Combine schedulers using SequentialLRWrapper
+    combined_scheduler = SequentialLRWrapper(
+        optimizer,
+        schedulers=[warmup_scheduler, main_scheduler],
+        milestones=[warmup_steps]
+    )
+    
+    return combined_scheduler
+
+
 def get_lr_scheduler(
         name: Optional[str],
         optimizer: torch.optim.Optimizer,
         **kwargs,
 ):
     if name == "cosine":
-        if 'total_iters' in kwargs:
-            kwargs['T_max'] = kwargs.pop('total_iters')
-        return torch.optim.lr_scheduler.CosineAnnealingLR(
-            optimizer, **kwargs
+        # All parameters passed via kwargs, handled in _create_scheduler_with_warmup
+        return _create_scheduler_with_warmup(
+            "cosine", optimizer, **kwargs
         )
     elif name == "cosine_with_restarts":
-        if 'total_iters' in kwargs:
-            kwargs['T_0'] = kwargs.pop('total_iters')
-        return torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
-            optimizer, **kwargs
+        # All parameters passed via kwargs, handled in _create_scheduler_with_warmup
+        return _create_scheduler_with_warmup(
+            "cosine_with_restarts", optimizer, **kwargs
         )
     elif name == "step":
 

--- a/toolkit/util/debug.py
+++ b/toolkit/util/debug.py
@@ -1,0 +1,82 @@
+"""
+Debug utilities. memory_debug context manager measures GPU/RAM around a block;
+enabled via set_debug_config(config) with config.debug. Extensible to RAM later.
+"""
+import contextlib
+from typing import Callable
+
+import torch
+
+_debug_config = None
+
+
+def set_debug_config(config) -> None:
+    """Register the config object used to decide if memory debug is enabled (config.debug)."""
+    global _debug_config
+    _debug_config = config
+
+
+def is_debug_enabled() -> bool:
+    """Return True if debug logging is enabled (config.debug). Used for optional debug messages."""
+    if _debug_config is None:
+        return False
+    return bool(getattr(_debug_config, "debug", False))
+
+
+def _is_enabled_for_cuda() -> bool:
+    if _debug_config is None:
+        return False
+    if not getattr(_debug_config, "debug", False):
+        return False
+    return torch.cuda.is_available()
+
+
+def _cuda_snapshot_mb():
+    """Return (allocated_mb, max_allocated_mb)."""
+    return (
+        torch.cuda.memory_allocated() / 2**20,
+        torch.cuda.max_memory_allocated() / 2**20,
+    )
+
+
+def _format_cuda_diff(label: str, before: tuple, after: tuple) -> list:
+    mem_before, max_before = before
+    mem_after, max_after = after
+    delta = mem_before - mem_after
+    delta_str = f"(freed {delta:.1f} MB)" if delta >= 0 else f"(+{-delta:.1f} MB)"
+    return [
+        f"[DEBUG {label}] CUDA allocated: {mem_before:.1f} MB -> {mem_after:.1f} MB {delta_str}",
+        f"[DEBUG {label}] CUDA max:       {max_before:.1f} MB -> {max_after:.1f} MB",
+    ]
+
+
+@contextlib.contextmanager
+def memory_debug(
+    print_fn: Callable[[str], None],
+    label: str,
+    kind: str = "cuda",
+):
+    """
+    Context manager: measure memory around the block and log if debug is enabled.
+    enabled is read from the config set via set_debug_config(); no need to pass it.
+    kind="cuda" measures CUDA allocated/max; other kinds (e.g. "ram") are stubs for now.
+    """
+    if kind != "cuda":
+        yield
+        return
+    if not _is_enabled_for_cuda():
+        yield
+        return
+    before = _cuda_snapshot_mb()
+    try:
+        yield
+    finally:
+        torch.cuda.synchronize()
+        after = _cuda_snapshot_mb()
+        for line in _format_cuda_diff(label, before, after):
+            print_fn(line)
+
+
+def cuda_memory_debug(print_fn: Callable[[str], None], label: str):
+    """Alias for memory_debug(print_fn, label, kind="cuda")."""
+    return memory_debug(print_fn, label, kind="cuda")

--- a/toolkit/util/device.py
+++ b/toolkit/util/device.py
@@ -1,0 +1,28 @@
+"""
+Device utilities. safe_module_to_device moves a module in-place without using
+Module.to(), avoiding PyTorch's swap_tensors path which fails on quantized
+parameters (e.g. QLinear) that have requires_grad=False.
+"""
+from typing import Optional
+
+import torch
+
+
+def safe_module_to_device(
+    module: torch.nn.Module,
+    device: torch.device,
+    dtype: Optional[torch.dtype] = None,
+) -> None:
+    """
+    Move module to device (and optionally dtype) by moving param/buffer .data in-place.
+    Avoids Module.to() which uses swap_tensors and can raise on tensors
+    that do not require gradients (e.g. QLinear in quantized models).
+    """
+    for _, param in module.named_parameters(recurse=False):
+        if param.device != device or (dtype is not None and param.dtype != dtype):
+            param.data = param.data.to(device=device, dtype=dtype or param.dtype)
+    for _, buf in module.named_buffers(recurse=False):
+        if buf.device != device or (dtype is not None and buf.dtype != dtype):
+            buf.data = buf.data.to(device=device, dtype=dtype or buf.dtype)
+    for _, child in module.named_children():
+        safe_module_to_device(child, device, dtype)

--- a/toolkit/util/quantize.py
+++ b/toolkit/util/quantize.py
@@ -129,6 +129,8 @@ def quantize(
 def quantize_model(
     base_model: "BaseModel",
     model_to_quantize: torch.nn.Module,
+    use_accuracy_recovery: bool = True,
+    adapter_attr_name: str = "accuracy_recovery_adapter",
 ):
     from toolkit.dequantize import patch_dequantization_on_save
 
@@ -140,7 +142,7 @@ def quantize_model(
     # patch the state dict method
     patch_dequantization_on_save(model_to_quantize)
 
-    if base_model.model_config.accuracy_recovery_adapter is not None:
+    if use_accuracy_recovery and base_model.model_config.accuracy_recovery_adapter is not None:
         from toolkit.config_modules import NetworkConfig
         from toolkit.lora_special import LoRASpecialNetwork
 

--- a/ui/src/app/api/jobs/[jobID]/stop/route.ts
+++ b/ui/src/app/api/jobs/[jobID]/stop/route.ts
@@ -1,7 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { PrismaClient } from '@prisma/client';
+import { getTrainingFolder } from '@/server/settings';
+import path from 'path';
+import fs from 'fs';
 
 const prisma = new PrismaClient();
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 export async function GET(request: NextRequest, { params }: { params: { jobID: string } }) {
   const { jobID } = await params;
@@ -10,14 +22,54 @@ export async function GET(request: NextRequest, { params }: { params: { jobID: s
     where: { id: jobID },
   });
 
-  // update job status to 'running'
-  await prisma.job.update({
-    where: { id: jobID },
-    data: {
-      stop: true,
-      info: 'Stopping job...',
-    },
-  });
+  if (!job) {
+    return NextResponse.json({ error: 'Job not found' }, { status: 404 });
+  }
 
-  return NextResponse.json(job);
+  const markStopped = (info: string) =>
+    prisma.job.update({
+      where: { id: jobID },
+      data: {
+        stop: true,
+        status: 'stopped',
+        info,
+      },
+    });
+
+  if (job.status !== 'running') {
+    const updated = await markStopped(job.status === 'stopped' ? job.info : 'Job stopped');
+    return NextResponse.json(updated);
+  }
+
+  let pid: number | null = null;
+  try {
+    const trainingRoot = await getTrainingFolder();
+    const pidPath = path.join(trainingRoot, job.name, 'pid.txt');
+    if (fs.existsSync(pidPath)) {
+      const raw = fs.readFileSync(pidPath, 'utf8').trim();
+      const n = parseInt(raw, 10);
+      if (Number.isInteger(n) && n > 0) pid = n;
+    }
+  } catch {
+    // pid file missing or unreadable — treat as no process
+  }
+
+  if (pid === null) {
+    const updated = await markStopped('Job stopped');
+    return NextResponse.json(updated);
+  }
+
+  if (!isProcessAlive(pid)) {
+    const updated = await markStopped('Job stopped');
+    return NextResponse.json(updated);
+  }
+
+  try {
+    process.kill(pid, 'SIGTERM');
+  } catch {
+    // Process may have exited; still mark as stopped
+  }
+
+  const updated = await markStopped('Job stopped');
+  return NextResponse.json(updated);
 }

--- a/ui/src/app/jobs/new/SimpleJob.tsx
+++ b/ui/src/app/jobs/new/SimpleJob.tsx
@@ -531,12 +531,15 @@ export default function SimpleJob({
                 <SelectInput
                   label="Timestep Bias"
                   className="pt-2"
+                  docKey="train.content_or_style"
                   value={jobConfig.config.process[0].train.content_or_style}
                   onChange={value => setJobConfig(value, 'config.process[0].train.content_or_style')}
                   options={[
                     { value: 'balanced', label: 'Balanced' },
                     { value: 'content', label: 'High Noise' },
                     { value: 'style', label: 'Low Noise' },
+                    { value: 'gaussian', label: 'Gaussian (Normal)' },
+                    { value: 'fixed_cycle', label: 'Fixed Cycle' },
                   ]}
                 />
                 <SelectInput
@@ -551,6 +554,65 @@ export default function SimpleJob({
                     { value: 'stepped', label: 'Stepped Recovery' },
                   ]}
                 />
+                {jobConfig.config.process[0].train.content_or_style === 'fixed_cycle' && (
+                  <>
+                    <TextInput
+                      label="Fixed Cycle Timesteps"
+                      className="pt-2"
+                      docKey="train.fixed_cycle_timesteps"
+                      value={
+                        jobConfig.config.process[0].train.fixed_cycle_timesteps
+                          ? jobConfig.config.process[0].train.fixed_cycle_timesteps.join(', ')
+                          : '999, 875, 750, 625, 500, 375, 250, 125'
+                      }
+                      onChange={value => {
+                        const arr = value
+                          .split(',')
+                          .map(s => parseFloat(s.trim()))
+                          .filter(n => !isNaN(n));
+                        setJobConfig(arr, 'config.process[0].train.fixed_cycle_timesteps');
+                      }}
+                      placeholder="eg. 999, 875, 750, 625, 500, 375, 250, 125"
+                    />
+                    <NumberInput
+                      label="Fixed Cycle Seed (optional)"
+                      className="pt-2"
+                      docKey="train.fixed_cycle_seed"
+                      value={jobConfig.config.process[0].train.fixed_cycle_seed || ''}
+                      onChange={value => setJobConfig(value ? parseInt(value as string) : null, 'config.process[0].train.fixed_cycle_seed')}
+                      placeholder="eg. 42 (leave empty for no shuffle)"
+                      min={0}
+                    />
+                    <TextInput
+                      label="Fixed Cycle Weight Peak Timesteps (optional)"
+                      className="pt-2"
+                      docKey="train.fixed_cycle_weight_peak_timesteps"
+                      value={
+                        jobConfig.config.process[0].train.fixed_cycle_weight_peak_timesteps
+                          ? jobConfig.config.process[0].train.fixed_cycle_weight_peak_timesteps.join(', ')
+                          : '500, 375'
+                      }
+                      onChange={value => {
+                        const arr = value
+                          .split(',')
+                          .map(s => parseFloat(s.trim()))
+                          .filter(n => !isNaN(n));
+                        setJobConfig(arr.length > 0 ? arr : null, 'config.process[0].train.fixed_cycle_weight_peak_timesteps');
+                      }}
+                      placeholder="eg. 500, 375 (leave empty to disable)"
+                    />
+                    <NumberInput
+                      label="Fixed Cycle Weight Sigma (optional)"
+                      className="pt-2"
+                      docKey="train.fixed_cycle_weight_sigma"
+                      value={jobConfig.config.process[0].train.fixed_cycle_weight_sigma || 372.8}
+                      onChange={value => setJobConfig(value, 'config.process[0].train.fixed_cycle_weight_sigma')}
+                      placeholder="eg. 372.8"
+                      min={0}
+                      step={0.1}
+                    />
+                  </>
+                )}
               </div>
               <div>
                 <FormGroup label="EMA (Exponential Moving Average)">
@@ -674,6 +736,21 @@ export default function SimpleJob({
                           }
                           placeholder="eg. 1.0"
                           min={0}
+                        />
+                        <NumberInput
+                          label="BPP Probability"
+                          docKey={'train.blank_prompt_probability'}
+                          className="pt-2"
+                          value={
+                            (jobConfig.config.process[0].train.blank_prompt_probability as number) ?? 1.0
+                          }
+                          onChange={value =>
+                            setJobConfig(value, 'config.process[0].train.blank_prompt_probability')
+                          }
+                          placeholder="eg. 0.1 for 10%, 1.0 for 100%"
+                          min={0}
+                          max={1}
+                          step={0.1}
                         />
                       </>
                     )}

--- a/ui/src/components/SampleImageViewer.tsx
+++ b/ui/src/components/SampleImageViewer.tsx
@@ -82,7 +82,7 @@ export default function SampleImageViewer({
       if (idx < 0 || idx >= sampleImages.length) return;
       onChange(sampleImages[idx]);
     },
-    [sampleImages, numSamples, onChange],
+    [sampleImages, onChange],
   );
 
   const currentIndex = useMemo(() => {
@@ -167,9 +167,11 @@ export default function SampleImageViewer({
           onCancel();
           break;
         case 'ArrowUp':
+          event.preventDefault();
           handleArrowUp();
           break;
         case 'ArrowDown':
+          event.preventDefault();
           handleArrowDown();
           break;
         case 'ArrowLeft':

--- a/ui/src/docs.tsx
+++ b/ui/src/docs.tsx
@@ -287,6 +287,78 @@ const docs: { [key: string]: ConfigDoc } = {
       </>
     ),
   },
+  'train.blank_prompt_probability': {
+    title: 'BPP Probability',
+    description: (
+      <>
+        Controls how often the Blank Prompt Preservation check runs during training. 
+        Value between 0.0 and 1.0. Default is 1.0 (runs every step). 
+        Setting to 0.1 means BPP runs ~10% of steps, reducing training time by up to 45% 
+        while still preventing model degradation. Lower values give the model more freedom 
+        to adapt to new concepts between BPP corrections. Recommended: 0.1-0.2 for Turbo models.
+      </>
+    ),
+  },
+  'train.content_or_style': {
+    title: 'Timestep Bias',
+    description: (
+      <>
+        Controls how timesteps are sampled during training:
+        <br /><br />
+        <b>Balanced</b>: Uniform distribution across all timesteps.
+        <br /><br />
+        <b>High Noise</b>: Cubic distribution favoring earlier timesteps (more noise). Best for learning content/structure.
+        <br /><br />
+        <b>Low Noise</b>: Cubic distribution favoring later timesteps (less noise). Best for learning style/details.
+        <br /><br />
+        <b>Gaussian (Normal)</b>: Normal distribution with configurable center and spread. Use <code>gaussian_mean</code> and <code>gaussian_std</code> in YAML config:
+        <br />
+        • <code>gaussian_mean</code> (default 0.5): Center of distribution. Lower values (0.0-0.5) = more noise/earlier timesteps, higher values (0.5-1.0) = less noise/later timesteps.
+        <br />
+        • <code>gaussian_std</code> (default 0.2): Spread of distribution. Smaller = narrower focus, larger = wider coverage.
+        <br />
+        • <code>gaussian_std_target</code> (optional, default None): Enable curriculum learning. When set, gaussian_std will linearly interpolate from initial value to this target value during training. Example: start with gaussian_std: 0.001 (narrow distribution, focused training) → end with gaussian_std_target: 0.3 (wide distribution, diverse timestep coverage).
+        <br />
+        • <code>timestep_bias_exponent</code> (default 3.0): Controls the cubic bias exponent for content/style timestep distribution. Higher values create stronger bias toward edges (early timesteps for content, late timesteps for style). Lower values create more uniform distribution.
+        <br /><br />
+        <b>Fixed Cycle</b>: Deterministic cycle over a fixed list of timestep values. Same step number always gets the same timestep, so training is reproducible. Recommended for distilled/Turbo models (e.g. Z-Image-Turbo LoRA) that are sensitive to random timestep sampling. Configure via YAML: <code>fixed_cycle_timesteps</code>, <code>fixed_cycle_seed</code>, <code>fixed_cycle_weight_peak_timesteps</code>.
+      </>
+    ),
+  },
+  'train.fixed_cycle_timesteps': {
+    title: 'Fixed Cycle Timesteps',
+    description: (
+      <>
+        Used when <code>content_or_style</code> is <code>fixed_cycle</code>. List of timestep values (scheduler scale, typically 0–1000) to cycle through deterministically. At step <code>s</code>, the whole batch uses <code>fixed_cycle_timesteps[s % length]</code> (after optional shuffle by <code>fixed_cycle_seed</code>). Values are snapped to the nearest scheduler timestep.
+        <br /><br />
+        Default: <code>[999, 875, 750, 625, 500, 375, 250, 125]</code>. Set in config file (e.g. YAML) as an array of numbers.
+      </>
+    ),
+  },
+  'train.fixed_cycle_seed': {
+    title: 'Fixed Cycle Seed',
+    description: (
+      <>
+        Used when <code>content_or_style</code> is <code>fixed_cycle</code>. If set, the list <code>fixed_cycle_timesteps</code> is shuffled once at the start of training using this seed. Same seed gives the same cycle order and reproducible runs. If <code>null</code> or unset, the cycle uses the order from the config.
+      </>
+    ),
+  },
+  'train.fixed_cycle_weight_peak_timesteps': {
+    title: 'Fixed Cycle Weight Peak Timesteps',
+    description: (
+      <>
+        Used when <code>content_or_style</code> is <code>fixed_cycle</code>. Enables timestep-weighted loss (like <code>timestep_type: weighted</code>): loss is multiplied by weights with peaks at these timestep values. Default: <code>[500, 375]</code> so maximum weight is around 500 and 375. Set to <code>null</code> or empty to disable weighting. Set in config file as an array of numbers.
+      </>
+    ),
+  },
+  'train.fixed_cycle_weight_sigma': {
+    title: 'Fixed Cycle Weight Sigma',
+    description: (
+      <>
+        Used when <code>content_or_style</code> is <code>fixed_cycle</code> and <code>fixed_cycle_weight_peak_timesteps</code> is set. Standard deviation (sigma) for the Gaussian distribution used to weight loss around the peak timesteps. Controls the width of the Gaussian peaks — larger values create wider, flatter distributions, smaller values create sharper peaks. Default: <code>372.8</code>.
+      </>
+    ),
+  },
   'train.do_differential_guidance': {
     title: 'Differential Guidance',
     description: (

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -142,10 +142,15 @@ export interface TrainConfig {
   diff_output_preservation_class: string;
   blank_prompt_preservation?: boolean;
   blank_prompt_preservation_multiplier?: number;
+  blank_prompt_probability?: number;
   switch_boundary_every: number;
   loss_type: 'mse' | 'mae' | 'wavelet' | 'stepped';
   do_differential_guidance?: boolean;
   differential_guidance_scale?: number;
+  fixed_cycle_timesteps?: number[];
+  fixed_cycle_seed?: number | null;
+  fixed_cycle_weight_peak_timesteps?: number[] | null;
+  fixed_cycle_weight_sigma?: number;
 }
 
 export interface QuantizeKwargsConfig {


### PR DESCRIPTION
# Training, Optimizers, Device Handling & Z-Image Improvements

## Overview

This PR bundles improvements across the training pipeline, optimizers, device handling, and Z-Image inference: timestep sampling and schedulers, Adafactor extensions, low-VRAM device handling, and a separate sampling model with quantization and UI fixes. It also adds fixes and refactors for Adafactor LR clamping, Z-Image loading/dtype, train checkpoint memory and optimizer state, PEFT LoRA loading, and text-embedding cache behaviour (shuffle_tokens, per-epoch shuffle, trigger_word).

## Training & Schedulers

- **blank_prompt_probability** — Control how often Blank Prompt Preservation (BPP) runs to reduce step time while limiting degradation.
- **Differential guidance** — Separate metric and loss-graph category; LR graph with metric filtering.
- **Timestep sampling** — Gaussian/content-style distribution, configurable `gaussian_std` curriculum, timestep debug logging and mapping fixes in `BaseSDTrainProcess`.
- **Warmup for cosine LR** — Warmup support for cosine schedulers; fixes for `SequentialLR.step()` and T_0/T_max duplication with warmup; example config and guide (`WARMUP_SCHEDULER_GUIDE.md`).
- **Fixed cycle training** — Config and UI for fixed cycle; sigma parameter fix for weight calculation.
- **Networks & config** — `rank_dropout`/`module_dropout`, alpha for Peft LoRA, SNR compatibility for flow matching; validation for image/video scaling.
- **UI** — SimpleJob controls, docs, and types for new training options; loss graph and LR visualization.
- **Train robustness** — Free memory before checkpoint save to reduce OOM risk; validate optimizer state load and document save behaviour.

## Optimizers (Adafactor)

- **min_lr/max_lr** and **get_avg_learning_rate** for finer control and logging.
- **RMS tracking** — Methods and weight-update RMS logging.
- **Fixes** — `lr=0` with `relative_step`, uninitialized state, clamping to `max_lr` (including max_lr 1e-2→1e-4 and streamlined clamping logic); truncated normal sampling and spelling fix.

## Device Handling

- **safe_module_to_device** in `toolkit/util/device.py` for consistent, low-VRAM-aware transfers.
- **Conditional model transfer** in ltx2, qwen_image, and wan22 based on `low_vram` (and related) flags instead of raw `model.to(device)`.

## Z-Image & Inference

- **Separate sampling model** — Own transformer with device handling (e.g. CPU when not generating) and optional quantization.
- **Sampling model unload** and **LoRA on sampling transformer** during generation.
- **Quantization** — Custom attribute for accuracy recovery adapter; assignment fix in `quantize_model`.
- **Robustness** — File cleanup with retries and logging; ZImageModel device transfer fixes.
- **UI** — Stop job API correctly marks job stopped and handles dead process; sample image viewer keyboard navigation fix.
- **Loading & dtype** — Load sampling transformer first and extract load helpers; normalize model paths (HF identifier warning); use `dtype` instead of deprecated `torch_dtype` for transformers; streamline embedding conversion and device management; optional `debug_zimage_load` to trace safetensors load/mmap.

## Text Embedding Cache & Shuffle

- **shuffle_tokens + cache_text_embeddings** — Apply caption shuffle only when not caching; skip shuffling cached prompt embeds when `shuffle_tokens` is false in `set_epoch_num` and `load_prompt_embedding`; respect `shuffle_tokens` for cached embeddings so cache paths stay stable.
- **Per-epoch shuffle** — When `cache_text_embeddings` is true, shuffle token order along the sequence at the start of each new epoch; `PromptEmbeds.shuffle_sequence()`, dataset `set_epoch_num` / `clear_cached_embeddings_memory`, wired at epoch boundary in `BaseSDTrainProcess`; epoch_num synced at train start for correct resume.
- **First segment/token fixed** — In `get_caption`, when `shuffle_tokens` is on, keep the first comma-separated segment in place and shuffle the rest; in `shuffle_sequence`, keep index 0 fixed and permute only 1..seq_len-1.
- **Memory & UX** — Clear cached embeddings when not using cache; retain prompt embeddings when cached; logging when cached tokens are shuffled each epoch.
- **SD trainer** — Prefer `trigger_word` over blank when `batch.prompt_embeds` is None; require `trigger_word` when `cache_text_embeddings` is enabled and batch has no cached embeds (ValueError otherwise); reg batches keep using blank.

## PEFT

- **LoRA loading** — Apply alpha key fix for all PEFT types when loading LoRA.

## Commits

1. **feat(training): timestep sampling, schedulers, networks, loss UI** — blank_prompt_probability, differential guidance, LR graph; Gaussian/content-style timestep sampling, warmup for cosine LR; BaseSDTrainProcess timestep mapping, fixed cycle; rank_dropout/module_dropout, alpha for Peft LoRA, SNR flow matching; timestep debug logging, config and UI.

2. **feat(optimizers): Adafactor min/max lr, RMS tracking, fixes** — min_lr/max_lr, get_avg_learning_rate, RMS tracking; fixes for lr=0 with relative_step, uninitialized state, clamp to max_lr; truncated normal, weight update RMS logging.

3. **refactor(device): safe_module_to_device and conditional model transfer** — safe_module_to_device in toolkit/util/device.py; use in ltx2, qwen_image, wan22 for low_vram-aware handling.

4. **feat(Z-Image): sampling model, quantization, stop job API** — Separate sampling model, device handling, quantization; unload, LoRA on sampling transformer; accuracy recovery adapter, file cleanup with retries; stop job API and sample viewer fix.

5. **fix(optimizers): adjust max_lr and improve learning rate clamping** — Adafactor max_lr 1e-2→1e-4; streamlined clamping between min_lr and max_lr with relative_step.

6. **refactor(z_image): streamline embedding conversion and device management** — dtype instead of deprecated torch_dtype; normalize paths; load sampling transformer first, extract helpers; embedding conversion and device handling; debug_zimage_load.

7. **fix(train): free memory before checkpoint save to reduce OOM risk** — Free memory before checkpoint save; validate optimizer state load and document save behaviour.

8. **fix(peft): apply alpha key fix for all peft types when loading LoRA** — Alpha key fix for all PEFT types on LoRA load.

9. **refactor(dataloader): remove redundant token shuffling logic** — Redundant shuffling removed; shuffle_tokens skipped when caching; first segment/token fixed (get_caption + shuffle_sequence); set_epoch_num, clear_cached_embeddings_memory, shuffle at epoch start, logging; respect shuffle_tokens for cached embeds; trigger_word when cache_text_embeddings and no cache.

10. **fix(adafactor): apply new min_lr/max_lr on restart after loading checkpoint** — Ensures Adafactor applies updated min_lr/max_lr when resuming from checkpoint.

11. **refactor(paths): rename normalize_model_path to normalize_path and strip whitespace** — Centralised path normalisation and whitespace stripping in toolkit/paths.py.

12. **feat(debug): add memory_debug util and use for CUDA load/unload logging** — Adds toolkit/util/debug.py with memory_debug() context manager and debug config; wraps text encoder unload and Z-Image load stages for optional [DEBUG …] CUDA memory lines when logging.debug is enabled.

13. **fix(sampling), feat(lora): sampling VRAM, single LoRA, path and debug wiring** — Sampling: load sampling transformer on CPU, guarantee unload to CPU after generate_images, do not force unet to GPU. LoRA: single LoRA for training and sampling via shared parameters; free pretrained LoRA memory after load. Uses normalize_path in Z-Image and wires memory_debug in BaseSDTrainProcess LoRA load and Z-Image stages; train.example.yaml, base_model, network_mixins updates.