### PR TITLE
feat: enable immediate saving on UI stop and enhance optimizer state backup

### DIFF
--- a/extensions_built_in/sd_trainer/DiffusionTrainer.py
+++ b/extensions_built_in/sd_trainer/DiffusionTrainer.py
@@ -30,6 +30,7 @@ class DiffusionTrainer(SDTrainer):
         
         if self.is_ui_trainer:
             self.is_stopping = False
+            self._is_saving = False
             # Create a thread pool for database operations
             self.thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
             # Track all async tasks
@@ -140,7 +141,19 @@ class DiffusionTrainer(SDTrainer):
     def maybe_stop(self):
         if not self.is_ui_trainer:
             return
+        if self._is_saving or self.is_stopping:
+            return
         if self.should_stop():
+            # Trigger an immediate save of LoRA weights and optimizer.pt.
+            # This ensures the current step is recorded in the Metadata,
+            # allowing the user to resume from this exact point later.
+            print(f"\n[Stop Signal Detected] Saving emergency checkpoint at step {self.step_num}...")
+            self._is_saving = True
+            try:
+                self.save(self.step_num) 
+            finally:
+                self._is_saving = False
+
             self._run_async_operation(
                 self._update_status("stopped", "Job stopped"))
             self.is_stopping = True
@@ -308,8 +321,10 @@ class DiffusionTrainer(SDTrainer):
         self.update_status("running", "Training")
 
     def save(self, step=None):
-        self.maybe_stop()
+        if not self._is_saving:
+            self.maybe_stop()
         self.update_status("running", "Saving model")
         super().save(step)
-        self.maybe_stop()
-        self.update_status("running", "Training")
+        if not self._is_saving:
+            self.maybe_stop()
+            self.update_status("running", "Training")

--- a/jobs/process/BaseSDTrainProcess.py
+++ b/jobs/process/BaseSDTrainProcess.py
@@ -684,12 +684,23 @@ class BaseSDTrainProcess(BaseTrainProcess):
             try:
                 filename = f'optimizer.pt'
                 file_path = os.path.join(self.save_root, filename)
+                backup_optimizer_path = os.path.join(self.save_root, 'optimizer_prev.pt')
+                
+                # If optimizer.pt already exists, rename it to optimizer_prev.pt
+                if os.path.exists(file_path):
+                    # If an old backup also exists, delete it first (to ensure a successful rename)
+                    if os.path.exists(backup_optimizer_path):
+                        os.remove(backup_optimizer_path)
+                    
+                    os.rename(file_path, backup_optimizer_path)
+                    print_acc(f"Existing optimizer.pt moved to optimizer_prev.pt")
+
                 try:
                     state_dict = unwrap_model(self.optimizer).state_dict()
                 except Exception as e:
                     state_dict = self.optimizer.state_dict()
                 torch.save(state_dict, file_path)
-                print_acc(f"Saved optimizer to {file_path}")
+                print_acc(f"Saved latest optimizer to {file_path}")
             except Exception as e:
                 print_acc(e)
                 print_acc("Could not save optimizer")


### PR DESCRIPTION
This PR improves the training interruption workflow by ensuring that training progress is captured immediately when a user requests a stop via the UI. It also introduces a backup mechanism for the optimizer state to provide users with more flexibility when resuming or rolling back training.

### Key Changes

1. Immediate Save on UI Stop (DiffusionTrainer)
Modified maybe_stop to trigger self.save() as soon as a stop signal is detected.
Added a _is_saving flag to manage the saving state, preventing infinite recursion or redundant calls during emergency saves.
Benefit: Users can now resume training from the precise step of interruption rather than being forced to roll back to the last scheduled checkpoint. This ensures LoRA weights, Metadata, and optimizer states are perfectly synchronized at the exit point.

2. Optimizer State Rotation (BaseSDTrainProcess)
Implemented a backup system for the optimizer state. When saving, the existing optimizer.pt is moved to optimizer_prev.pt instead of being directly overwritten by the new state.

### Example Scenario (How to roll back)

If a user decides they prefer the results from a previous scheduled save over the final interrupted save:

1. Current State: You have a scheduled save at Step 500 (train_000000500.safetensors and optimizer_prev.pt) and an interruption save at Step 666 (train_000000666.safetensors and optimizer.pt).
2. Rollback Process:
 - Delete the interruption files: train_000000666.safetensors and optimizer.pt.
 - Rename optimizer_prev.pt to optimizer.pt.
3. Result: The trainer will successfully resume training from Step 500 using the correct historical optimizer state.

___

These changes have been verified in a local environment and are confirmed to be working as intended.