### PR TITLE
Fix random_noise_multiplier never being applied to the noise.

### DIFF
--- a/jobs/process/BaseSDTrainProcess.py
+++ b/jobs/process/BaseSDTrainProcess.py
@@ -1358,7 +1358,7 @@ class BaseSDTrainProcess(BaseTrainProcess):
                 if self.train_config.random_noise_multiplier > 0.0:
                     sigma = self.train_config.random_noise_multiplier
                     noise_multiplier = torch.exp(torch.randn(s, device=noise.device, dtype=noise.dtype) * sigma)
-                
+                    noise = noise * noise_multiplier
             with self.timer('make_noisy_latents'):
 
                 latent_multiplier = self.train_config.latent_multiplier


### PR DESCRIPTION
The random noise multiplier calculated when self.train_config.random_noise_multiplier > 0.0 is never applied to the noise. This fixes that.