### PR TITLE
Fix Qwen attention mask crash with diffusers >=0.37

### DIFF
--- a/extensions_built_in/diffusion_models/qwen_image/qwen_image.py
+++ b/extensions_built_in/diffusion_models/qwen_image/qwen_image.py
@@ -280,11 +280,11 @@ class QwenImageModel(BaseModel):
         gen_config.height = int(gen_config.height // sc * sc)
         img = pipeline(
             prompt_embeds=conditional_embeds.text_embeds,
-            prompt_embeds_mask=conditional_embeds.get_attention_mask(
+            prompt_embeds_mask=conditional_embeds.attention_mask.to(
                 self.device_torch, dtype=torch.int64
             ),
             negative_prompt_embeds=unconditional_embeds.text_embeds,
-            negative_prompt_embeds_mask=unconditional_embeds.get_attention_mask(
+            negative_prompt_embeds_mask=unconditional_embeds.attention_mask.to(
                 self.device_torch, dtype=torch.int64
             ),
             height=gen_config.height,
@@ -324,10 +324,10 @@ class QwenImageModel(BaseModel):
         img_shapes = [[(1, img_h2, img_w2)]] * batch_size
 
         enc_hs = text_embeddings.text_embeds.to(self.device_torch, self.torch_dtype)
-        prompt_embeds_mask = text_embeddings.get_attention_mask(
+        prompt_embeds_mask = text_embeddings.attention_mask.to(
             self.device_torch, dtype=torch.int64
         )
-        txt_seq_lens = prompt_embeds_mask.sum(dim=1).tolist() if prompt_embeds_mask is not None else None
+        txt_seq_lens = prompt_embeds_mask.sum(dim=1).tolist()
 
         noise_pred = self.transformer(
             hidden_states=latent_model_input.to(
@@ -336,7 +336,7 @@ class QwenImageModel(BaseModel):
             timestep=(timestep / 1000).detach(),
             guidance=None,
             encoder_hidden_states=enc_hs.detach(),
-            encoder_hidden_states_mask=prompt_embeds_mask.detach() if prompt_embeds_mask is not None else None,
+            encoder_hidden_states_mask=prompt_embeds_mask.detach(),
             img_shapes=img_shapes,
             txt_seq_lens=txt_seq_lens,
             return_dict=False,
@@ -355,12 +355,16 @@ class QwenImageModel(BaseModel):
         if self.pipeline.text_encoder.device != self.device_torch:
             self.pipeline.text_encoder.to(self.device_torch)
         
-        max_sequence_length = 1024
-        
-        prompt_embeds, prompt_embeds_mask = self.pipeline._get_qwen_prompt_embeds(prompt, self.device_torch)
-        prompt_embeds = prompt_embeds[:, :max_sequence_length]
-        prompt_embeds_mask = prompt_embeds_mask[:, :max_sequence_length]
-
+        prompt_embeds, prompt_embeds_mask = self.pipeline.encode_prompt(
+            prompt,
+            device=self.device_torch,
+            num_images_per_prompt=1,
+        )
+        # diffusers >=0.37 returns None when all tokens are valid (no padding)
+        if prompt_embeds_mask is None:
+            prompt_embeds_mask = torch.ones(
+                prompt_embeds.shape[:2], device=prompt_embeds.device, dtype=torch.int64
+            )
         pe = PromptEmbeds(prompt_embeds)
         pe.attention_mask = prompt_embeds_mask
         return pe

--- a/extensions_built_in/diffusion_models/qwen_image/qwen_image_edit.py
+++ b/extensions_built_in/diffusion_models/qwen_image/qwen_image_edit.py
@@ -118,11 +118,11 @@ class QwenImageEditModel(QwenImageModel):
         img = pipeline(
             image=control_img,
             prompt_embeds=conditional_embeds.text_embeds,
-            prompt_embeds_mask=conditional_embeds.get_attention_mask(
+            prompt_embeds_mask=conditional_embeds.attention_mask.to(
                 self.device_torch, dtype=torch.int64
             ),
             negative_prompt_embeds=unconditional_embeds.text_embeds,
-            negative_prompt_embeds_mask=unconditional_embeds.get_attention_mask(
+            negative_prompt_embeds_mask=unconditional_embeds.attention_mask.to(
                 self.device_torch, dtype=torch.int64
             ),
             height=gen_config.height,
@@ -197,6 +197,11 @@ class QwenImageEditModel(QwenImageModel):
             device=self.device_torch,
             num_images_per_prompt=1,
         )
+        # diffusers >=0.37 returns None when all tokens are valid (no padding)
+        if prompt_embeds_mask is None:
+            prompt_embeds_mask = torch.ones(
+                prompt_embeds.shape[:2], device=prompt_embeds.device, dtype=torch.int64
+            )
         pe = PromptEmbeds(prompt_embeds)
         pe.attention_mask = prompt_embeds_mask
         return pe
@@ -246,10 +251,10 @@ class QwenImageEditModel(QwenImageModel):
         latent_model_input = torch.cat([latent_model_input, control], dim=1)
         batch_size = latent_model_input.shape[0]
 
-        prompt_embeds_mask = text_embeddings.get_attention_mask(
+        prompt_embeds_mask = text_embeddings.attention_mask.to(
             self.device_torch, dtype=torch.int64
         )
-        txt_seq_lens = prompt_embeds_mask.sum(dim=1).tolist() if prompt_embeds_mask is not None else None
+        txt_seq_lens = prompt_embeds_mask.sum(dim=1).tolist()
         enc_hs = text_embeddings.text_embeds.to(self.device_torch, self.torch_dtype)
 
         noise_pred = self.transformer(
@@ -257,7 +262,7 @@ class QwenImageEditModel(QwenImageModel):
             timestep=timestep / 1000,
             guidance=None,
             encoder_hidden_states=enc_hs,
-            encoder_hidden_states_mask=prompt_embeds_mask.detach() if prompt_embeds_mask is not None else None,
+            encoder_hidden_states_mask=prompt_embeds_mask.detach(),
             img_shapes=img_shapes,
             txt_seq_lens=txt_seq_lens,
             return_dict=False,

--- a/extensions_built_in/diffusion_models/qwen_image/qwen_image_edit_plus.py
+++ b/extensions_built_in/diffusion_models/qwen_image/qwen_image_edit_plus.py
@@ -136,11 +136,11 @@ class QwenImageEditPlusModel(QwenImageModel):
         img = pipeline(
             image=control_img_list,
             prompt_embeds=conditional_embeds.text_embeds,
-            prompt_embeds_mask=conditional_embeds.get_attention_mask(
+            prompt_embeds_mask=conditional_embeds.attention_mask.to(
                 self.device_torch, dtype=torch.int64
             ),
             negative_prompt_embeds=unconditional_embeds.text_embeds,
-            negative_prompt_embeds_mask=unconditional_embeds.get_attention_mask(
+            negative_prompt_embeds_mask=unconditional_embeds.attention_mask.to(
                 self.device_torch, dtype=torch.int64
             ),
             height=gen_config.height,
@@ -192,6 +192,11 @@ class QwenImageEditPlusModel(QwenImageModel):
             device=self.device_torch,
             num_images_per_prompt=1,
         )
+        # diffusers >=0.37 returns None when all tokens are valid (no padding)
+        if prompt_embeds_mask is None:
+            prompt_embeds_mask = torch.ones(
+                prompt_embeds.shape[:2], device=prompt_embeds.device, dtype=torch.int64
+            )
         pe = PromptEmbeds(prompt_embeds)
         pe.attention_mask = prompt_embeds_mask
         return pe
@@ -318,10 +323,10 @@ class QwenImageEditPlusModel(QwenImageModel):
 
                 latent_model_input = torch.cat(packed_latents_with_controls_list, dim=0)
 
-            prompt_embeds_mask = text_embeddings.get_attention_mask(
+            prompt_embeds_mask = text_embeddings.attention_mask.to(
                 self.device_torch, dtype=torch.int64
             )
-            txt_seq_lens = prompt_embeds_mask.sum(dim=1).tolist() if prompt_embeds_mask is not None else None
+            txt_seq_lens = prompt_embeds_mask.sum(dim=1).tolist()
             enc_hs = text_embeddings.text_embeds.to(self.device_torch, self.torch_dtype)
 
         noise_pred = self.transformer(
@@ -331,7 +336,7 @@ class QwenImageEditPlusModel(QwenImageModel):
             timestep=(timestep / 1000).detach(),
             guidance=None,
             encoder_hidden_states=enc_hs.detach(),
-            encoder_hidden_states_mask=prompt_embeds_mask.detach() if prompt_embeds_mask is not None else None,
+            encoder_hidden_states_mask=prompt_embeds_mask.detach(),
             img_shapes=img_shapes,
             txt_seq_lens=txt_seq_lens,
             return_dict=False,

--- a/toolkit/prompt_utils.py
+++ b/toolkit/prompt_utils.py
@@ -35,13 +35,6 @@ class PromptEmbeds:
 
         self.attention_mask = attention_mask
 
-    def get_attention_mask(self, *args, **kwargs):
-        if self.attention_mask is None:
-            return None
-        if isinstance(self.attention_mask, list) or isinstance(self.attention_mask, tuple):
-            return [t.to(*args, **kwargs) for t in self.attention_mask]
-        return self.attention_mask.to(*args, **kwargs)
-
     def to(self, *args, **kwargs):
         if isinstance(self.text_embeds, list) or isinstance(self.text_embeds, tuple):
             self.text_embeds = [t.to(*args, **kwargs) for t in self.text_embeds]


### PR DESCRIPTION
## Problem

`diffusers` v0.37 ([PR #12987](https://github.com/huggingface/diffusers/pull/12987)) optimizes all-ones attention masks to `None` in `encode_prompt()` when there is no padding. This causes an `AttributeError: 'NoneType' object has no attribute 'to'` crash in all three Qwen image extensions during training.

The recent fix in `295094b` addresses `qwen_image.py` by switching to the private `_get_qwen_prompt_embeds()` API, but `qwen_image_edit.py` and `qwen_image_edit_plus.py` still crash.

## Fix

Reconstruct the all-ones mask right after `encode_prompt()` returns `None`, in `get_prompt_embeds()` of all three Qwen variants:

```python
prompt_embeds, prompt_embeds_mask = self.pipeline.encode_prompt(...)
if prompt_embeds_mask is None:
    prompt_embeds_mask = torch.ones(
        prompt_embeds.shape[:2], device=prompt_embeds.device, dtype=torch.int64
    )
```

This approach:
- Uses the public `encode_prompt()` API (not `_get_qwen_prompt_embeds`)
- Works with both old and new diffusers versions
- Requires zero downstream changes — the mask is always a tensor
- Fixes all three variants: base, edit, and edit_plus

Also removes redundant duplicate mask assignments in `qwen_image_edit.py` and `qwen_image_edit_plus.py`.

Fixes #740