### PR TITLE
Add 1328 native resolution for Qwen Image training

### DIFF
--- a/config/examples/train_lora_qwen_image_24gb.yaml
+++ b/config/examples/train_lora_qwen_image_24gb.yaml
@@ -35,7 +35,7 @@ config:
           shuffle_tokens: false  # shuffle caption order, split by commas
           cache_latents_to_disk: true  # leave this true unless you have a large dataset
           # if you OOM, 1024 may be too much, but should work
-          resolution: [ 512, 768, 1024, 1328 ]  # 1328 is the native 1:1 resolution for Qwen Image
+          resolution: [ 512, 768, 1024 ]  # qwen image enjoys multiple resolutions
       train:
         batch_size: 1
         # caching text embeddings is required for 24GB


### PR DESCRIPTION
## Summary

Qwen-Image and Qwen-Image-2512 have a native 1:1 resolution of **1328x1328** as documented in the [official model card](https://huggingface.co/Qwen/Qwen-Image-2512).

- Added 1328 as a resolution option in the training UI