### PR TITLE
✨ Quality: CheckpointGradients uses undefined instance variable self.num_chunks

### DIFF
--- a/toolkit/layers.py
+++ b/toolkit/layers.py
@@ -39,6 +39,6 @@ class CheckpointGradients(nn.Module):
 
     def forward(self, module, *args, num_chunks=1):
         if self.is_gradient_checkpointing:
-            return checkpoint(module, *args, num_chunks=self.num_chunks)
+            return checkpoint(module, *args, num_chunks=num_chunks)
         else:
             return module(*args)


### PR DESCRIPTION
## Problem

The `CheckpointGradients.forward()` method references `self.num_chunks` but this attribute is never initialized in `__init__`. The constructor only sets `is_gradient_checkpointing`, and the forward method accepts `num_chunks` as a parameter but never stores it as an instance attribute. When gradient checkpointing is enabled, this will raise `AttributeError: 'CheckpointGradients' object has no attribute 'num_chunks'`.


**Severity**: `high`
**File**: `toolkit/layers.py`

## Solution

In `__init__`, add: `self.num_chunks = 1` (or accept num_chunks in constructor). Or in `forward()`, use the parameter directly: `checkpoint(module, *args, num_chunks=num_chunks)`


## Changes

- `toolkit/layers.py` (modified)

## Testing

- [x] Existing tests pass
- [x] Manual review completed
- [x] No new warnings/errors introduced
