### PR TITLE
feat: add Z-Image LoRA training support (arch='zimage')

### DIFF
--- a/extensions_built_in/sd_trainer/SDTrainer.py
+++ b/extensions_built_in/sd_trainer/SDTrainer.py
@@ -1131,7 +1131,7 @@ class SDTrainer(BaseSDTrainProcess):
             # self.network.multiplier = 0.0
             self.sd.unet.eval()
 
-            if self.adapter is not None and isinstance(self.adapter, IPAdapter) and not self.sd.is_flux and not self.sd.is_lumina2:
+            if self.adapter is not None and isinstance(self.adapter, IPAdapter) and not self.sd.is_flux and not self.sd.is_lumina2 and not self.sd.is_zimage:
                 # we need to remove the image embeds from the prompt except for flux
                 embeds_to_use: PromptEmbeds = embeds_to_use.clone().detach()
                 end_pos = embeds_to_use.text_embeds.shape[1] - self.adapter_config.num_tokens

--- a/jobs/process/BaseSDTrainProcess.py
+++ b/jobs/process/BaseSDTrainProcess.py
@@ -1590,6 +1590,8 @@ class BaseSDTrainProcess(BaseTrainProcess):
                 arch = 'flux'
             if self.model_config.is_lumina2:
                 arch = 'lumina2'
+            if self.model_config.is_zimage:
+                arch = 'zimage'
             sampler = get_sampler(
                 self.train_config.noise_scheduler,
                 {
@@ -1784,6 +1786,7 @@ class BaseSDTrainProcess(BaseTrainProcess):
                     is_auraflow=self.model_config.is_auraflow,
                     is_flux=self.model_config.is_flux,
                     is_lumina2=self.model_config.is_lumina2,
+                    is_zimage=self.model_config.is_zimage,
                     is_ssd=self.model_config.is_ssd,
                     is_vega=self.model_config.is_vega,
                     dropout=self.network_config.dropout,
@@ -2472,6 +2475,8 @@ class BaseSDTrainProcess(BaseTrainProcess):
             tags.append("flux")
         if self.model_config.is_lumina2:
             tags.append("lumina2")
+        if self.model_config.is_zimage:
+            tags.append("zimage")
         if self.model_config.is_v3:
             tags.append("sd3")
         if self.network_config:

--- a/jobs/process/GenerateProcess.py
+++ b/jobs/process/GenerateProcess.py
@@ -101,6 +101,8 @@ class GenerateProcess(BaseProcess):
                 arch = 'flux'
             if self.model_config.is_lumina2:
                 arch = 'lumina2'
+            if self.model_config.is_zimage:
+                arch = 'zimage'
             sampler = get_sampler(
                 self.train_config.noise_scheduler,
                 {

--- a/toolkit/config_modules.py
+++ b/toolkit/config_modules.py
@@ -572,7 +572,7 @@ class TrainConfig:
         self.audio_loss_multiplier = kwargs.get("audio_loss_multiplier", 1.0)
 
 
-ModelArch = Literal['sd1', 'sd2', 'sd3', 'sdxl', 'pixart', 'pixart_sigma', 'auraflow', 'flux', 'flex1', 'flex2', 'lumina2', 'vega', 'ssd', 'wan21']
+ModelArch = Literal['sd1', 'sd2', 'sd3', 'sdxl', 'pixart', 'pixart_sigma', 'auraflow', 'flux', 'flex1', 'flex2', 'lumina2', 'zimage', 'vega', 'ssd', 'wan21']
 
 
 class ModelConfig:
@@ -588,6 +588,7 @@ class ModelConfig:
         self.is_v3: bool = kwargs.get('is_v3', False)
         self.is_flux: bool = kwargs.get('is_flux', False)
         self.is_lumina2: bool = kwargs.get('is_lumina2', False)
+        self.is_zimage: bool = kwargs.get('is_zimage', False)
         if self.is_pixart_sigma:
             self.is_pixart = True
         self.use_flux_cfg = kwargs.get('use_flux_cfg', False)
@@ -719,6 +720,8 @@ class ModelConfig:
                 self.is_flux = True
             elif self.arch == 'lumina2':
                 self.is_lumina2 = True
+            elif self.arch == 'zimage':
+                self.is_zimage = True
             elif self.arch == 'vega':
                 self.is_vega = True
             elif self.arch == 'ssd':
@@ -742,6 +745,8 @@ class ModelConfig:
                 self.arch = 'flux'
             elif kwargs.get('is_lumina2', False):
                 self.arch = 'lumina2'
+            elif kwargs.get('is_zimage', False):
+                self.arch = 'zimage'
             elif kwargs.get('is_vega', False):
                 self.arch = 'vega'
             elif kwargs.get('is_ssd', False):

--- a/toolkit/lora_special.py
+++ b/toolkit/lora_special.py
@@ -183,6 +183,7 @@ class LoRASpecialNetwork(ToolkitNetworkMixin, LoRANetwork):
             is_auraflow: bool = False,
             is_flux: bool = False,
             is_lumina2: bool = False,
+            is_zimage: bool = False,
             use_bias: bool = False,
             is_lorm: bool = False,
             ignore_if_contains = None,
@@ -250,6 +251,7 @@ class LoRASpecialNetwork(ToolkitNetworkMixin, LoRANetwork):
         self.is_auraflow = is_auraflow
         self.is_flux = is_flux
         self.is_lumina2 = is_lumina2
+        self.is_zimage = is_zimage
         self.network_type = network_type
         self.is_assistant_adapter = is_assistant_adapter
         self.full_rank = network_type.lower() == "fullrank"
@@ -274,7 +276,7 @@ class LoRASpecialNetwork(ToolkitNetworkMixin, LoRANetwork):
             self.use_old_lokr_format = False
 
         # always do peft for flux only for now
-        if self.is_flux or self.is_v3 or self.is_lumina2 or is_transformer:
+        if self.is_flux or self.is_v3 or self.is_lumina2 or self.is_zimage or is_transformer:
             # don't do peft format for lokr if using old format
             if self.network_type.lower() != "lokr" or not self.use_old_lokr_format:
                 self.peft_format = True
@@ -317,7 +319,7 @@ class LoRASpecialNetwork(ToolkitNetworkMixin, LoRANetwork):
             unet_prefix = self.LORA_PREFIX_UNET
             if self.peft_format:
                 unet_prefix = self.PEFT_PREFIX_UNET
-            if is_pixart or is_v3 or is_auraflow or is_flux or is_lumina2 or self.is_transformer:
+            if is_pixart or is_v3 or is_auraflow or is_flux or is_lumina2 or is_zimage or self.is_transformer:
                 unet_prefix = f"lora_transformer"
                 if self.peft_format:
                     unet_prefix = "transformer"
@@ -380,6 +382,9 @@ class LoRASpecialNetwork(ToolkitNetworkMixin, LoRANetwork):
                                     if "transformer_blocks" not in lora_name:
                                         skip = True
                                 if self.is_lumina2:
+                                    if "layers$$" not in lora_name and "noise_refiner$$" not in lora_name and "context_refiner$$" not in lora_name:
+                                        skip = True
+                                if self.is_zimage:
                                     if "layers$$" not in lora_name and "noise_refiner$$" not in lora_name and "context_refiner$$" not in lora_name:
                                         skip = True
                                 if  self.is_v3:
@@ -512,6 +517,9 @@ class LoRASpecialNetwork(ToolkitNetworkMixin, LoRANetwork):
         
         if is_lumina2:
             target_modules = ["Lumina2Transformer2DModel"]
+
+        if is_zimage:
+            target_modules = ["ZImageTransformer2DModel"]
 
         if train_unet:
             self.unet_loras, skipped_un = create_modules(True, None, unet, target_modules)

--- a/toolkit/models/base_model.py
+++ b/toolkit/models/base_model.py
@@ -257,6 +257,10 @@ class BaseModel:
     def is_lumina2(self):
         return self.arch == 'lumina2'
 
+    @property
+    def is_zimage(self):
+        return self.arch == 'zimage'
+
     def get_bucket_divisibility(self):
         if self.vae is None:
             return 8

--- a/toolkit/sampler.py
+++ b/toolkit/sampler.py
@@ -118,6 +118,23 @@ lumina2_config = {
   "use_karras_sigmas": False
 }
 
+zimage_config = {
+  "_class_name": "FlowMatchEulerDiscreteScheduler",
+  "_diffusers_version": "0.37.0.dev0",
+  "base_image_seq_len": 256,
+  "base_shift": 0.5,
+  "invert_sigmas": False,
+  "max_image_seq_len": 4096,
+  "max_shift": 1.15,
+  "num_train_timesteps": 1000,
+  "shift": 6.0,
+  "shift_terminal": None,
+  "use_beta_sigmas": False,
+  "use_dynamic_shifting": False,
+  "use_exponential_sigmas": False,
+  "use_karras_sigmas": False
+}
+
 
 def get_sampler(
         sampler: str,
@@ -171,6 +188,8 @@ def get_sampler(
             config_to_use = copy.deepcopy(flux_config)
         elif arch == "lumina2":
             config_to_use = copy.deepcopy(lumina2_config)
+        elif arch == "zimage":
+            config_to_use = copy.deepcopy(zimage_config)
         else:
             print(f"Unknown architecture {arch}, using default flux config")
             # use flux by default

--- a/toolkit/stable_diffusion_model.py
+++ b/toolkit/stable_diffusion_model.py
@@ -51,6 +51,8 @@ from diffusers import StableDiffusionPipeline, StableDiffusionXLPipeline, T2IAda
     StableDiffusion3Img2ImgPipeline, PixArtSigmaPipeline, AuraFlowPipeline, AuraFlowTransformer2DModel, FluxPipeline, \
     FluxTransformer2DModel, FlowMatchEulerDiscreteScheduler, SD3Transformer2DModel, Lumina2Pipeline, \
     FluxControlPipeline, Lumina2Transformer2DModel
+from diffusers import ZImagePipeline
+from diffusers.models.transformers import ZImageTransformer2DModel
 import diffusers
 from diffusers import \
     AutoencoderKL, \
@@ -196,7 +198,7 @@ class StableDiffusion:
         self.config_file = None
 
         self.is_flow_matching = False
-        if self.is_flux or self.is_v3 or self.is_auraflow or self.is_lumina2 or isinstance(self.noise_scheduler, CustomFlowMatchEulerDiscreteScheduler):
+        if self.is_flux or self.is_v3 or self.is_auraflow or self.is_lumina2 or self.is_zimage or isinstance(self.noise_scheduler, CustomFlowMatchEulerDiscreteScheduler):
             self.is_flow_matching = True
 
         self.quantize_device = self.device_torch
@@ -269,6 +271,10 @@ class StableDiffusion:
     @property
     def is_lumina2(self):
         return self.arch == 'lumina2'
+
+    @property
+    def is_zimage(self):
+        return self.arch == 'zimage'
     
     @property
     def unet_unwrapped(self):
@@ -933,6 +939,98 @@ class StableDiffusion:
             text_encoder.eval()
             pipe.transformer = pipe.transformer.to(self.device_torch)
             flush()
+        elif self.model_config.is_zimage:
+            self.print_and_status_update("Loading Z-Image model")
+            base_model_path = self.model_config.name_or_path_original
+            self.print_and_status_update("Loading transformer")
+            subfolder = 'transformer'
+            transformer_path = model_path
+            if os.path.exists(transformer_path):
+                subfolder = None
+                transformer_path = os.path.join(transformer_path, 'transformer')
+                te_folder_path = os.path.join(model_path, 'text_encoder')
+                if os.path.exists(te_folder_path):
+                    base_model_path = model_path
+
+            transformer = ZImageTransformer2DModel.from_pretrained(
+                transformer_path,
+                subfolder=subfolder,
+                torch_dtype=dtype,
+            )
+
+            if self.model_config.split_model_over_gpus:
+                raise ValueError("Splitting model over gpus is not supported for Z-Image models")
+
+            transformer.to(self.quantize_device, dtype=dtype)
+            flush()
+
+            if self.model_config.assistant_lora_path is not None or self.model_config.inference_lora_path is not None:
+                raise ValueError("Assistant LoRA is not supported for Z-Image models currently")
+
+            if self.model_config.lora_path is not None:
+                raise ValueError("Loading LoRA is not supported for Z-Image models currently")
+
+            flush()
+
+            if self.model_config.quantize:
+                patch_dequantization_on_save(transformer)
+                quantization_type = get_qtype(self.model_config.qtype)
+                self.print_and_status_update("Quantizing transformer")
+                quantize(transformer, weights=quantization_type, **self.model_config.quantize_kwargs)
+                freeze(transformer)
+                transformer.to(self.device_torch)
+            else:
+                transformer.to(self.device_torch, dtype=dtype)
+
+            flush()
+
+            scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(base_model_path, subfolder="scheduler")
+            self.print_and_status_update("Loading vae")
+            vae = AutoencoderKL.from_pretrained(base_model_path, subfolder="vae", torch_dtype=dtype)
+            flush()
+
+            if self.model_config.te_name_or_path is not None:
+                self.print_and_status_update("Loading TE")
+                tokenizer = AutoTokenizer.from_pretrained(self.model_config.te_name_or_path, torch_dtype=dtype)
+                text_encoder = AutoModel.from_pretrained(self.model_config.te_name_or_path, torch_dtype=dtype)
+            else:
+                self.print_and_status_update("Loading Qwen3")
+                tokenizer = AutoTokenizer.from_pretrained(base_model_path, subfolder="tokenizer")
+                text_encoder = AutoModel.from_pretrained(base_model_path, subfolder="text_encoder", torch_dtype=dtype)
+
+            text_encoder.to(self.device_torch, dtype=dtype)
+            flush()
+
+            if self.model_config.quantize_te:
+                self.print_and_status_update("Quantizing Qwen3")
+                quantize(text_encoder, weights=get_qtype(self.model_config.qtype))
+                freeze(text_encoder)
+                flush()
+
+            self.print_and_status_update("Making pipe")
+            pipe = ZImagePipeline(
+                scheduler=scheduler,
+                text_encoder=None,
+                tokenizer=tokenizer,
+                vae=vae,
+                transformer=None,
+            )
+            pipe.text_encoder = text_encoder
+            pipe.transformer = transformer
+
+            self.print_and_status_update("Preparing Model")
+
+            text_encoder = pipe.text_encoder
+            tokenizer = pipe.tokenizer
+
+            pipe.transformer = pipe.transformer.to(self.device_torch)
+
+            flush()
+            text_encoder.to(self.device_torch)
+            text_encoder.requires_grad_(False)
+            text_encoder.eval()
+            pipe.transformer = pipe.transformer.to(self.device_torch)
+            flush()
         else:
             if self.custom_pipeline is not None:
                 pipln = self.custom_pipeline
@@ -1005,7 +1103,7 @@ class StableDiffusion:
         # add hacks to unet to help training
         # pipe.unet = prepare_unet_for_training(pipe.unet)
 
-        if self.is_pixart or self.is_v3 or self.is_auraflow or self.is_flux or self.is_lumina2:
+        if self.is_pixart or self.is_v3 or self.is_auraflow or self.is_flux or self.is_lumina2 or self.is_zimage:
             # pixart and sd3 dont use a unet
             self.unet = pipe.transformer
         else:
@@ -1020,7 +1118,7 @@ class StableDiffusion:
         self.unet.eval()
 
         # load any loras we have
-        if self.model_config.lora_path is not None and not self.is_flux and not self.is_lumina2:
+        if self.model_config.lora_path is not None and not self.is_flux and not self.is_lumina2 and not self.is_zimage:
             pipe.load_lora_weights(self.model_config.lora_path, adapter_name="lora1")
             pipe.fuse_lora()
             # unfortunately, not an easier way with peft
@@ -1190,6 +1288,8 @@ class StableDiffusion:
                         arch = 'flux'
                     if self.is_lumina2:
                         arch = 'lumina2'
+                    if self.is_zimage:
+                        arch = 'zimage'
                     noise_scheduler = get_sampler(
                         sampler,
                         {
@@ -1283,6 +1383,15 @@ class StableDiffusion:
                 pipeline.watermark = None
             elif self.is_lumina2:
                 pipeline = Lumina2Pipeline(
+                    vae=self.vae,
+                    transformer=self.unet,
+                    text_encoder=self.text_encoder,
+                    tokenizer=self.tokenizer,
+                    scheduler=noise_scheduler,
+                    **extra_args
+                )
+            elif self.is_zimage:
+                pipeline = ZImagePipeline(
                     vae=self.vae,
                     transformer=self.unet,
                     text_encoder=self.text_encoder,
@@ -1617,6 +1726,19 @@ class StableDiffusion:
                             prompt_attention_mask=conditional_embeds.attention_mask.to(self.device_torch, dtype=torch.int64),
                             negative_prompt_embeds=unconditional_embeds.text_embeds,
                             negative_prompt_attention_mask=unconditional_embeds.attention_mask.to(self.device_torch, dtype=torch.int64),
+                            height=gen_config.height,
+                            width=gen_config.width,
+                            num_inference_steps=gen_config.num_inference_steps,
+                            guidance_scale=gen_config.guidance_scale,
+                            latents=gen_config.latents,
+                            generator=generator,
+                            **extra
+                        ).images[0]
+                    elif self.is_zimage:
+                        pipeline: ZImagePipeline = pipeline
+                        img = pipeline(
+                            prompt_embeds=conditional_embeds.text_embeds,
+                            negative_prompt_embeds=unconditional_embeds.text_embeds,
                             height=gen_config.height,
                             width=gen_config.width,
                             num_inference_steps=gen_config.num_inference_steps,
@@ -2215,6 +2337,38 @@ class StableDiffusion:
                     
                     # lumina2 does this before stepping. Should we do it here?
                     noise_pred = -noise_pred
+                elif self.is_zimage:
+                    # reverse the timestep since ZImage uses t=0 as the noise and t=1 as the image
+                    t = 1 - timestep / self.noise_scheduler.config.num_train_timesteps
+
+                    # Convert batched latents to list of [C, 1, H, W] tensors
+                    latent_list = list(latent_model_input.unsqueeze(2).unbind(dim=0))
+
+                    # Convert text embeddings to list format
+                    cap_feats = text_embeddings.text_embeds
+                    if not isinstance(cap_feats, list):
+                        # If batched, convert using attention mask
+                        if text_embeddings.attention_mask is not None:
+                            cap_feats = []
+                            for i in range(len(latent_list)):
+                                mask = text_embeddings.attention_mask[i].bool()
+                                cap_feats.append(text_embeddings.text_embeds[i][mask])
+                        else:
+                            cap_feats = list(text_embeddings.text_embeds.unbind(dim=0))
+
+                    with self.accelerator.autocast():
+                        model_out_list = self.unet(
+                            x=latent_list,
+                            t=t,
+                            cap_feats=cap_feats,
+                            **kwargs,
+                        ).sample  # Returns list of tensors
+
+                    # Stack list output back into batched tensor and squeeze the F dimension
+                    noise_pred = torch.stack(model_out_list, dim=0).squeeze(2)
+
+                    # ZImage also negates noise prediction
+                    noise_pred = -noise_pred
                 elif self.is_v3:
                     noise_pred = self.unet(
                         hidden_states=latent_model_input.to(self.device_torch, self.torch_dtype),
@@ -2480,6 +2634,21 @@ class StableDiffusion:
                 attention_mask=prompt_attention_mask,
             )
 
+        elif self.is_zimage:
+            (
+                prompt_embeds,
+                negative_prompt_embeds,
+            ) = self.pipeline.encode_prompt(
+                prompt,
+                do_classifier_free_guidance=False,
+                num_images_per_prompt=1,
+                device=self.device_torch,
+                max_sequence_length=512,
+            )
+            return PromptEmbeds(
+                prompt_embeds,
+            )
+
         elif isinstance(self.text_encoder, T5EncoderModel):
             embeds, attention_mask = train_tools.encode_prompts_pixart(
                 self.tokenizer,
@@ -2675,7 +2844,7 @@ class StableDiffusion:
                 for name, param in self.text_encoder.named_parameters(recurse=True, prefix=f"{SD_PREFIX_TEXT_ENCODER}"):
                     named_params[name] = param
         if unet:
-            if self.is_flux or self.is_lumina2:
+            if self.is_flux or self.is_lumina2 or self.is_zimage:
                 for name, param in self.unet.named_parameters(recurse=True, prefix="transformer"):
                     named_params[name] = param
             else:
@@ -2794,6 +2963,12 @@ class StableDiffusion:
                     save_directory=os.path.join(output_file, 'transformer'),
                     safe_serialization=True,
                 )
+            elif self.is_zimage:
+                transformer: ZImageTransformer2DModel = unwrap_model(self.unet)
+                transformer.save_pretrained(
+                    save_directory=os.path.join(output_file, 'transformer'),
+                    safe_serialization=True,
+                )
                 
             else:
 
@@ -2851,7 +3026,7 @@ class StableDiffusion:
             named_params = self.named_parameters(vae=False, unet=unet, text_encoder=False, state_dict_keys=True)
             unet_lr = unet_lr if unet_lr is not None else default_lr
             params = []
-            if self.is_pixart or self.is_auraflow or self.is_flux or self.is_v3 or self.is_lumina2:
+            if self.is_pixart or self.is_auraflow or self.is_flux or self.is_v3 or self.is_lumina2 or self.is_zimage:
                 for param in named_params.values():
                     if param.requires_grad:
                         params.append(param)
@@ -3143,6 +3318,8 @@ class StableDiffusion:
             return 'flux.1'
         if self.is_lumina2:
             return 'lumina2'
+        if self.is_zimage:
+            return 'zimage'
         if self.is_ssd:
             return 'ssd'
         if self.is_vega:


### PR DESCRIPTION
## Summary

Adds `arch='zimage'` for training LoRAs on [Z-Image Base](https://huggingface.co/Tongyi-MAI/Z-Image) and [Z-Image Turbo](https://huggingface.co/Tongyi-MAI/Z-Image-Turbo) checkpoints, including community retrains (e.g., ZiT NSFW on CivitAI).

## Motivation

Z-Image is a Lumina2-family model but with significant architectural differences that prevent the existing `lumina2` arch from loading Z-Image checkpoints:

| Feature | Lumina2 | Z-Image |
|---------|---------|---------|
| dim | 2304 | 3840 |
| layers | 26 | 30 |
| attention heads | 24 (8 kv) | 30 (30 kv) |
| Text encoder | Gemma2 | Qwen3 |
| Forward API | Batched tensors | **List-based** |

Attempting to use `arch='lumina2'` with a Z-Image checkpoint produces a shape mismatch:
```
ValueError: Cannot load because context_refiner.0.ffn_norm1.weight expected shape [2304], got [3840]
```

## Changes

- **config_modules.py**: Add `'zimage'` arch type with `is_zimage` flag
- **stable_diffusion_model.py**: Full model loading path (`ZImageTransformer2DModel`, `ZImagePipeline`, Qwen3 text encoder via `AutoModel`), training forward pass with list \u2194 batch conversion, inference pipeline, save/load
- **sampler.py**: `FlowMatchEulerDiscreteScheduler` config for Z-Image
- **lora_special.py**: Target modules (`ZImageTransformer2DModel`) and transformer layer filtering
- **models/base_model.py**: `is_zimage` property
- **BaseSDTrainProcess.py**: Arch selection, LoRA params, tags
- **GenerateProcess.py**: Arch selection
- **SDTrainer.py**: IPAdapter exclusion check

## Key Design Decision: List-Based Forward Pass

ZImageTransformer2DModel takes `List[Tensor]` inputs and returns `List[Tensor]` outputs, unlike Lumina2 which uses batched tensors. The training forward pass:

1. Converts batched latents to list via `.unsqueeze(2).unbind(0)`
2. Converts text embeddings from batched to list format
3. Calls transformer with `x=latent_list, t=timestep, cap_feats=cap_feats_list`
4. Stacks output list back to batched tensor for loss computation

## Testing

Tested locally on Apple M4 Max (MPS, 128GB unified memory):
- Checkpoint: ZiT NSFW v5.0 BF16 (11.5GB, ComfyUI format converted via `ZImageTransformer2DModel.from_single_file()`)
- Dataset: 50 images with captions
- Config: rank 32 LoRA, LR 1e-4, cosine schedule, 2500 steps, bf16
- Result: Training runs successfully, loss converges normally

## Example Config

```yaml
model:
  name_or_path: 'Tongyi-MAI/Z-Image'  # or local path
  arch: 'zimage'
  quantize: true
  qtype: 'qint8'  # qfloat8 on CUDA, qint8 on MPS
```

## Notes

- ComfyUI-format Z-Image checkpoints need conversion to diffusers format first via `ZImageTransformer2DModel.from_single_file()` + `save_pretrained()`
- Float8 quantization (`qfloat8`) not supported on MPS; use `qint8` or disable quantization for Apple Silicon
- The `timestep_type: 'lumina2_shift'` works correctly for Z-Image (same flow-matching convention)