### PR TITLE
Security: Critical - API Unprotected if AI_TOOLKIT_AUTH is Unset

### DIFF
--- a/ui/src/middleware.ts
+++ b/ui/src/middleware.ts
@@ -9,9 +9,6 @@ export function middleware(request: NextRequest) {
   // check env var for AI_TOOLKIT_AUTH, if not set, approve all requests
   // if it is set make sure bearer token matches
   const tokenToUse = process.env.AI_TOOLKIT_AUTH || null;
-  if (!tokenToUse) {
-    return NextResponse.next();
-  }
 
   // Get the token from the headers
   const token = request.headers.get('Authorization')?.split(' ')[1];
@@ -24,6 +21,15 @@ export function middleware(request: NextRequest) {
   // Check if the route should be protected
   // This will apply to all API routes that start with /api/
   if (request.nextUrl.pathname.startsWith('/api/')) {
+    // If AI_TOOLKIT_AUTH is not set, all protected API routes are unauthorized by default.
+    if (!tokenToUse) {
+      return new NextResponse(JSON.stringify({ error: 'Unauthorized: AI_TOOLKIT_AUTH not configured' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // If AI_TOOLKIT_AUTH is set, proceed with token validation
     if (!token || token !== tokenToUse) {
       // Return a JSON response with 401 Unauthorized
       return new NextResponse(JSON.stringify({ error: 'Unauthorized' }), {


### PR DESCRIPTION
## Problem

The `middleware.ts` explicitly allows all requests to pass through if the `AI_TOOLKIT_AUTH` environment variable is not set. This creates a critical security vulnerability where the entire API can be accessed without any authentication if this environment variable is accidentally or intentionally omitted in a production deployment. This design choice makes the application insecure by default, relying on correct environment configuration rather than secure-by-default principles.


**Severity**: `critical`
**File**: `ui/src/middleware.ts`

## Solution

Modify the middleware to require authentication by default. If `process.env.AI_TOOLKIT_AUTH` is not set, the application should either fail to start (e.g., during build or server initialization) or reject all protected routes with a 401 Unauthorized response, rather than allowing them.


## Changes

- `ui/src/middleware.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
