### PR TITLE
Fix flux_train_ui startup on Gradio 6 by removing removed Image kwargs

### DIFF
--- a/flux_train_ui.py
+++ b/flux_train_ui.py
@@ -331,8 +331,6 @@ with gr.Blocks(theme=theme, css=css) as demo:
                                     interactive=False,
                                     scale=2,
                                     show_label=False,
-                                    show_share_button=False,
-                                    show_download_button=False,
                                 )
                                 locals()[f"caption_{i}"] = gr.Textbox(
                                     label=f"Caption {i}", scale=15, interactive=True


### PR DESCRIPTION
Fixes #776.

## Summary
- remove `show_share_button=False` from the `gr.Image(...)` used in `flux_train_ui.py`
- remove `show_download_button=False` from the same component

## Why
Gradio 6.x no longer accepts these kwargs, so `flux_train_ui` crashes while building the UI with:

```text
TypeError: Image.__init__() got an unexpected keyword argument 'show_share_button'
```

## Validation
```bash
env -u ALL_PROXY -u all_proxy -u HTTP_PROXY -u HTTPS_PROXY -u WS_PROXY -u WSS_PROXY -u http_proxy -u https_proxy \
  /data/iqdoctor/ai-toolkit/.venv/bin/python - <<'PY'
import flux_train_ui
print('import flux_train_ui OK')
PY
```

This now imports successfully on `gradio 6.10.0`.

Note: there is still a separate non-blocking Gradio 6 warning about `theme` / `css` being passed to `Blocks(...)`; this PR intentionally keeps scope to the startup blocker.
