### PR TITLE
Add Rose optimizer

### DIFF
--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -41,3 +41,4 @@ av==16.0.1
 torchcodec==0.9.1
 librosa==0.11.0
 mutagen==1.47.0
+rose-opt

--- a/toolkit/optimizer.py
+++ b/toolkit/optimizer.py
@@ -97,6 +97,9 @@ def get_optimizer(
     elif lower_type == 'automagic':
         from toolkit.optimizers.automagic import Automagic
         optimizer = Automagic(params, lr=float(learning_rate), **optimizer_params)
+    elif lower_type == 'rose':
+        from rose_opt import Rose
+        optimizer = Rose(params, lr=float(learning_rate), **optimizer_params)
     else:
         raise ValueError(f'Unknown optimizer type {optimizer_type}')
     return optimizer

--- a/ui/src/app/jobs/new/SimpleJob.tsx
+++ b/ui/src/app/jobs/new/SimpleJob.tsx
@@ -582,6 +582,7 @@ export default function SimpleJob({
                     { value: 'automagic', label: 'Automagic' },
                     { value: 'prodigyopt', label: 'Prodigy' },
                     { value: 'prodigy8bit', label: 'Prodigy8Bit' },
+                    { value: 'rose', label: 'Rose' },
                   ]}
                 />
                 <NumberInput


### PR DESCRIPTION
Rose optimizer: https://github.com/MatthewK78/Rose

- Stateless: uses less memory than even 8-bit versions of other optimizers. If not for temporary working memory, its memory usage would be as low as plain vanilla SGD (**without** momentum).
- Matches or exceeds AdamW in observed accuracy and convergence.
- Training loss runs higher while validation loss runs lower, consistent with implicit regularization rather than memorization.

Note: Requires a higher than usual learning rate. For example, 1e-3 instead of AdamW's 1e-4.