### PR TITLE
fix: handle missing Flux VAE config values and None prompt inputs

### DIFF
--- a/toolkit/stable_diffusion_model.py
+++ b/toolkit/stable_diffusion_model.py
@@ -1012,6 +1012,12 @@ class StableDiffusion:
         self.vae: 'AutoencoderKL' = pipe.vae.to(self.vae_device_torch, dtype=self.vae_torch_dtype)
         self.vae.eval()
         self.vae.requires_grad_(False)
+        # Flux VAE loaded from ComfyUI single-file checkpoints may not carry these config values
+        if self.is_flux:
+            if getattr(self.vae.config, 'scaling_factor', None) is None:
+                self.vae.config.scaling_factor = 0.3611
+            if getattr(self.vae.config, 'shift_factor', None) is None:
+                self.vae.config.shift_factor = 0.1159
         VAE_SCALE_FACTOR = 2 ** (len(self.vae.config['block_out_channels']) - 1)
         self.vae_scale_factor = VAE_SCALE_FACTOR
         self.unet.to(self.device_torch, dtype=dtype)
@@ -2449,7 +2455,7 @@ class StableDiffusion:
             prompt_embeds, pooled_prompt_embeds = train_tools.encode_prompts_flux(
                 self.tokenizer,  # list
                 self.text_encoder,  # list
-                prompt,
+                [prompt if prompt is not None else ''] if isinstance(prompt, str) or prompt is None else prompt,
                 truncate=not long_prompts,
                 max_length=512,
                 dropout_prob=dropout_prob,

--- a/toolkit/train_tools.py
+++ b/toolkit/train_tools.py
@@ -528,6 +528,13 @@ def encode_prompts_flux(
     device = text_encoder[0].device
     dtype = text_encoder[0].dtype
 
+    # Normalize prompts: ensure every element is a non-None string so the
+    # CLIP/T5 tokenizers never receive None or False as input
+    if isinstance(prompts, list):
+        prompts = [str(p) if p is not None and p is not False else '' for p in prompts]
+    else:
+        prompts = [str(prompts) if prompts is not None and prompts is not False else '']
+
     batch_size = len(prompts)
 
     # clip


### PR DESCRIPTION
## Problem

When Flux is loaded from a **ComfyUI single-file checkpoint** (.safetensors), the bundled VAE often omits scaling_factor and shift_factor from its config. This causes a crash during sample generation:

`
TypeError: unsupported operand type(s) for +: 'Tensor' and 'NoneType'
# diffusers/pipelines/flux/pipeline_flux.py line 1010
latents = (latents / self.vae.config.scaling_factor) + self.vae.config.shift_factor
`

A second related issue: the CLIP/T5 tokenisers raise a TypeError: TextEncodeInput must be Union[TextInputSequence, ...] when they receive None or False as the unconditional (negative) prompt, which can happen through the dropout path or when callers pass bare strings/None to encode_prompt.

## Changes

### 	oolkit/stable_diffusion_model.py
- After loading the VAE, inject the correct Flux defaults (scaling_factor=0.3611, shift_factor=0.1159) **only when the values are absent** - existing configs are untouched.
- Wrap the prompt argument in a list inside encode_prompt for the Flux branch, so a bare string or None never reaches encode_prompts_flux as a non-list.

### 	oolkit/train_tools.py
- Normalise every element of prompts in encode_prompts_flux to a str, replacing None / False with '', before the tokeniser call.

## Testing

Verified end-to-end with lux1-dev.safetensors loaded from a local ComfyUI checkpoint directory (24 GB VRAM, 8-bit quantisation, damw8bit optimiser). Training now proceeds past the baseline sample generation step.

## Notes

The correct Flux VAE constants (.3611 / .1159) match the values published in the official lack-forest-labs/FLUX.1-dev model card.