### PR TITLE
Enable VAE tiling for Wan to avoid OOM at sample-time

### DIFF
--- a/toolkit/models/wan21/wan21.py
+++ b/toolkit/models/wan21/wan21.py
@@ -487,6 +487,7 @@ class Wan21(BaseModel):
         self.pipeline = pipe
         self.model = transformer
         self.vae = vae
+        self.vae.enable_tiling()
         self.text_encoder = text_encoder
         self.tokenizer = tokenizer
 


### PR DESCRIPTION
## Description

The shipped 24GB example `config/examples/train_lora_wan21_14b_24gb.yaml` (and the 1B variant) OOMs at the first sample step on 24GB GPUs under its own defaults. The VAE supports tiled decoding via `AutoencoderKLWan.enable_tiling` but `Wan21.load_model` never opts in, so the decoder's last upsample `conv3d` tries to allocate a ~7.7 GiB contiguous workspace at 832×480 × 33–40 frames; with the transformer still on GPU there's only ~7.6 GiB free.

The fix is one line:

```python
  self.vae = vae
  self.vae.enable_tiling()

AutoencoderKLWan.tiled_decode already exists with blend_v / blend_h seam blending — this just turns it on at load time. Cost is ~20–30% slower VAE decode at sample time only (training step time is unaffected). On a 1000-step run with the default  sample_every: 250 that's roughly +1 minute total wall-clock.

The 24GB example configs already enable low_vram: true and quantize: true — every  other VRAM-saving knob in the file. Making tiled VAE decode default seemed like the lowest-friction fix to make those examples actually run on the hardware they  advertise.                                             

Tested with Wan2.1-T2V-14B on a single 24GB GPU sampling at 832×480×33 frames: OOMs without the patch, runs cleanly with it. Visual quality preserved (existing tile blending handles seams).    
