### PR TITLE
Make UI fully mobile responsive

### DIFF
--- a/ui/src/app/dashboard/page.tsx
+++ b/ui/src/app/dashboard/page.tsx
@@ -10,7 +10,7 @@ export default function Dashboard() {
     <>
       <TopBar>
         <div>
-          <h1 className="text-lg">Dashboard</h1>
+          <h1 className="text-sm md:text-lg">Dashboard</h1>
         </div>
         <div className="flex-1"></div>
       </TopBar>

--- a/ui/src/app/datasets/[datasetName]/page.tsx
+++ b/ui/src/app/datasets/[datasetName]/page.tsx
@@ -4,13 +4,15 @@ import { useEffect, useState, use, useMemo } from 'react';
 import { LuImageOff, LuLoader, LuBan } from 'react-icons/lu';
 import { FaChevronLeft } from 'react-icons/fa';
 import DatasetImageCard from '@/components/DatasetImageCard';
-import { Button } from '@headlessui/react';
+import { Button, MenuItem } from '@headlessui/react';
 import AddImagesModal, { openImagesModal, useOpenImagesModalOnDrag } from '@/components/AddImagesModal';
 import { TopBar, MainContent } from '@/components/layout';
 import { apiClient } from '@/utils/api';
 import useSettings from '@/hooks/useSettings';
 import { pathJoin } from '@/utils/basic';
 import AutoCaptionButton from '@/components/AutoCaptionButton';
+import { openCaptionDatasetModal } from '@/components/CaptionDatasetModal';
+import OverflowMenu from '@/components/OverflowMenu';
 
 export default function DatasetPage({ params }: { params: { datasetName: string } }) {
   const [imgList, setImgList] = useState<{ img_path: string }[]>([]);
@@ -105,11 +107,11 @@ export default function DatasetPage({ params }: { params: { datasetName: string 
             <FaChevronLeft />
           </Button>
         </div>
-        <div>
-          <h1 className="text-lg">Dataset: {datasetName}</h1>
+        <div className="min-w-0 flex-1">
+          <h1 className="text-sm md:text-lg truncate">Dataset: {datasetName}</h1>
         </div>
-        <div className="flex-1"></div>
-        <div>
+        {/* Desktop: all buttons inline */}
+        <div className="hidden md:flex items-center gap-2">
           <AutoCaptionButton
             datasetPath={`${pathJoin(settings.DATASETS_FOLDER, datasetName)}`}
             setIsAutoCaptioning={setIsAutoCaptioning}
@@ -120,6 +122,25 @@ export default function DatasetPage({ params }: { params: { datasetName: string 
           >
             Add Images
           </Button>
+        </div>
+        {/* Mobile: Add Images button + overflow menu */}
+        <div className="flex md:hidden items-center gap-1">
+          <Button
+            className="text-white bg-slate-600 px-2 py-1 rounded-md text-xs"
+            onClick={() => openImagesModal(datasetName, () => refreshImageList(datasetName))}
+          >
+            Add Images
+          </Button>
+          <OverflowMenu>
+            <MenuItem>
+              <button
+                className="w-full text-left cursor-pointer px-4 py-1 hover:bg-gray-800 rounded"
+                onClick={() => openCaptionDatasetModal(pathJoin(settings.DATASETS_FOLDER, datasetName), () => {})}
+              >
+                Auto Caption
+              </button>
+            </MenuItem>
+          </OverflowMenu>
         </div>
       </TopBar>
       <MainContent>

--- a/ui/src/app/datasets/page.tsx
+++ b/ui/src/app/datasets/page.tsx
@@ -7,6 +7,7 @@ import { TextInput } from '@/components/formInputs';
 import useDatasetList from '@/hooks/useDatasetList';
 import { Button } from '@headlessui/react';
 import { FaRegTrashAlt } from 'react-icons/fa';
+import { Plus } from 'lucide-react';
 import { openConfirm } from '@/components/ConfirmModal';
 import { TopBar, MainContent } from '@/components/layout';
 import UniversalTable, { TableColumn } from '@/components/UniversalTable';
@@ -39,6 +40,7 @@ export default function Datasets() {
       title: 'Actions',
       key: 'actions',
       className: 'w-20 text-right',
+      mobileAlignRight: true,
       render: row => (
         <button
           className="text-gray-200 hover:bg-red-600 p-2 rounded-full transition-colors"
@@ -114,15 +116,16 @@ export default function Datasets() {
     <>
       <TopBar>
         <div>
-          <h1 className="text-lg">Datasets</h1>
+          <h1 className="text-sm md:text-lg">Datasets</h1>
         </div>
         <div className="flex-1"></div>
         <div>
           <Button
-            className="text-white bg-slate-600 px-3 py-1 rounded-md hover:bg-slate-500 transition-colors"
+            className="text-white bg-slate-600 px-3 py-1 rounded-md hover:bg-slate-500 transition-colors flex items-center gap-1.5"
             onClick={() => openNewDatasetModal()}
           >
-            New Dataset
+            <Plus className="w-4 h-4" />
+            <span className="whitespace-nowrap">New Dataset</span>
           </Button>
         </div>
       </TopBar>

--- a/ui/src/app/jobs/[jobID]/page.tsx
+++ b/ui/src/app/jobs/[jobID]/page.tsx
@@ -23,7 +23,7 @@ interface Page {
   component: React.ComponentType<{ job: Job }>;
   menuItem?: React.ComponentType<{ job?: Job | null }> | null;
   mainCss?: string;
-  jobTypes?: string[]; // if specified, only show this page for these job types
+  jobTypes?: string[];
 }
 
 const pages: Page[] = [
@@ -32,7 +32,7 @@ const pages: Page[] = [
     value: 'overview',
     icon: MdDashboard,
     component: JobOverview,
-    mainCss: 'pt-24',
+    mainCss: 'pt-14 md:pt-24 pb-16 md:pb-0',
   },
   {
     name: 'Samples',
@@ -40,23 +40,23 @@ const pages: Page[] = [
     icon: MdImage,
     component: SampleImages,
     menuItem: SampleImagesMenu,
-    mainCss: 'pt-24',
+    mainCss: 'pt-14 md:pt-24 pb-16 md:pb-0',
     jobTypes: ['train'],
   },
   {
-    name: 'Loss Graph',
+    name: 'Loss',
     value: 'loss_log',
     icon: MdShowChart,
     component: JobLossGraph,
-    mainCss: 'pt-24 pb-4',
+    mainCss: 'pt-14 md:pt-24 pb-16 md:pb-4',
     jobTypes: ['train'],
   },
   {
-    name: 'Config File',
+    name: 'Config',
     value: 'config',
     icon: MdCode,
     component: JobConfigViewer,
-    mainCss: 'pt-[80px] px-0 pb-0',
+    mainCss: 'pt-14 md:pt-[80px] px-0 pb-16 md:pb-0',
   },
 ];
 
@@ -67,7 +67,6 @@ export default function JobPage({ params }: { params: { jobID: string } }) {
   const [pageKey, setPageKey] = useState<PageKey>('overview');
 
   const page = pages.find(p => p.value === pageKey);
-
   const jobType = job?.job_type || 'unknown';
 
   let title = `Job: ${job?.name || 'Loading...'}`;
@@ -75,65 +74,72 @@ export default function JobPage({ params }: { params: { jobID: string } }) {
     title = `Captioning: ${job?.job_ref || 'Loading...'}`;
   }
 
+  const visiblePages = pages.filter(p => !p.jobTypes || p.jobTypes.includes(jobType));
+
   return (
     <>
-      {/* Fixed top bar */}
       <TopBar>
         <div>
           <Button className="text-gray-500 dark:text-gray-300 px-3 mt-1" onClick={() => redirect('/jobs')}>
             <FaChevronLeft />
           </Button>
         </div>
-        <div>
-          <h1 className="text-lg">{title}</h1>
+        <div className="min-w-0 flex-1">
+          <h1 className="text-sm md:text-lg truncate">{title}</h1>
         </div>
-        <div className="flex-1"></div>
-        {job && (
-          <JobActionBar
-            job={job}
-            onRefresh={refreshJob}
-            hideView
-            afterDelete={() => {
-              redirect('/jobs');
-            }}
-            autoStartQueue={true}
-          />
-        )}
-      </TopBar>
-      <MainContent className={pages.find(page => page.value === pageKey)?.mainCss}>
-        {status === 'loading' && job == null && <p>Loading...</p>}
-        {status === 'error' && job == null && <p>Error fetching job</p>}
         {job && (
           <>
-            {pages.map(page => {
-              const Component = page.component;
-              return page.value === pageKey ? <Component key={page.value} job={job} /> : null;
-            })}
+            <div className="hidden md:block">
+              <JobActionBar job={job} onRefresh={refreshJob} hideView afterDelete={() => redirect('/jobs')} autoStartQueue />
+            </div>
+            <div className="md:hidden">
+              <JobActionBar job={job} onRefresh={refreshJob} hideView afterDelete={() => redirect('/jobs')} autoStartQueue variant="menu" />
+            </div>
           </>
         )}
-      </MainContent>
-      <div className="bg-gray-800 absolute top-12 left-0 w-full h-8 flex items-center px-2 text-sm">
-        {pages.map(page => {
-          if (page.jobTypes && !page.jobTypes.includes(jobType)) {
-            return null;
-          }
-          return (
-            <Button
-              key={page.value}
-              onClick={() => setPageKey(page.value)}
-              className={`px-4 py-1 h-8 flex items-center gap-1.5 ${page.value === pageKey ? 'bg-gray-300 dark:bg-gray-700 text-white' : ''}`}
-            >
-              <page.icon className="text-sm" />
-              {page.name}
-            </Button>
-          );
-        })}
+      </TopBar>
+
+      {/* Desktop: tab bar */}
+      <div className="bg-gray-800 absolute top-12 left-0 w-full h-8 items-center px-2 text-sm overflow-x-auto hidden md:flex z-[5]">
+        {visiblePages.map(p => (
+          <Button
+            key={p.value}
+            onClick={() => setPageKey(p.value)}
+            className={`px-4 py-1 h-8 flex items-center gap-1.5 ${p.value === pageKey ? 'bg-gray-300 dark:bg-gray-700 text-white' : ''}`}
+          >
+            <p.icon className="text-sm" />
+            {p.name}
+          </Button>
+        ))}
         {page?.menuItem && (
           <>
             <div className="flex-grow"></div>
             <page.menuItem job={job} />
           </>
         )}
+      </div>
+
+      <MainContent className={page?.mainCss}>
+        {status === 'loading' && job == null && <p>Loading...</p>}
+        {status === 'error' && job == null && <p>Error fetching job</p>}
+        {job && pages.map(p => {
+          const Component = p.component;
+          return p.value === pageKey ? <Component key={p.value} job={job} /> : null;
+        })}
+      </MainContent>
+
+      {/* Mobile: bottom tab bar */}
+      <div className="md:hidden fixed bottom-0 left-0 w-full bg-gray-900 border-t border-gray-700 flex items-center justify-around z-20 h-14">
+        {visiblePages.map(p => (
+          <button
+            key={p.value}
+            onClick={() => setPageKey(p.value)}
+            className={`flex flex-col items-center justify-center flex-1 h-full text-xs gap-0.5 ${p.value === pageKey ? 'text-white' : 'text-gray-500'}`}
+          >
+            <p.icon className="text-lg" />
+            {p.name}
+          </button>
+        ))}
       </div>
     </>
   );

--- a/ui/src/app/jobs/new/SimpleJob.tsx
+++ b/ui/src/app/jobs/new/SimpleJob.tsx
@@ -232,6 +232,31 @@ export default function SimpleJob({
         )}
         <div className={topBarClass}>
           <Card title="Job">
+            <SelectInput
+              label="Job Type"
+              value={`${jobConfig.config.process[0].type}`}
+              onChange={value => {
+                const currentOption = jobTypeOptions.find(
+                  option => option.value === jobConfig.config.process[0].type,
+                );
+                if (currentOption && currentOption.onDeactivate) {
+                  setJobConfig(currentOption.onDeactivate(objectCopy(jobConfig)));
+                }
+                const option = jobTypeOptions.find(option => option.value === value);
+                if (option) {
+                  if (option.onActivate) {
+                    setJobConfig(option.onActivate(objectCopy(jobConfig)));
+                  }
+                  jobTypeOptions.forEach(opt => {
+                    if (opt.value !== option.value && opt.onDeactivate) {
+                      setJobConfig(opt.onDeactivate(objectCopy(jobConfig)));
+                    }
+                  });
+                }
+                setJobConfig(value, 'config.process[0].type');
+              }}
+              options={jobTypeOptions}
+            />
             <TextInput
               label="Training Name"
               value={jobConfig.config.name}

--- a/ui/src/app/jobs/new/page.tsx
+++ b/ui/src/app/jobs/new/page.tsx
@@ -14,12 +14,14 @@ import useDatasetList from '@/hooks/useDatasetList';
 import YAML from 'yaml';
 import path from 'path';
 import { TopBar, MainContent } from '@/components/layout';
-import { Button } from '@headlessui/react';
+import { Button, MenuItem } from '@headlessui/react';
 import { FaChevronLeft } from 'react-icons/fa';
+import OverflowMenu from '@/components/OverflowMenu';
 import SimpleJob from './SimpleJob';
 import AdvancedConfigEditor from '@/components/AdvancedConfigEditor';
 import ErrorBoundary from '@/components/ErrorBoundary';
 import { apiClient } from '@/utils/api';
+import { isMac } from '@/helpers/basic';
 
 const isDev = process.env.NODE_ENV === 'development';
 
@@ -195,77 +197,80 @@ export default function TrainingForm() {
             <FaChevronLeft />
           </Button>
         </div>
-        <div>
-          <h1 className="text-lg">{runId ? 'Edit Training Job' : 'New Training Job'}</h1>
+        <div className="min-w-0 flex-1">
+          <h1 className="text-sm md:text-lg truncate">{runId ? 'Edit Training Job' : 'New Training Job'}</h1>
         </div>
-        <div className="flex-1"></div>
-        {showAdvancedView && (
-          <>
-            <div>
-              <SelectInput
-                value={`${gpuIDs}`}
-                onChange={value => setGpuIDs(value)}
-                options={gpuList.map((gpu: any) => ({ value: `${gpu.index}`, label: `GPU #${gpu.index}` }))}
-              />
-            </div>
-            <div className="mx-4 bg-gray-200 dark:bg-gray-800 w-1 h-6"></div>
-            <div>
-              <Button className="text-gray-200 bg-gray-800 px-3 py-1 rounded-md" onClick={handleImportConfig}>
-                Import Config
-              </Button>
-            </div>
-            <div className="mx-4 bg-gray-200 dark:bg-gray-800 w-1 h-6"></div>
-          </>
-        )}
-        {!showAdvancedView && (
-          <>
-            <div>
-              <SelectInput
-                value={`${jobConfig?.config.process[0].type}`}
-                onChange={value => {
-                  // undo current job type changes
-                  const currentOption = jobTypeOptions.find(
-                    option => option.value === jobConfig?.config.process[0].type,
-                  );
-                  if (currentOption && currentOption.onDeactivate) {
-                    setJobConfig(currentOption.onDeactivate(objectCopy(jobConfig)));
-                  }
-                  const option = jobTypeOptions.find(option => option.value === value);
-                  if (option) {
-                    if (option.onActivate) {
-                      setJobConfig(option.onActivate(objectCopy(jobConfig)));
-                    }
-                    jobTypeOptions.forEach(opt => {
-                      if (opt.value !== option.value && opt.onDeactivate) {
-                        setJobConfig(opt.onDeactivate(objectCopy(jobConfig)));
-                      }
-                    });
-                  }
-                  setJobConfig(value, 'config.process[0].type');
-                }}
-                options={jobTypeOptions}
-              />
-            </div>
-            <div className="mx-4 bg-gray-200 dark:bg-gray-800 w-1 h-6"></div>
-          </>
-        )}
-
-        <div className="pr-2">
-          <Button
-            className="text-gray-200 bg-gray-800 px-3 py-1 rounded-md"
-            onClick={() => setShowAdvancedView(!showAdvancedView)}
-          >
-            {showAdvancedView ? 'Show Simple' : 'Show Advanced'}
-          </Button>
+        {/* Desktop: show all controls inline */}
+        <div className="hidden md:flex items-center">
+          {showAdvancedView && (
+            <>
+              {!isMac() && (
+                <>
+                  <div>
+                    <SelectInput
+                      value={`${gpuIDs}`}
+                      onChange={value => setGpuIDs(value)}
+                      options={gpuList.map((gpu: any) => ({ value: `${gpu.index}`, label: `GPU #${gpu.index}` }))}
+                    />
+                  </div>
+                  <div className="mx-4 bg-gray-200 dark:bg-gray-800 w-1 h-6"></div>
+                </>
+              )}
+              <div>
+                <Button className="text-gray-200 bg-gray-800 px-3 py-1 rounded-md" onClick={handleImportConfig}>
+                  Import Config
+                </Button>
+              </div>
+              <div className="mx-4 bg-gray-200 dark:bg-gray-800 w-1 h-6"></div>
+            </>
+          )}
+          <div className="pr-2">
+            <Button
+              className="text-gray-200 bg-gray-800 px-3 py-1 rounded-md whitespace-nowrap"
+              onClick={() => setShowAdvancedView(!showAdvancedView)}
+            >
+              {showAdvancedView ? 'Show Simple' : 'Show Advanced'}
+            </Button>
+          </div>
+          <div>
+            <Button
+              className="text-white bg-green-600 hover:bg-green-700 px-3 py-1 rounded-md whitespace-nowrap"
+              onClick={() => saveJob()}
+              disabled={status === 'saving'}
+            >
+              {status === 'saving' ? 'Saving...' : runId ? 'Update Job' : 'Create Job'}
+            </Button>
+          </div>
         </div>
-        <div>
+        {/* Mobile: create button + overflow menu */}
+        <div className="flex md:hidden items-center gap-1">
           <Button
-            className="text-white bg-green-600 hover:bg-green-700 px-3 py-1 rounded-md"
+            className="text-white bg-green-600 hover:bg-green-700 px-2 py-1 rounded-md text-xs whitespace-nowrap"
             onClick={() => saveJob()}
             disabled={status === 'saving'}
           >
-            {status === 'saving' ? 'Saving...' : runId ? 'Update Job' : 'Create Job'}
+            {status === 'saving' ? 'Saving...' : runId ? 'Update' : 'Create'}
           </Button>
+          <OverflowMenu>
+              <MenuItem>
+                <button
+                  className="w-full text-left cursor-pointer px-4 py-1 hover:bg-gray-800 rounded"
+                  onClick={() => setShowAdvancedView(!showAdvancedView)}
+                >
+                  {showAdvancedView ? 'Show Simple' : 'Show Advanced'}
+                </button>
+              </MenuItem>
+              {showAdvancedView && (
+                <MenuItem>
+                  <button
+                    className="w-full text-left cursor-pointer px-4 py-1 hover:bg-gray-800 rounded"
+                    onClick={handleImportConfig}
+                  >
+                    Import Config
+                  </button>
+                </MenuItem>
+              )}
+          </OverflowMenu>
         </div>
       </TopBar>
 
@@ -277,8 +282,17 @@ export default function TrainingForm() {
         onChange={handleFileSelected}
       />
 
+      {showAdvancedView && !isMac() && (
+        <div className="md:hidden bg-gray-900 border-t border-gray-800 absolute top-12 left-0 w-full h-10 flex items-center px-3 gap-2 text-sm z-[5]">
+          <SelectInput
+            value={`${gpuIDs}`}
+            onChange={value => setGpuIDs(value)}
+            options={gpuList.map((gpu: any) => ({ value: `${gpu.index}`, label: `GPU #${gpu.index}` }))}
+          />
+        </div>
+      )}
       {showAdvancedView ? (
-        <div className="pt-[48px] absolute top-0 left-0 w-full h-full overflow-auto">
+        <div className={`${!isMac() ? 'pt-[88px]' : 'pt-[48px]'} md:pt-[48px] absolute top-0 left-0 w-full h-full overflow-auto`}>
           <AdvancedConfigEditor
             config={jobConfig}
             setConfig={setJobConfig}

--- a/ui/src/app/jobs/page.tsx
+++ b/ui/src/app/jobs/page.tsx
@@ -3,18 +3,20 @@
 import JobsTable from '@/components/JobsTable';
 import { TopBar, MainContent } from '@/components/layout';
 import Link from 'next/link';
+import { Plus } from 'lucide-react';
 
 export default function Dashboard() {
   return (
     <>
       <TopBar>
         <div>
-          <h1 className="text-lg">Queue</h1>
+          <h1 className="text-sm md:text-lg">Queue</h1>
         </div>
         <div className="flex-1"></div>
         <div>
-          <Link href="/jobs/new" className="text-white bg-slate-600 px-3 py-1 rounded-md">
-            New Training Job
+          <Link href="/jobs/new" className="text-white bg-slate-600 px-3 py-1 rounded-md flex items-center gap-1.5">
+            <Plus className="w-4 h-4" />
+            <span className="whitespace-nowrap">New Training Job</span>
           </Link>
         </div>
       </TopBar>

--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -44,7 +44,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <script dangerouslySetInnerHTML={{ __html: `window.server_platform = "${platform}";` }} />
         <ThemeProvider>
           <AuthWrapper authRequired={authRequired}>
-            <div className="flex h-screen bg-gray-950">
+            <div className="flex h-dvh bg-gray-950">
               <Sidebar />
               <main className="flex-1 overflow-auto bg-gray-950 text-gray-100 relative">
                 <Suspense>{children}</Suspense>

--- a/ui/src/app/settings/page.tsx
+++ b/ui/src/app/settings/page.tsx
@@ -36,7 +36,7 @@ export default function Settings() {
     <>
       <TopBar>
         <div>
-          <h1 className="text-lg">Settings</h1>
+          <h1 className="text-sm md:text-lg">Settings</h1>
         </div>
         <div className="flex-1"></div>
       </TopBar>

--- a/ui/src/components/AddImagesModal.tsx
+++ b/ui/src/components/AddImagesModal.tsx
@@ -245,7 +245,7 @@ export default function AddImagesModal() {
       />
 
       <div className="fixed inset-0 z-10 w-screen overflow-y-auto">
-        <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+        <div className="flex min-h-full items-center justify-center p-4 text-center sm:p-0">
           <DialogPanel
             transition
             className="relative transform overflow-hidden rounded-lg bg-gray-800 text-left shadow-xl transition-all data-closed:translate-y-4 data-closed:opacity-0 data-enter:duration-300 data-enter:ease-out data-leave:duration-200 data-leave:ease-in sm:my-8 sm:w-full sm:max-w-lg data-closed:sm:translate-y-0 data-closed:sm:scale-95"

--- a/ui/src/components/AddSingleImageModal.tsx
+++ b/ui/src/components/AddSingleImageModal.tsx
@@ -88,7 +88,7 @@ export default function AddSingleImageModal() {
       />
 
       <div className="fixed inset-0 z-10 w-screen overflow-y-auto">
-        <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+        <div className="flex min-h-full items-center justify-center p-4 text-center sm:p-0">
           <DialogPanel
             transition
             className="relative transform overflow-hidden rounded-lg bg-gray-800 text-left shadow-xl transition-all data-closed:translate-y-4 data-closed:opacity-0 data-enter:duration-300 data-enter:ease-out data-leave:duration-200 data-leave:ease-in sm:my-8 sm:w-full sm:max-w-lg data-closed:sm:translate-y-0 data-closed:sm:scale-95"

--- a/ui/src/components/ConfirmModal.tsx
+++ b/ui/src/components/ConfirmModal.tsx
@@ -141,7 +141,7 @@ export default function ConfirmModal() {
       />
 
       <div className="fixed inset-0 z-10 w-screen overflow-y-auto">
-        <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+        <div className="flex min-h-full items-center justify-center p-4 text-center sm:p-0">
           <DialogPanel
             transition
             className="relative transform overflow-hidden rounded-lg bg-gray-800 text-left shadow-xl transition-all data-closed:translate-y-4 data-closed:opacity-0 data-enter:duration-300 data-enter:ease-out data-leave:duration-200 data-leave:ease-in sm:my-8 sm:w-full sm:max-w-lg data-closed:sm:translate-y-0 data-closed:sm:scale-95"

--- a/ui/src/components/DocModal.tsx
+++ b/ui/src/components/DocModal.tsx
@@ -26,7 +26,7 @@ export default function DocModal() {
       />
 
       <div className="fixed inset-0 z-10 w-screen overflow-y-auto">
-        <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+        <div className="flex min-h-full items-center justify-center p-4 text-center sm:p-0">
           <DialogPanel
             transition
             className="relative transform overflow-hidden rounded-lg bg-gray-800 text-left shadow-xl transition-all data-closed:translate-y-4 data-closed:opacity-0 data-enter:duration-300 data-enter:ease-out data-leave:duration-200 data-leave:ease-in sm:my-8 sm:w-full sm:max-w-[50rem] data-closed:sm:translate-y-0 data-closed:sm:scale-95"

--- a/ui/src/components/JobActionBar.tsx
+++ b/ui/src/components/JobActionBar.tsx
@@ -1,13 +1,13 @@
 import Link from 'next/link';
-import { Eye, Trash2, Pen, Play, Pause, Cog, X } from 'lucide-react';
+import { Eye, Trash2, Pen, Play, Pause, Cog, X, Copy, AlertTriangle } from 'lucide-react';
 import { Button } from '@headlessui/react';
 import { openConfirm } from '@/components/ConfirmModal';
 import { Job } from '@prisma/client';
 import { startJob, stopJob, deleteJob, getAvaliableJobActions, markJobAsStopped } from '@/utils/jobs';
 import { startQueue } from '@/utils/queue';
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
-import { redirect } from 'next/navigation';
 import { openCaptionDatasetModal } from '@/components/CaptionDatasetModal';
+import OverflowMenu from './OverflowMenu';
 
 interface JobActionBarProps {
   job: Job;
@@ -16,6 +16,8 @@ interface JobActionBarProps {
   hideView?: boolean;
   className?: string;
   autoStartQueue?: boolean;
+  variant?: 'inline' | 'menu';
+  stopPropagation?: boolean;
 }
 
 export default function JobActionBar({
@@ -25,150 +27,165 @@ export default function JobActionBar({
   className,
   hideView,
   autoStartQueue = false,
+  variant = 'inline',
+  stopPropagation = false,
 }: JobActionBarProps) {
   const { canStart, canStop, canDelete, canEdit, canRemoveFromQueue } = getAvaliableJobActions(job);
 
   if (!afterDelete) afterDelete = onRefresh;
 
-  return (
-    <div className={`${className}`}>
-      {canStart && (
-        <Button
-          onClick={async () => {
-            if (!canStart) return;
-            await startJob(job.id);
-            // start the queue as well
-            if (autoStartQueue) {
-              await startQueue(job.gpu_ids);
-            }
-            if (onRefresh) onRefresh();
-          }}
-          className={`ml-2 opacity-100`}
-        >
-          <Play />
-        </Button>
-      )}
-      {canRemoveFromQueue && (
-        <Button
-          onClick={async () => {
-            if (!canRemoveFromQueue) return;
-            await markJobAsStopped(job.id);
-            if (onRefresh) onRefresh();
-          }}
-          className={`ml-2 opacity-100`}
-        >
-          <X />
-        </Button>
-      )}
-      {canStop && (
-        <Button
-          onClick={() => {
-            if (!canStop) return;
-            openConfirm({
-              title: 'Stop Job',
-              message: `Are you sure you want to stop the job "${job.name}"? You CAN resume later.`,
-              type: 'info',
-              confirmText: 'Stop',
-              onConfirm: async () => {
-                await stopJob(job.id);
-                if (onRefresh) onRefresh();
-              },
-            });
-          }}
-          className={`ml-2 opacity-100`}
-        >
-          <Pause />
-        </Button>
-      )}
-      {!hideView && (
-        <Link href={`/jobs/${job.id}`} className="ml-2 text-gray-200 hover:text-gray-100 inline-block">
-          <Eye />
-        </Link>
-      )}
-      {job.job_type === 'caption' && canEdit && (
-        <div
-          className="ml-2 hover:text-gray-100 inline-block cursor-pointer"
-          onClick={() =>
-            openCaptionDatasetModal(
-              job.job_ref || '',
-              () => {
-                if (onRefresh) onRefresh();
-              },
-              { jobId: job.id },
-            )
-          }
-        >
-          <Pen />
-        </div>
-      )}
-      {job.job_type === 'train' && canEdit && (
-        <Link href={`/jobs/new?id=${job.id}`} className="ml-2 hover:text-gray-100 inline-block">
-          <Pen />
-        </Link>
-      )}
-      <Button
-        onClick={() => {
-          let message = `Are you sure you want to delete the job "${job.name}"? This will also permanently remove it from your disk.`;
-          if (job.status === 'running') {
-            message += ' WARNING: The job is currently running. You should stop it first if you can.';
-          }
-          openConfirm({
-            title: 'Delete Job',
-            message: message,
-            type: 'warning',
-            confirmText: 'Delete',
-            onConfirm: async () => {
-              if (job.status === 'running') {
-                try {
-                  await stopJob(job.id);
-                } catch (e) {
-                  console.error('Error stopping job before deleting:', e);
-                }
-              }
-              await deleteJob(job.id);
-              if (afterDelete) afterDelete();
-            },
-          });
-        }}
-        className={`ml-2 opacity-100`}
-      >
-        <Trash2 />
-      </Button>
-      <div className="border-r border-1 border-gray-700 ml-2 inline"></div>
-      <Menu>
-        <MenuButton className={'ml-2'}>
-          <Cog />
-        </MenuButton>
-        <MenuItems anchor="bottom" className="bg-gray-900 border border-gray-700 rounded shadow-lg w-48 px-2 py-2 mt-4">
+  const wrap = (fn: (e: React.MouseEvent) => void) => (e: React.MouseEvent) => {
+    if (stopPropagation) e.stopPropagation();
+    fn(e);
+  };
+
+  const handleStart = wrap(async () => {
+    await startJob(job.id);
+    if (autoStartQueue) await startQueue(job.gpu_ids);
+    onRefresh?.();
+  });
+
+  const handleStop = wrap(() => {
+    openConfirm({
+      title: 'Stop Job',
+      message: `Are you sure you want to stop the job "${job.name}"? You CAN resume later.`,
+      type: 'info',
+      confirmText: 'Stop',
+      onConfirm: async () => { await stopJob(job.id); onRefresh?.(); },
+    });
+  });
+
+  const handleRemoveFromQueue = wrap(async () => {
+    await markJobAsStopped(job.id);
+    onRefresh?.();
+  });
+
+  const handleEdit = wrap(() => {
+    if (job.job_type === 'caption') {
+      openCaptionDatasetModal(job.job_ref || '', () => onRefresh?.(), { jobId: job.id });
+    }
+  });
+
+  const handleDelete = wrap(() => {
+    let message = `Are you sure you want to delete the job "${job.name}"? This will also permanently remove it from your disk.`;
+    if (job.status === 'running') {
+      message += ' WARNING: The job is currently running. You should stop it first if you can.';
+    }
+    openConfirm({
+      title: 'Delete Job',
+      message,
+      type: 'warning',
+      confirmText: 'Delete',
+      onConfirm: async () => {
+        if (job.status === 'running') {
+          try { await stopJob(job.id); } catch (e) { console.error('Error stopping job before deleting:', e); }
+        }
+        await deleteJob(job.id);
+        afterDelete?.();
+      },
+    });
+  });
+
+  const handleMarkStopped = wrap(() => {
+    openConfirm({
+      title: 'Mark Job as Stopped',
+      message: `Are you sure you want to mark this job as stopped? This will set the job status to 'stopped' if the status is hung. Only do this if you are 100% sure the job is stopped. This will NOT stop the job.`,
+      type: 'warning',
+      confirmText: 'Mark as Stopped',
+      onConfirm: async () => { await markJobAsStopped(job.id); onRefresh?.(); },
+    });
+  });
+
+  if (variant === 'menu') {
+    const menuItemClass = 'w-full text-left cursor-pointer px-4 py-1.5 hover:bg-gray-800 rounded flex items-center gap-2 text-sm';
+    return (
+      <div className={className}>
+        <OverflowMenu onClick={stopPropagation ? (e) => e.stopPropagation() : undefined}>
+          {!hideView && (
+            <MenuItem>
+              <Link href={`/jobs/${job.id}`} className={menuItemClass} onClick={stopPropagation ? (e: React.MouseEvent) => e.stopPropagation() : undefined}>
+                <Eye className="w-4 h-4" /> View
+              </Link>
+            </MenuItem>
+          )}
+          {canStart && (
+            <MenuItem>
+              <button className={menuItemClass} onClick={handleStart}><Play className="w-4 h-4" /> Start</button>
+            </MenuItem>
+          )}
+          {canStop && (
+            <MenuItem>
+              <button className={menuItemClass} onClick={handleStop}><Pause className="w-4 h-4" /> Stop</button>
+            </MenuItem>
+          )}
+          {canRemoveFromQueue && (
+            <MenuItem>
+              <button className={menuItemClass} onClick={handleRemoveFromQueue}><X className="w-4 h-4" /> Remove from Queue</button>
+            </MenuItem>
+          )}
+          {job.job_type === 'train' && canEdit && (
+            <MenuItem>
+              <Link href={`/jobs/new?id=${job.id}`} className={menuItemClass} onClick={stopPropagation ? (e: React.MouseEvent) => e.stopPropagation() : undefined}>
+                <Pen className="w-4 h-4" /> Edit
+              </Link>
+            </MenuItem>
+          )}
+          {job.job_type === 'caption' && canEdit && (
+            <MenuItem>
+              <button className={menuItemClass} onClick={handleEdit}><Pen className="w-4 h-4" /> Edit</button>
+            </MenuItem>
+          )}
+          <MenuItem>
+            <button className={menuItemClass} onClick={handleDelete}><Trash2 className="w-4 h-4" /> Delete</button>
+          </MenuItem>
+          <div className="border-t border-gray-700 my-1"></div>
           {job.job_type === 'train' && (
             <MenuItem>
-              <Link
-                href={`/jobs/new?cloneId=${job.id}`}
-                className="cursor-pointer px-4 py-1 hover:bg-gray-800 rounded block"
-              >
-                Clone Job
+              <Link href={`/jobs/new?cloneId=${job.id}`} className={menuItemClass} onClick={stopPropagation ? (e: React.MouseEvent) => e.stopPropagation() : undefined}>
+                <Copy className="w-4 h-4" /> Clone Job
               </Link>
             </MenuItem>
           )}
           <MenuItem>
-            <div
-              className="cursor-pointer px-4 py-1 hover:bg-gray-800 rounded"
-              onClick={() => {
-                let message = `Are you sure you want to mark this job as stopped? This will set the job status to 'stopped' if the status is hung. Only do this if you are 100% sure the job is stopped. This will NOT stop the job.`;
-                openConfirm({
-                  title: 'Mark Job as Stopped',
-                  message: message,
-                  type: 'warning',
-                  confirmText: 'Mark as Stopped',
-                  onConfirm: async () => {
-                    await markJobAsStopped(job.id);
-                    onRefresh && onRefresh();
-                  },
-                });
-              }}
-            >
-              Mark as Stopped
-            </div>
+            <button className={menuItemClass} onClick={handleMarkStopped}><AlertTriangle className="w-4 h-4" /> Mark as Stopped</button>
+          </MenuItem>
+        </OverflowMenu>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`${className}`}>
+      {canStart && (
+        <Button onClick={handleStart} className="ml-2 opacity-100"><Play /></Button>
+      )}
+      {canRemoveFromQueue && (
+        <Button onClick={handleRemoveFromQueue} className="ml-2 opacity-100"><X /></Button>
+      )}
+      {canStop && (
+        <Button onClick={handleStop} className="ml-2 opacity-100"><Pause /></Button>
+      )}
+      {!hideView && (
+        <Link href={`/jobs/${job.id}`} className="ml-2 text-gray-200 hover:text-gray-100 inline-block"><Eye /></Link>
+      )}
+      {job.job_type === 'caption' && canEdit && (
+        <div className="ml-2 hover:text-gray-100 inline-block cursor-pointer" onClick={handleEdit}><Pen /></div>
+      )}
+      {job.job_type === 'train' && canEdit && (
+        <Link href={`/jobs/new?id=${job.id}`} className="ml-2 hover:text-gray-100 inline-block"><Pen /></Link>
+      )}
+      <Button onClick={handleDelete} className="ml-2 opacity-100"><Trash2 /></Button>
+      <div className="border-r border-1 border-gray-700 ml-2 inline"></div>
+      <Menu>
+        <MenuButton className="ml-2"><Cog /></MenuButton>
+        <MenuItems anchor="bottom" className="bg-gray-900 border border-gray-700 rounded shadow-lg w-56 px-2 py-2 mt-4">
+          {job.job_type === 'train' && (
+            <MenuItem>
+              <Link href={`/jobs/new?cloneId=${job.id}`} className="cursor-pointer px-4 py-1 hover:bg-gray-800 rounded block">Clone Job</Link>
+            </MenuItem>
+          )}
+          <MenuItem>
+            <div className="cursor-pointer px-4 py-1 hover:bg-gray-800 rounded" onClick={handleMarkStopped}>Mark as Stopped</div>
           </MenuItem>
         </MenuItems>
       </Menu>

--- a/ui/src/components/JobOverview.tsx
+++ b/ui/src/components/JobOverview.tsx
@@ -92,7 +92,7 @@ export default function JobOverview({ job }: JobOverviewProps) {
   return (
     <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
       {/* Job Information Panel */}
-      <div className="col-span-2 bg-gray-900 rounded-xl shadow-lg overflow-hidden border border-gray-800 flex flex-col">
+      <div className="col-span-1 md:col-span-2 bg-gray-900 rounded-xl shadow-lg overflow-hidden border border-gray-800 flex flex-col">
         <div className="bg-gray-800 px-4 py-3 flex items-center justify-between">
           <h2 className="text-gray-100">
             <Info className="w-5 h-5 mr-2 -mt-1 text-amber-600 dark:text-amber-400 inline-block" /> {job.info}

--- a/ui/src/components/JobsTable.tsx
+++ b/ui/src/components/JobsTable.tsx
@@ -56,6 +56,7 @@ export default function JobsTable({ onlyActive = false, job_type = null }: JobsT
     {
       title: 'Steps',
       key: 'steps',
+      hideOnMobile: true,
       render: row => {
         const jobConfig: JobConfig = JSON.parse(row.job_config);
         if (row.job_type !== 'train') {
@@ -81,6 +82,7 @@ export default function JobsTable({ onlyActive = false, job_type = null }: JobsT
     {
       title: 'GPU',
       key: 'gpu_ids',
+      hideOnMobile: true,
     },
     {
       title: 'Status',
@@ -97,14 +99,19 @@ export default function JobsTable({ onlyActive = false, job_type = null }: JobsT
     {
       title: 'Info',
       key: 'info',
+      hideOnMobile: true,
       className: 'truncate max-w-xs',
     },
     {
       title: 'Actions',
       key: 'actions',
       className: 'text-right',
+      mobileAlignRight: true,
       render: row => {
         return <JobActionBar job={row} onRefresh={refreshJobs} autoStartQueue={false} />;
+      },
+      mobileRender: row => {
+        return <JobActionBar job={row} onRefresh={refreshJobs} variant="menu" stopPropagation />;
       },
     },
   ];
@@ -165,33 +172,33 @@ export default function JobsTable({ onlyActive = false, job_type = null }: JobsT
                   { 'bg-red-600 dark:bg-red-900': !queue?.is_running },
                 )}
               >
-                <div className="flex items-center space-x-2 flex-1 py-2">
-                  <h2 className="font-semibold text-white">{jobsDict[gpuKey].name}</h2>
-                  <span className="px-2 py-0.5 bg-gray-700 rounded-full text-xs text-gray-300"># {queue?.gpu_ids}</span>
+                <div className="flex items-center space-x-2 flex-1 py-2 min-w-0">
+                  <h2 className="font-semibold text-white truncate text-sm md:text-base">{jobsDict[gpuKey].name}</h2>
+                  <span className="px-2 py-0.5 bg-gray-700 rounded-full text-xs text-gray-300 shrink-0 whitespace-nowrap"># {queue?.gpu_ids}</span>
                 </div>
-                <div className="text-sm text-gray-300 italic flex items-center">
+                <div className="text-sm text-gray-300 italic flex items-center shrink-0">
                   {queue?.is_running ? (
                     <>
-                      <span className="text-green-100 dark:text-green-400 mr-2">Queue Running</span>
+                      <span className="text-green-100 dark:text-green-400 mr-2 hidden md:inline">Queue Running</span>
                       <button
                         onClick={async () => {
                           await stopQueue(queue.gpu_ids as string);
                           refresh();
                         }}
-                        className="ml-4 text-xs text-white bg-red-600 hover:bg-red-700 px-2 py-1 rounded"
+                        className="text-xs text-white bg-red-600 hover:bg-red-700 px-2 py-1 rounded"
                       >
                         STOP
                       </button>
                     </>
                   ) : (
                     <>
-                      <span className="text-red-100 dark:text-red-400 mr-2">Queue Stopped</span>
+                      <span className="text-red-100 dark:text-red-400 mr-2 hidden md:inline">Queue Stopped</span>
                       <button
                         onClick={async () => {
                           await startQueue(gpuKey);
                           refresh();
                         }}
-                        className="ml-4 text-xs text-white bg-green-600 hover:bg-green-700 px-2 py-1 rounded"
+                        className="text-xs text-white bg-green-600 hover:bg-green-700 px-2 py-1 rounded"
                       >
                         START
                       </button>

--- a/ui/src/components/Modal.tsx
+++ b/ui/src/components/Modal.tsx
@@ -68,7 +68,7 @@ export const Modal: React.FC<ModalProps> = ({
       >
         {/* Modal panel */}
         <div
-          className={`relative mx-auto w-full ${sizeClasses[size]} rounded-lg bg-white dark:bg-gray-900 border border-gray-700 shadow-xl transition-all`}
+          className={`relative mx-auto w-full ${sizeClasses[size]} md:rounded-lg bg-white dark:bg-gray-900 md:border border-gray-700 shadow-xl transition-all min-h-dvh md:min-h-0 flex flex-col md:block`}
           onClick={e => e.stopPropagation()}
         >
           {/* Modal header */}

--- a/ui/src/components/OverflowMenu.tsx
+++ b/ui/src/components/OverflowMenu.tsx
@@ -1,0 +1,20 @@
+import { MoreVertical } from 'lucide-react';
+import { Menu, MenuButton, MenuItems } from '@headlessui/react';
+
+interface OverflowMenuProps {
+  children: React.ReactNode;
+  onClick?: (e: React.MouseEvent) => void;
+}
+
+export default function OverflowMenu({ children, onClick }: OverflowMenuProps) {
+  return (
+    <Menu>
+      <MenuButton className="p-1 text-gray-300 hover:text-white" onClick={onClick}>
+        <MoreVertical className="w-5 h-5" />
+      </MenuButton>
+      <MenuItems anchor="bottom end" className="bg-gray-900 border border-gray-700 rounded shadow-lg w-56 px-2 py-2 mt-4 z-50">
+        {children}
+      </MenuItems>
+    </Menu>
+  );
+}

--- a/ui/src/components/SampleImages.tsx
+++ b/ui/src/components/SampleImages.tsx
@@ -137,7 +137,7 @@ export default function SampleImages({ job }: SampleImagesProps) {
 
     return (
       <div
-        className={`mt-10 flex flex-col items-center justify-center py-16 px-8 rounded-xl border-2 border-gray-700 border-dashed ${bgColor} ${textColor} mx-auto max-w-md text-center`}
+        className={`flex flex-col items-center justify-center py-16 px-8 rounded-xl border-2 border-gray-700 border-dashed ${bgColor} ${textColor} mx-auto max-w-md text-center`}
       >
         <div className={`${iconColor} mb-4`}>{icon}</div>
         <h3 className="text-lg font-semibold mb-2">{text}</h3>
@@ -255,7 +255,7 @@ export default function SampleImages({ job }: SampleImagesProps) {
   }, [status, sampleImages.length]);
 
   return (
-    <div ref={containerRef} className="absolute top-[80px] left-0 right-0 bottom-0 overflow-y-auto">
+    <div ref={containerRef} className="absolute top-[56px] md:top-[80px] left-0 right-0 bottom-14 md:bottom-0 overflow-y-auto px-4 md:px-0 pt-2 md:pt-0">
       <div className="pb-4">
         {PageInfoContent}
         {sampleImages && (
@@ -303,20 +303,24 @@ export default function SampleImages({ job }: SampleImagesProps) {
         sampleConfig={sampleConfig}
         refreshSampleImages={refreshSampleImages}
       />
-      <div
-        className="fixed top-20 mt-4 right-6 w-10 h-10 rounded-full bg-gray-900 shadow-lg flex items-center justify-center text-white opacity-80 hover:opacity-100 cursor-pointer"
-        onClick={scrollToTop}
-        title="Scroll to Top"
-      >
-        <FaCaretUp className="text-gray-500 dark:text-gray-400" />
-      </div>
-      <div
-        className="fixed bottom-5 right-6 w-10 h-10 rounded-full bg-gray-900 shadow-lg flex items-center justify-center text-white opacity-80 hover:opacity-100 cursor-pointer"
-        onClick={scrollToBottom}
-        title="Scroll to Bottom"
-      >
-        <FaCaretDown className="text-gray-500 dark:text-gray-400" />
-      </div>
+      {sampleImages.length > 0 && (
+        <>
+          <div
+            className="fixed top-20 mt-4 right-6 w-10 h-10 rounded-full bg-gray-900 shadow-lg flex items-center justify-center text-white opacity-80 hover:opacity-100 cursor-pointer"
+            onClick={scrollToTop}
+            title="Scroll to Top"
+          >
+            <FaCaretUp className="text-gray-500 dark:text-gray-400" />
+          </div>
+          <div
+            className="fixed bottom-5 right-6 w-10 h-10 rounded-full bg-gray-900 shadow-lg flex items-center justify-center text-white opacity-80 hover:opacity-100 cursor-pointer"
+            onClick={scrollToBottom}
+            title="Scroll to Bottom"
+          >
+            <FaCaretDown className="text-gray-500 dark:text-gray-400" />
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -1,10 +1,19 @@
+'use client';
+
 import Link from 'next/link';
-import { Home, Settings, BrainCircuit, Images, Plus } from 'lucide-react';
+import { Home, Settings, BrainCircuit, Images, Plus, ChevronLeft } from 'lucide-react';
 import { FaXTwitter, FaDiscord, FaYoutube } from 'react-icons/fa6';
 import ThemeToggle from './ThemeToggle';
 import ThemeLogo from './ThemeLogo';
+import { createGlobalState } from 'react-global-hooks';
+
+export const sidebarOpenState = createGlobalState(false);
+
+export const toggleSidebar = () => sidebarOpenState.set(!sidebarOpenState.get());
 
 const Sidebar = () => {
+  const [mobileOpen, setMobileOpen] = sidebarOpenState.use();
+
   const navigation = [
     { name: 'Dashboard', href: '/dashboard', icon: Home },
     { name: 'New Job', href: '/jobs/new', icon: Plus },
@@ -18,67 +27,79 @@ const Sidebar = () => {
   const socialIconClass = 'w-5 h-5 text-gray-400 hover:text-white';
 
   return (
-    <div className="flex flex-col w-59 bg-gray-900 text-gray-100">
-      <div className="px-4 py-3">
-        <h1 className="text-l">
-          <ThemeLogo />
-          <span className="font-bold uppercase">Ostris</span>
-          <span className="ml-2 uppercase text-gray-300">AI-Toolkit</span>
-        </h1>
-      </div>
-      <nav className="flex-1">
-        <ul className="px-2 py-4 space-y-2">
-          {navigation.map(item => (
-            <li key={item.name}>
-              <Link
-                href={item.href}
-                className="flex items-center px-4 py-2 text-gray-300 hover:bg-gray-800 rounded-lg transition-colors"
-              >
-                <item.icon className="w-5 h-5 mr-3" />
-                {item.name}
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </nav>
-      <a
-        href="https://ostris.com/support"
-        target="_blank"
-        rel="noreferrer"
-        className="flex items-center space-x-2 px-4 py-3"
-      >
-        <div className="min-w-[26px] min-h-[26px]">
-          <svg height="24" version="1.1" width="24" xmlns="http://www.w3.org/2000/svg">
-            <g transform="translate(0 -1028.4)">
-              <path
-                d="m7 1031.4c-1.5355 0-3.0784 0.5-4.25 1.7-2.3431 2.4-2.2788 6.1 0 8.5l9.25 9.8 9.25-9.8c2.279-2.4 2.343-6.1 0-8.5-2.343-2.3-6.157-2.3-8.5 0l-0.75 0.8-0.75-0.8c-1.172-1.2-2.7145-1.7-4.25-1.7z"
-                fill="#c0392b"
-              />
-            </g>
-          </svg>
+    <>
+      {mobileOpen && (
+        <div
+          className="fixed inset-0 bg-black/50 z-30 md:hidden"
+          onClick={() => setMobileOpen(false)}
+        />
+      )}
+      <div className={`flex flex-col w-59 bg-gray-900 text-gray-100 shrink-0 transition-transform z-40 fixed inset-y-0 left-0 md:relative ${mobileOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'}`}>
+        <div className="px-4 py-3 flex items-center">
+          <h1 className="text-l flex items-center flex-1">
+            <ThemeLogo />
+            <span className="font-bold uppercase">Ostris</span>
+            <span className="ml-2 uppercase text-gray-300">AI-Toolkit</span>
+          </h1>
+          <button
+            className="md:hidden p-1 text-gray-400 hover:text-white"
+            onClick={() => setMobileOpen(false)}
+          >
+            <ChevronLeft className="w-5 h-5" />
+          </button>
         </div>
-        <div className="uppercase text-gray-500 text-sm mb-2 flex-1 pt-2 pl-0">Support AI-Toolkit</div>
-      </a>
+        <nav className="flex-1">
+          <ul className="px-2 py-4 space-y-2">
+            {navigation.map(item => (
+              <li key={item.name}>
+                <Link
+                  href={item.href}
+                  onClick={() => setMobileOpen(false)}
+                  className="flex items-center px-4 py-2 text-gray-300 hover:bg-gray-800 rounded-lg transition-colors"
+                >
+                  <item.icon className="w-5 h-5 mr-3 shrink-0" />
+                  {item.name}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </nav>
+        <a
+          href="https://ostris.com/support"
+          target="_blank"
+          rel="noreferrer"
+          className="flex items-center space-x-2 px-4 py-3"
+        >
+          <div className="min-w-[26px] min-h-[26px]">
+            <svg height="24" version="1.1" width="24" xmlns="http://www.w3.org/2000/svg">
+              <g transform="translate(0 -1028.4)">
+                <path
+                  d="m7 1031.4c-1.5355 0-3.0784 0.5-4.25 1.7-2.3431 2.4-2.2788 6.1 0 8.5l9.25 9.8 9.25-9.8c2.279-2.4 2.343-6.1 0-8.5-2.343-2.3-6.157-2.3-8.5 0l-0.75 0.8-0.75-0.8c-1.172-1.2-2.7145-1.7-4.25-1.7z"
+                  fill="#c0392b"
+                />
+              </g>
+            </svg>
+          </div>
+          <div className="uppercase text-gray-500 text-sm mb-2 flex-1 pt-2 pl-0">Support AI-Toolkit</div>
+        </a>
 
-      {/* Social links grid */}
-      <div className="px-1 py-1 border-t border-gray-800">
-        <div className="grid grid-cols-4 gap-4">
-          <a href="https://discord.gg/VXmU2f5WEU" target="_blank" rel="noreferrer" className={socialsBoxClass}>
-            <FaDiscord className={socialIconClass} />
-            {/* <span className="text-xs text-gray-500 mt-1">Discord</span> */}
-          </a>
-          <a href="https://www.youtube.com/@ostrisai" target="_blank" rel="noreferrer" className={socialsBoxClass}>
-            <FaYoutube className={socialIconClass} />
-            {/* <span className="text-xs text-gray-500 mt-1">YouTube</span> */}
-          </a>
-          <a href="https://x.com/ostrisai" target="_blank" rel="noreferrer" className={socialsBoxClass}>
-            <FaXTwitter className={socialIconClass} />
-            {/* <span className="text-xs text-gray-500 mt-1">X</span> */}
-          </a>
-          <ThemeToggle />
+        {/* Social links grid */}
+        <div className="px-1 py-1 border-t border-gray-800">
+          <div className="grid grid-cols-4 gap-4 items-center">
+            <a href="https://discord.gg/VXmU2f5WEU" target="_blank" rel="noreferrer" className={socialsBoxClass}>
+              <FaDiscord className={socialIconClass} />
+            </a>
+            <a href="https://www.youtube.com/@ostrisai" target="_blank" rel="noreferrer" className={socialsBoxClass}>
+              <FaYoutube className={socialIconClass} />
+            </a>
+            <a href="https://x.com/ostrisai" target="_blank" rel="noreferrer" className={socialsBoxClass}>
+              <FaXTwitter className={socialIconClass} />
+            </a>
+            <ThemeToggle />
+          </div>
         </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/ui/src/components/UniversalTable.tsx
+++ b/ui/src/components/UniversalTable.tsx
@@ -1,11 +1,18 @@
+'use client';
+
+import { useState } from 'react';
 import Loading from './Loading';
 import classNames from 'classnames';
+import { ChevronDown } from 'lucide-react';
 
 export interface TableColumn {
   title: string;
   key: string;
   render?: (row: any) => React.ReactNode;
+  mobileRender?: (row: any) => React.ReactNode;
   className?: string;
+  hideOnMobile?: boolean;
+  mobileAlignRight?: boolean;
 }
 
 interface TableRow {
@@ -18,6 +25,56 @@ interface TableProps {
   isLoading: boolean;
   theadClassName?: string;
   onRefresh: () => void;
+}
+
+function MobileTable({ columns, rows }: { columns: TableColumn[]; rows: TableRow[] }) {
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
+  const visibleCols = columns.filter(c => !c.hideOnMobile);
+  const hiddenCols = columns.filter(c => c.hideOnMobile);
+
+  return (
+    <div className="divide-y divide-gray-700">
+      {rows.map((row, index) => {
+        const isExpanded = expandedIndex === index;
+        const rowClass = index % 2 === 0 ? 'bg-gray-900' : 'bg-gray-800';
+        return (
+          <div key={index} className={rowClass}>
+            <div
+              className="flex items-center px-3 py-2 gap-2 cursor-pointer"
+              onClick={(e) => {
+                if ((e.target as HTMLElement).closest('a')) return;
+                setExpandedIndex(isExpanded ? null : index);
+              }}
+            >
+              {hiddenCols.length > 0 && (
+                <ChevronDown className={classNames('w-4 h-4 text-gray-500 shrink-0 transition-transform', { 'rotate-180': isExpanded })} />
+              )}
+              {visibleCols.map(col => {
+                const content = col.mobileRender ? col.mobileRender(row) : col.render ? col.render(row) : row[col.key];
+                return (
+                  <div key={col.key} className={classNames('text-sm', col.className, col.mobileAlignRight ? 'ml-auto' : 'min-w-0')}>
+                    {content}
+                  </div>
+                );
+              })}
+            </div>
+            {isExpanded && hiddenCols.length > 0 && (
+              <div className="px-3 pb-3 pt-1 pl-9 space-y-2">
+                {hiddenCols.map(col => (
+                  <div key={col.key} className="flex items-center gap-2 text-sm">
+                    <span className="text-xs uppercase text-gray-500 w-12 shrink-0">{col.title}</span>
+                    <span className={col.className}>
+                      {col.render ? col.render(row) : row[col.key]}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
 }
 
 export default function UniversalTable({
@@ -44,35 +101,40 @@ export default function UniversalTable({
           </button>
         </div>
       ) : (
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm text-left text-gray-300">
-            <thead className={classNames('text-xs uppercase bg-gray-800', theadClassName)}>
-              <tr>
-                {columns.map(column => (
-                  <th key={column.key} className="px-3 py-2">
-                    {column.title}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {rows?.map((row, index) => {
-                // Style for alternating rows
-                const rowClass = index % 2 === 0 ? 'bg-gray-900' : 'bg-gray-800';
-
-                return (
-                  <tr key={index} className={`${rowClass} border-b border-gray-700 hover:bg-gray-700`}>
-                    {columns.map(column => (
-                      <td key={column.key} className={classNames('px-3 py-2', column.className)}>
-                        {column.render ? column.render(row) : row[column.key]}
-                      </td>
-                    ))}
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+        <>
+          {/* Desktop table */}
+          <div className="hidden md:block overflow-x-auto">
+            <table className="w-full text-sm text-left text-gray-300">
+              <thead className={classNames('text-xs uppercase bg-gray-800', theadClassName)}>
+                <tr>
+                  {columns.map(column => (
+                    <th key={column.key} className="px-3 py-2">
+                      {column.title}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {rows?.map((row, index) => {
+                  const rowClass = index % 2 === 0 ? 'bg-gray-900' : 'bg-gray-800';
+                  return (
+                    <tr key={index} className={`${rowClass} border-b border-gray-700 hover:bg-gray-700`}>
+                      {columns.map(column => (
+                        <td key={column.key} className={classNames('px-3 py-2', column.className)}>
+                          {column.render ? column.render(row) : row[column.key]}
+                        </td>
+                      ))}
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+          {/* Mobile expandable rows */}
+          <div className="md:hidden">
+            <MobileTable columns={columns} rows={rows} />
+          </div>
+        </>
       )}
     </div>
   );

--- a/ui/src/components/layout.tsx
+++ b/ui/src/components/layout.tsx
@@ -1,4 +1,8 @@
+'use client';
+
 import classNames from 'classnames';
+import { Menu } from 'lucide-react';
+import { toggleSidebar } from './Sidebar';
 
 interface Props {
   className?: string;
@@ -13,6 +17,12 @@ export const TopBar: React.FC<Props> = ({ children, className }) => {
         className,
       )}
     >
+      <button
+        className="md:hidden p-1 mr-1 text-gray-300 hover:text-white"
+        onClick={toggleSidebar}
+      >
+        <Menu className="w-5 h-5" />
+      </button>
       {children ? children : null}
     </div>
   );


### PR DESCRIPTION
## Description

The next js UI was not mobile friendly, I added mobile versions of things when needed and better breakpoints in areas to make this mobile friendly. I did not touch any functionality, just UX.

### Key changes

**Sidebar** — Hidden on mobile by default. Slides in as a full overlay via a hamburger button in the top bar.

**Jobs Table** — Mobile view uses expandable rows (tap to reveal Steps/GPU/Info). Actions render via `⋮` menu.

**Job Detail Page**: Tabs move to a fixed bottom navigation bar on mobile. Actions use the `⋮` menu.

**New Job Page**: Job type selector moved into the form body in he job card for BOTH mobile and desktop to free up room on the top bar. Also in advanced view the GPU selector is moved as a sub bar under the toolbar for the same reason. anything beyond the hero action is moved into the `⋮` menu.

**Other tables/toolbars/modals**: outside of main job pages, datasets, overview, etc had minor adjustments similar to job pages following the same pattern

### Screenshots

<img width="342" height="449" alt="Screenshot 2026-05-10 at 1 58 36 PM" src="https://github.com/user-attachments/assets/9517e855-3411-4bab-8749-ecbd337c5e2a" />
<img width="334" height="192" alt="Screenshot 2026-05-10 at 1 58 27 PM" src="https://github.com/user-attachments/assets/ec4a02fe-d812-4576-aea5-892f8c2b3367" />
<img width="340" height="188" alt="Screenshot 2026-05-10 at 1 58 17 PM" src="https://github.com/user-attachments/assets/29697f45-9a44-499b-b4f9-228b76e5cf11" />
<img width="337" height="411" alt="Screenshot 2026-05-10 at 1 57 42 PM" src="https://github.com/user-attachments/assets/92c11893-4b13-4d5d-8eb8-a3a585e88ac4" />
<img width="339" height="733" alt="Screenshot 2026-05-10 at 1 57 02 PM" src="https://github.com/user-attachments/assets/4c69ebd2-0859-4276-a088-a7900449f304" />
<img width="339" height="733" alt="Screenshot 2026-05-10 at 1 56 04 PM" src="https://github.com/user-attachments/assets/fd0a378d-5b57-47ac-8d37-e8262925f9d7" />
<img width="339" height="733" alt="Screenshot 2026-05-10 at 1 54 49 PM" src="https://github.com/user-attachments/assets/2189f994-9332-4eb2-9caf-00bf81c11af2" />
<img width="339" height="733" alt="Screenshot 2026-05-10 at 1 54 39 PM" src="https://github.com/user-attachments/assets/6a3671fb-7f35-4174-8ca7-90d65337ff5f" />
<img width="412" height="437" alt="Screenshot 2026-05-10 at 1 16 43 PM" src="https://github.com/user-attachments/assets/a283bc4b-6b18-44c9-a2be-50a8e96f7444" />
<img width="336" height="730" alt="Screenshot 2026-05-10 at 2 00 33 PM" src="https://github.com/user-attachments/assets/ae8c65e7-3709-4f0c-824b-c6c36bfb5629" />
<img width="338" height="462" alt="Screenshot 2026-05-10 at 2 00 26 PM" src="https://github.com/user-attachments/assets/fc64ab9b-a2c1-4323-aaac-8e0b1435d4a7" />
<img width="338" height="354" alt="Screenshot 2026-05-10 at 2 00 14 PM" src="https://github.com/user-attachments/assets/2d66c207-6575-492e-95be-a268545ad6c0" />


### Testing

- Open in browser DevTools with mobile viewport
- Verify all functionality still exists on mobile and desktop after UX changes