### PR TITLE
Add dual-GPU model-parallel paths for 8 LoRA-training architectures (FLUX.2 / Wan 2.2 / LTX-2 / Qwen-Image / Chroma / FLUX.1-Kontext / HiDream-I1 / Z-Image)

### DIFF
--- a/extensions_built_in/diffusion_models/chroma/chroma_dual_gpu.py
+++ b/extensions_built_in/diffusion_models/chroma/chroma_dual_gpu.py
@@ -1,0 +1,601 @@
+"""Dual-GPU model-parallel path for Chroma1-HD LoRA training.
+
+Activates when ``CHROMA_DUAL_GPU=true``. Distributes the ``Chroma``
+transformer (ai-toolkit's vendored copy under ``chroma/src/model.py`` —
+Chroma is its own implementation, not a diffusers class) across two CUDA
+devices with a single PCIe boundary mid-``single_blocks``, keeps the T5
+text encoder on a configurable device (``CHROMA_TE_DEVICE``, defaulting
+to ``device_torch``), and reuses the same LoRA / multiplier patches the
+FLUX.2 / Wan 2.2 / LTX-2 / Qwen-Image / HiDream dual-GPU paths install
+(those hook ai-toolkit-wide classes, not model-specific ones, so they
+apply unchanged here — the shared per-target patch flags make calling
+them all safe).
+
+Targets the ai-toolkit Chroma trainer
+(``extensions_built_in/diffusion_models/chroma/chroma_model.py``).
+Integration is a small edit at the call site:
+
+1. Make ``ChromaModel`` inherit from ``ChromaDualGPUMixin`` first
+   (MRO ordering: mixin before ``BaseModel``).
+2. In ``ChromaModel.__init__``, call ``self.init_te_device()`` after the
+   base ``__init__`` to resolve ``te_device_torch``.
+3. In ``ChromaModel.load_model``, after quantize, call
+   ``self.setup_dual_gpu_distribution(transformer, dtype)`` gated by
+   ``is_dual_gpu_enabled()``. Route the T5 ``.to()`` sites to
+   ``self.te_device_torch`` instead of ``self.device_torch`` (the
+   FakeCLIP stub site is a no-op and can stay).
+
+Chroma has the FLUX shape: a sequence of ``double_blocks`` (19), then a
+``cat(txt, img)``, then ``single_blocks`` (38), then a strip + ``final_layer``.
+All loop-invariant tensors (``pe``, ``txt_img_mask``, the modulation-vector
+dict produced once by ``distilled_guidance_layer``) are precomputed before
+the block loops, so a single-boundary forward replacement is sufficient.
+
+The split: all 19 ``double_blocks`` plus ``single_blocks[:split_at]`` live
+on cuda:0; the remaining ``single_blocks`` plus ``final_layer`` live on
+cuda:1, with one PCIe boundary inside the single-block loop. Default
+``split_at = num_single_blocks // 2 = 19``.
+
+Env vars:
+    CHROMA_DUAL_GPU=true              enable the dual-GPU path
+    CHROMA_TE_DEVICE=cpu              pin the T5 text encoder
+    CHROMA_DUAL_GPU_SPLIT_AT=19       override single_blocks split index
+                                      (default: num_single_blocks // 2)
+"""
+from __future__ import annotations
+
+import os
+import types
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from diffusers.utils import logging
+
+if TYPE_CHECKING:
+    from .chroma_model import ChromaModel  # noqa: F401
+
+logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
+
+
+def is_dual_gpu_enabled() -> bool:
+    return os.getenv("CHROMA_DUAL_GPU", "false").lower() == "true"
+
+
+def get_te_device_override() -> torch.device | None:
+    """Returns the text-encoder device override if CHROMA_TE_DEVICE is set."""
+    val = os.getenv("CHROMA_TE_DEVICE")
+    return torch.device(val) if val else None
+
+
+class ChromaDualGPUMixin:
+    """Mixin for :class:`ChromaModel` that adds the dual-GPU training path.
+
+    The mixin contributes:
+
+    - ``te_device_torch`` attribute (resolved from ``CHROMA_TE_DEVICE``
+      or defaulting to ``device_torch``). Always present — used even when
+      dual-GPU itself is disabled.
+    - ``text_encoder_to`` override that routes the T5 text encoder to
+      ``te_device_torch`` instead of ``device_torch``. The CLIP slot in
+      Chroma is a ``FakeCLIP`` stub with no real parameters; iterating
+      the list is harmless.
+    - ``setup_dual_gpu_distribution(transformer, dtype)`` to be called
+      from ``load_model`` after the transformer has been quantized (if
+      applicable) and before the pipeline composes it. Distributes
+      modules across cuda:0/cuda:1, replaces ``Chroma.forward`` with a
+      split-aware variant, pins ``transformer.to()`` to ignore device
+      arguments (preserving the layout against later ai-toolkit ``.to()``
+      calls), and installs the LoRA / multiplier patches.
+    """
+
+    te_device_torch: torch.device
+
+    # ---------------------------------------------------------------- init
+
+    def init_te_device(self) -> None:
+        """Resolve ``te_device_torch`` from env var or fall back to model device.
+
+        Must be called from :meth:`ChromaModel.__init__` after the base
+        ``__init__`` (which establishes ``self.device_torch``).
+        """
+        override = get_te_device_override()
+        self.te_device_torch = override if override is not None else self.device_torch  # type: ignore[attr-defined]
+        if self.te_device_torch.type == "cpu":
+            self.print_and_status_update(  # type: ignore[attr-defined]
+                "CHROMA_TE_DEVICE=cpu — the T5 text encoder will run on CPU. "
+                "Set `cache_text_embeddings: true` in your config so it runs "
+                "once at startup; otherwise it runs on CPU every step."
+            )
+
+    # ----------------------------------------------------------- TE override
+
+    def text_encoder_to(self, *args: Any, **kwargs: Any) -> None:
+        """Override of BaseModel.text_encoder_to that honors te_device_torch.
+
+        ai-toolkit's :class:`SDTrainer` hook ``hook_before_train_loop``
+        calls ``self.sd.text_encoder_to(self.device_torch)``
+        unconditionally. With ``CHROMA_TE_DEVICE=cpu`` we want the T5
+        encoder to stay on CPU regardless. Chroma stores text encoders as
+        a list (``[FakeCLIP, T5]``); iterate it. FakeCLIP's ``.to()`` is
+        benign — it has no real parameters.
+        """
+        target = self.te_device_torch
+        if isinstance(self.text_encoder, list):  # type: ignore[attr-defined]
+            for encoder in self.text_encoder:  # type: ignore[attr-defined]
+                encoder.to(target)
+        else:
+            self.text_encoder.to(target)  # type: ignore[attr-defined]
+
+    # ------------------------------------------------------------ load hook
+
+    def setup_dual_gpu_distribution(self, transformer: torch.nn.Module, dtype: torch.dtype) -> None:
+        """Distribute the Chroma transformer across cuda:0 and cuda:1.
+
+        Layout:
+            cuda:0  — ``img_in``, ``txt_in``, ``pe_embedder``,
+                      ``distilled_guidance_layer``, ALL ``double_blocks``,
+                      ``single_blocks[:split_at]``
+            cuda:1  — ``single_blocks[split_at:]``, ``final_layer``
+
+        ``Chroma`` has one module-level buffer (``mod_index``, non-persistent)
+        which is moved with the parent ``.to(d0, dtype=dtype)`` of the
+        whole transformer at the bottom of this function via the explicit
+        per-submodule ``.to()`` calls — except ``mod_index`` lives directly
+        on the parent module, so we move it explicitly. RoPE frequencies
+        are computed dynamically inside ``EmbedND.forward`` from
+        ``params.theta`` (no plain-attribute freq tensor to move).
+
+        Also installs the LoRA / multiplier patches that align downstream
+        ai-toolkit machinery with the split layout.
+        """
+        if not torch.cuda.is_available() or torch.cuda.device_count() < 2:
+            raise RuntimeError(
+                "CHROMA_DUAL_GPU=true needs at least 2 CUDA devices (cuda:0 + "
+                f"cuda:1); found {torch.cuda.device_count() if torch.cuda.is_available() else 0}. "
+                "Unset CHROMA_DUAL_GPU for single-GPU training."
+            )
+
+        d0 = torch.device("cuda:0")
+        d1 = torch.device("cuda:1")
+        n_single = len(transformer.single_blocks)
+        override = os.getenv("CHROMA_DUAL_GPU_SPLIT_AT")
+        if override is not None:
+            try:
+                split_at = int(override)
+            except ValueError:
+                raise ValueError(
+                    "CHROMA_DUAL_GPU_SPLIT_AT must be an integer; got "
+                    f"{override!r}."
+                )
+            if not (1 <= split_at < n_single):
+                raise ValueError(
+                    f"CHROMA_DUAL_GPU_SPLIT_AT={split_at} is out of range; "
+                    f"must be in [1, {n_single - 1}] for a model with "
+                    f"{n_single} single_blocks."
+                )
+        else:
+            split_at = n_single // 2
+
+        self.print_and_status_update(  # type: ignore[attr-defined]
+            f"Distributing transformer across {d0} and {d1}"
+        )
+        self.print_and_status_update(  # type: ignore[attr-defined]
+            f"Single-block split: {split_at} on {d0}, "
+            f"{n_single - split_at} on {d1}"
+        )
+
+        # --- cuda:0: embedders, distillation approximator, double-stream
+        #     blocks, first half of single-stream blocks
+        transformer.img_in.to(d0, dtype=dtype)
+        transformer.txt_in.to(d0, dtype=dtype)
+        # pe_embedder (EmbedND) has no parameters — RoPE is computed
+        # dynamically via torch.arange / torch.outer inside its forward —
+        # but call .to so child buffers (if any future addition) follow.
+        transformer.pe_embedder.to(d0, dtype=dtype)
+        transformer.distilled_guidance_layer.to(d0, dtype=dtype)
+
+        for blk in transformer.double_blocks:
+            blk.to(d0, dtype=dtype)
+
+        for i, blk in enumerate(transformer.single_blocks):
+            blk.to(d0 if i < split_at else d1, dtype=dtype)
+
+        # --- cuda:1: final output layer
+        transformer.final_layer.to(d1, dtype=dtype)
+
+        # mod_index buffer (registered non-persistent on the parent) feeds
+        # timestep_embedding under no_grad on cuda:0; keep it on d0.
+        if hasattr(transformer, "mod_index"):
+            transformer.mod_index = transformer.mod_index.to(d0)
+
+        transformer.forward = types.MethodType(
+            _make_split_forward(split_at), transformer
+        )
+        _pin_transformer_to(transformer)
+
+        _install_external_patches()
+
+
+# ---------------------------------------------------------------- helpers
+
+
+def _make_split_forward(split_at: int):
+    """Create a ``Chroma.forward`` variant that inserts a cuda:1 boundary
+    at ``single_blocks[split_at]``.
+
+    Recreates ai-toolkit's vendored ``Chroma.forward``
+    (``extensions_built_in/diffusion_models/chroma/src/model.py``) with
+    two additions:
+
+      1. The ``double_blocks`` loop runs entirely on cuda:0. Its outputs
+         (``img``, ``txt``) are concatenated (``cat(txt, img, dim=1)``)
+         and fed into the ``single_blocks`` loop, also starting on cuda:0.
+      2. At ``single_blocks[split_at]`` — the single PCIe boundary —
+         bridge to cuda:1 every tensor the downstream single blocks +
+         ``final_layer`` consume: ``img`` (the concatenated tensor),
+         ``pe``, ``txt_img_mask``, and a freshly-built ``mod_vectors_dict``
+         containing the cuda:1-resident slices for ``single_blocks[i].modulation.lin``
+         (``i >= split_at``) plus ``final_layer.adaLN_modulation.1``. The
+         original cuda:0 ``mod_vectors_dict`` is NOT mutated — gradient
+         checkpointing in the cuda:0 single blocks captures it by closure
+         and re-reads it during backward; mutating would corrupt that
+         re-read (Qwen-Image lesson).
+
+    After ``final_layer`` the output is moved back to cuda:0 so downstream
+    loss ops (which run on the model's nominal device) work without a
+    device-mismatch error.
+
+    Signature and return type match the vendored forward exactly.
+    """
+    import torch.utils.checkpoint as ckpt
+
+    from .src.layers import distribute_modulations, timestep_embedding
+
+    def forward(
+        self,
+        img: torch.Tensor,
+        img_ids: torch.Tensor,
+        txt: torch.Tensor,
+        txt_ids: torch.Tensor,
+        txt_mask: torch.Tensor,
+        timesteps: torch.Tensor,
+        guidance: torch.Tensor,
+        attn_padding: int = 1,
+    ) -> torch.Tensor:
+        if img.ndim != 3 or txt.ndim != 3:
+            raise ValueError("Input img and txt tensors must have 3 dimensions.")
+
+        # Devices of the first single block on each side of the boundary.
+        # double_blocks[*] + single_blocks[:split_at] all live on d0_dev;
+        # single_blocks[split_at:] + final_layer live on d1_dev.
+        d0_dev = next(self.single_blocks[0].parameters()).device
+        d1_dev = next(self.single_blocks[split_at].parameters()).device
+
+        # img_in / txt_in live on cuda:0; ensure inputs match.
+        if img.device != d0_dev:
+            img = img.to(d0_dev)
+        if txt.device != d0_dev:
+            txt = txt.to(d0_dev)
+        if img_ids.device != d0_dev:
+            img_ids = img_ids.to(d0_dev)
+        if txt_ids.device != d0_dev:
+            txt_ids = txt_ids.to(d0_dev)
+        if txt_mask.device != d0_dev:
+            txt_mask = txt_mask.to(d0_dev)
+
+        img = self.img_in(img)
+        txt = self.txt_in(txt)
+
+        # Distillation approximator — runs under no_grad on cuda:0,
+        # produces the mod_vectors tensor consumed by every block. The
+        # final tensor itself requires_grad_(True) per the vendored
+        # forward; the .requires_grad_(True) call inside the no_grad
+        # block is what marks the *output* to receive a backward graph
+        # from downstream block usage.
+        with torch.no_grad():
+            distill_timestep = timestep_embedding(timesteps.to(d0_dev), 16)
+            distil_guidance = timestep_embedding(guidance.to(d0_dev), 16)
+            modulation_index = timestep_embedding(self.mod_index, 32)
+            modulation_index = modulation_index.unsqueeze(0).repeat(img.shape[0], 1, 1)
+            timestep_guidance = (
+                torch.cat([distill_timestep, distil_guidance], dim=1)
+                .unsqueeze(1)
+                .repeat(1, self.mod_index_length, 1)
+            )
+            input_vec = torch.cat([timestep_guidance, modulation_index], dim=-1)
+            mod_vectors = self.distilled_guidance_layer(input_vec.requires_grad_(True))
+        mod_vectors_dict = distribute_modulations(
+            mod_vectors, self.depth_single_blocks, self.depth_double_blocks
+        )
+
+        ids = torch.cat((txt_ids, img_ids), dim=1)
+        pe = self.pe_embedder(ids)
+
+        # Build txt_img_mask on cuda:0 (consumed by every block; bridged
+        # at the boundary).
+        max_len = txt.shape[1]
+        with torch.no_grad():
+            # modify_mask_to_attend_padding is a no-grad helper in src/model.py;
+            # inline the same shape for the unmask side rather than importing
+            # the private fn, so a vendored rename doesn't break us. Mirror
+            # the vendored forward exactly.
+            from .src.model import modify_mask_to_attend_padding
+            txt_mask_w_padding = modify_mask_to_attend_padding(
+                txt_mask, max_len, attn_padding
+            )
+            txt_img_mask = torch.cat(
+                [
+                    txt_mask_w_padding,
+                    torch.ones([img.shape[0], img.shape[1]], device=txt_mask.device),
+                ],
+                dim=1,
+            )
+            txt_img_mask = txt_img_mask.float().T @ txt_img_mask.float()
+            txt_img_mask = (
+                txt_img_mask[None, None, ...]
+                .repeat(txt.shape[0], self.num_heads, 1, 1)
+                .int()
+                .bool()
+            )
+
+        # --- double_blocks: all on cuda:0
+        for i, block in enumerate(self.double_blocks):
+            img_mod = mod_vectors_dict[f"double_blocks.{i}.img_mod.lin"]
+            txt_mod = mod_vectors_dict[f"double_blocks.{i}.txt_mod.lin"]
+            double_mod = [img_mod, txt_mod]
+
+            if torch.is_grad_enabled() and self.gradient_checkpointing:
+                img.requires_grad_(True)
+                img, txt = ckpt.checkpoint(
+                    block, img, txt, pe, double_mod, txt_img_mask
+                )
+            else:
+                img, txt = block(
+                    img=img, txt=txt, pe=pe, distill_vec=double_mod, mask=txt_img_mask
+                )
+
+        txt_seq_len = txt.shape[1]
+        img = torch.cat((txt, img), 1)
+
+        # --- single_blocks: PCIe boundary at split_at
+        for i, block in enumerate(self.single_blocks):
+            if i == split_at and d1_dev != d0_dev:
+                # PCIe boundary: bridge every tensor the downstream single
+                # blocks + final_layer consume to cuda:1. Build a SEPARATE
+                # cuda:1 mod_vectors_dict slice — do NOT mutate the cuda:0
+                # dict (gradient-checkpoint backward re-reads it).
+                img = img.to(d1_dev)
+                pe = pe.to(d1_dev)
+                txt_img_mask = txt_img_mask.to(d1_dev)
+
+            if i < split_at:
+                single_mod = mod_vectors_dict[f"single_blocks.{i}.modulation.lin"]
+            else:
+                # Lazy per-block bridge: each single ModulationOut becomes
+                # a cuda:1 copy. ModulationOut is a dataclass with
+                # shift/scale/gate tensor fields — wrap the .to() through
+                # the dataclass to preserve type.
+                src = mod_vectors_dict[f"single_blocks.{i}.modulation.lin"]
+                single_mod = _modulation_to(src, d1_dev)
+
+            if torch.is_grad_enabled() and self.gradient_checkpointing:
+                img.requires_grad_(True)
+                img = ckpt.checkpoint(block, img, pe, single_mod, txt_img_mask)
+            else:
+                img = block(img, pe=pe, distill_vec=single_mod, mask=txt_img_mask)
+
+        img = img[:, txt_seq_len:, ...]
+        # final_layer lives on cuda:1; its distill_vec is a list of two
+        # tensor slices from mod_vectors. Bridge both to cuda:1.
+        final_mod_src = mod_vectors_dict["final_layer.adaLN_modulation.1"]
+        final_mod = [t.to(d1_dev) for t in final_mod_src]
+        img = self.final_layer(img, distill_vec=final_mod)
+
+        # Return on cuda:0 so downstream loss / scatter ops (which run on
+        # the model's nominal device) work without a device-mismatch error.
+        if img.device != d0_dev:
+            img = img.to(d0_dev)
+        return img
+
+    return forward
+
+
+def _modulation_to(mod: Any, device: torch.device) -> Any:
+    """Move a ModulationOut (or list of ModulationOut, for double blocks)
+    onto ``device``. Used at the PCIe boundary to construct cuda:1-resident
+    modulation slices without mutating the original cuda:0 dict.
+
+    ModulationOut is a dataclass with ``shift``, ``scale``, ``gate``
+    fields — reconstruct it on ``device``. For consistency with the
+    double-block branch (list of two ModulationOut), handle the list
+    case too.
+    """
+    from .src.layers import ModulationOut
+
+    if isinstance(mod, list):
+        return [_modulation_to(m, device) for m in mod]
+    if isinstance(mod, ModulationOut):
+        return ModulationOut(
+            shift=mod.shift.to(device),
+            scale=mod.scale.to(device),
+            gate=mod.gate.to(device),
+        )
+    # Final-layer entry: plain list of tensors. Handled separately in
+    # forward, but support the fallback path.
+    if hasattr(mod, "to"):
+        return mod.to(device)
+    return mod
+
+
+def _pin_transformer_to(transformer: torch.nn.Module) -> None:
+    """Wrap ``transformer.to()`` so device arguments are stripped (the model
+    is already distributed) while dtype changes still pass through.
+
+    Without this, ai-toolkit hooks like ``set_device_state`` (called every
+    training step) and ``pipe.transformer.to(self.device_torch)`` (the
+    pipeline composer at the bottom of ``ChromaModel.load_model``) would
+    silently re-collect the split onto cuda:0.
+    """
+    _orig_to = transformer.to
+
+    def _split_preserving_to(*args: Any, **kwargs: Any):
+        filtered_args = [
+            a for a in args
+            if not isinstance(a, (str, torch.device, int))
+        ]
+        filtered_kwargs = {k: v for k, v in kwargs.items() if k != "device"}
+        if not filtered_args and not filtered_kwargs:
+            return transformer
+        return _orig_to(*filtered_args, **filtered_kwargs)
+
+    transformer.to = _split_preserving_to  # type: ignore[assignment]
+
+
+# Module-level idempotency flag. The external patches hook
+# ai-toolkit-wide classes (``ToolkitNetworkMixin``, ``LoRANetwork``,
+# ``network_mixins.broadcast_and_multiply``) — not Chroma-specific code —
+# so they're already installed by the FLUX.2 / Wan / LTX-2 / Qwen-Image /
+# HiDream paths if any ran first. Gate all three installers behind a
+# single module flag plus per-target attribute flags (defense in depth).
+_PATCHES_INSTALLED = False
+
+
+def _install_external_patches() -> None:
+    """Idempotently install the LoRA-placement and multiplier-device patches.
+
+    These hook external ai-toolkit classes — done as runtime patches so
+    this file remains a self-contained addition. Safe to call alongside
+    the FLUX.2 / Wan / LTX-2 / Qwen-Image / HiDream helpers; all gate on
+    the same per-target flags.
+    """
+    global _PATCHES_INSTALLED
+    if _PATCHES_INSTALLED:
+        return
+    _patch_force_to()
+    _patch_apply_to_with_lazy_forward()
+    _patch_broadcast_and_multiply()
+    _PATCHES_INSTALLED = True
+
+
+def _patch_force_to() -> None:
+    """``ToolkitNetworkMixin.force_to`` moves the network's submodules to a
+    single device. Override so each LoRA module follows the device of the
+    layer it wraps.
+    """
+    from toolkit.network_mixins import ToolkitNetworkMixin
+
+    if getattr(ToolkitNetworkMixin, "_dual_gpu_patched", False):
+        return
+
+    def _per_layer_force_to(self_n, device, dtype):
+        try:
+            self_n.to(device, dtype)
+        except Exception:
+            pass
+        loras = []
+        if hasattr(self_n, "unet_loras"):
+            loras += self_n.unet_loras
+        if hasattr(self_n, "text_encoder_loras"):
+            loras += self_n.text_encoder_loras
+        for lora in loras:
+            tgt = device
+            try:
+                parent = lora.org_module[0]
+                p = next(parent.parameters(), None)
+                if p is not None:
+                    tgt = p.device
+            except Exception:
+                pass
+            lora.to(tgt, dtype)
+            for attr in ("lora_down", "lora_up", "lora_mid"):
+                m = getattr(lora, attr, None)
+                if m is not None:
+                    try:
+                        m.to(tgt, dtype)
+                    except Exception:
+                        pass
+
+    ToolkitNetworkMixin.force_to = _per_layer_force_to
+    ToolkitNetworkMixin._dual_gpu_patched = True
+
+
+def _patch_apply_to_with_lazy_forward() -> None:
+    """``LoRANetwork.apply_to`` creates wrapped LoRA modules and registers
+    them as submodules. After it runs, each LoRA's forward is wrapped to
+    lazily re-pin parameters to the input's device on every call.
+
+    The lazy-pin is the load-bearing safety net — any later ai-toolkit
+    hook that calls ``network.to(device)`` (e.g., from
+    ``accelerate.prepare``) is silently corrected on the next forward.
+    """
+    from toolkit.kohya_lora import LoRANetwork
+
+    if getattr(LoRANetwork, "_dual_gpu_apply_patched", False):
+        return
+
+    _orig_apply_to = LoRANetwork.apply_to
+
+    def _redistribute_apply_to(self_n, *args, **kwargs):
+        ret = _orig_apply_to(self_n, *args, **kwargs)
+        loras = []
+        if hasattr(self_n, "unet_loras"):
+            loras += self_n.unet_loras
+        if hasattr(self_n, "text_encoder_loras"):
+            loras += self_n.text_encoder_loras
+        for lora in loras:
+            if getattr(lora, "_dual_gpu_wrapped", False):
+                continue
+            lora.forward = _make_pinned_forward(lora, lora.forward)
+            try:
+                lora.org_module[0].forward = lora.forward
+            except Exception:
+                pass
+            lora._dual_gpu_wrapped = True
+        return ret
+
+    LoRANetwork.apply_to = _redistribute_apply_to
+    LoRANetwork._dual_gpu_apply_patched = True
+
+
+def _make_pinned_forward(lora, orig_forward):
+    """Wrap a LoRA module's forward to re-pin its parameters to the input
+    tensor's device on each call. Cheap no-op when devices already match.
+    """
+    def _pinned(*fargs, **fkwargs):
+        in_dev = None
+        for a in fargs:
+            if hasattr(a, "device") and getattr(a, "is_cuda", False):
+                in_dev = a.device
+                break
+        if in_dev is None:
+            return orig_forward(*fargs, **fkwargs)
+        p = next(lora.parameters(), None)
+        if p is not None and p.device != in_dev:
+            lora.to(in_dev)
+        return orig_forward(*fargs, **fkwargs)
+    return _pinned
+
+
+def _patch_broadcast_and_multiply() -> None:
+    """``network_mixins.broadcast_and_multiply(tensor, multiplier)`` fails
+    when ``tensor`` and ``multiplier`` live on different devices. Auto-move
+    the multiplier to match.
+    """
+    from toolkit import network_mixins as _nm
+
+    if getattr(_nm, "_dual_gpu_bm_patched", False):
+        return
+
+    _orig_bm = _nm.broadcast_and_multiply
+
+    def _device_aware_bm(tensor, multiplier):
+        try:
+            if hasattr(multiplier, "device") and multiplier.device != tensor.device:
+                multiplier = multiplier.to(tensor.device)
+        except Exception:
+            pass
+        return _orig_bm(tensor, multiplier)
+
+    _nm.broadcast_and_multiply = _device_aware_bm
+    _nm._dual_gpu_bm_patched = True

--- a/extensions_built_in/diffusion_models/chroma/chroma_model.py
+++ b/extensions_built_in/diffusion_models/chroma/chroma_model.py
@@ -20,6 +20,7 @@ from einops import rearrange, repeat
 import random
 import torch.nn.functional as F
 from .src.model import Chroma, chroma_params
+from .chroma_dual_gpu import ChromaDualGPUMixin, is_dual_gpu_enabled
 from safetensors.torch import load_file, save_file
 from toolkit.metadata import get_meta_for_safetensors
 import huggingface_hub
@@ -62,7 +63,7 @@ class FakeCLIP(torch.nn.Module):
         return torch.zeros(1, 1, 1).to(self.device)
 
 
-class ChromaModel(BaseModel):
+class ChromaModel(ChromaDualGPUMixin, BaseModel):
     arch = "chroma"
 
     def __init__(
@@ -85,6 +86,7 @@ class ChromaModel(BaseModel):
         self.is_flow_matching = True
         self.is_transformer = True
         self.target_lora_modules = ['Chroma']
+        self.init_te_device()
 
     # static method to get the noise scheduler
     @staticmethod
@@ -192,6 +194,12 @@ class ChromaModel(BaseModel):
         else:
             transformer.to(self.device_torch, dtype=dtype)
 
+        if is_dual_gpu_enabled():
+            # After this call, transformer.to() is pinned to ignore device
+            # arguments — the later pipe.transformer.to(self.device_torch)
+            # sites become no-ops and the split layout survives.
+            self.setup_dual_gpu_distribution(transformer, dtype)
+
         flush()
 
         self.print_and_status_update("Loading T5")
@@ -201,7 +209,7 @@ class ChromaModel(BaseModel):
         text_encoder_2 = T5EncoderModel.from_pretrained(
             extras_path, subfolder="text_encoder_2", torch_dtype=dtype
         )
-        text_encoder_2.to(self.device_torch, dtype=dtype)
+        text_encoder_2.to(self.te_device_torch, dtype=dtype)
         flush()
 
         if self.model_config.quantize_te:
@@ -250,10 +258,10 @@ class ChromaModel(BaseModel):
 
         flush()
         # just to make sure everything is on the right device and dtype
-        text_encoder[0].to(self.device_torch)
+        text_encoder[0].to(self.te_device_torch)
         text_encoder[0].requires_grad_(False)
         text_encoder[0].eval()
-        text_encoder[1].to(self.device_torch)
+        text_encoder[1].to(self.te_device_torch)
         text_encoder[1].requires_grad_(False)
         text_encoder[1].eval()
         pipe.transformer = pipe.transformer.to(self.device_torch)

--- a/extensions_built_in/diffusion_models/flux2/flux2_dual_gpu.py
+++ b/extensions_built_in/diffusion_models/flux2/flux2_dual_gpu.py
@@ -72,6 +72,13 @@ class Flux2DualGPUMixin:
         """
         override = get_te_device_override()
         self.te_device_torch = override if override is not None else self.device_torch
+        if self.te_device_torch.type == "cpu":
+            self.print_and_status_update(
+                "FLUX2_TE_DEVICE=cpu — Mistral will run on CPU. Set "
+                "`cache_text_embeddings: true` and `unload_text_encoder: true` "
+                "in your config so it runs once at startup; otherwise it runs "
+                "on CPU every step (very slow)."
+            )
 
     # ----------------------------------------------------------- TE override
 
@@ -102,17 +109,50 @@ class Flux2DualGPUMixin:
         Also installs the LoRA / multiplier patches that align downstream
         ai-toolkit machinery with the split layout.
         """
-        d0 = torch.device("cuda:0")
-        d1 = torch.device("cuda:1")
+        # Primary device follows the model's configured device (normally
+        # cuda:0); the second half goes on the next CUDA ordinal.
+        d0 = self.device_torch
+        if d0.type != "cuda":
+            raise RuntimeError(
+                f"FLUX2_DUAL_GPU=true requires a CUDA device; got {d0}. "
+                "Unset FLUX2_DUAL_GPU for non-CUDA training."
+            )
+        n_cuda = torch.cuda.device_count() if torch.cuda.is_available() else 0
+        d1_index = (d0.index or 0) + 1
+        if n_cuda < d1_index + 1:
+            raise RuntimeError(
+                f"FLUX2_DUAL_GPU=true needs at least {d1_index + 1} CUDA "
+                f"device(s) — to use cuda:{d0.index or 0} + cuda:{d1_index} — "
+                f"but found {n_cuda}. Unset FLUX2_DUAL_GPU for single-GPU "
+                "training."
+            )
+        d1 = torch.device(f"cuda:{d1_index}")
+
         n_single = len(transformer.single_blocks)
         override = os.getenv("FLUX2_DUAL_GPU_SPLIT_AT")
-        split_at = int(override) if override else (n_single // 2)
+        if override is not None:
+            try:
+                split_at = int(override)
+            except ValueError:
+                raise ValueError(
+                    "FLUX2_DUAL_GPU_SPLIT_AT must be an integer; got "
+                    f"{override!r}."
+                )
+            if not (1 <= split_at < n_single):
+                raise ValueError(
+                    f"FLUX2_DUAL_GPU_SPLIT_AT={split_at} is out of range; "
+                    f"must be in [1, {n_single - 1}] for a model with "
+                    f"{n_single} single_blocks."
+                )
+        else:
+            split_at = n_single // 2
+
         self.print_and_status_update(
             f"Distributing transformer across {d0} and {d1}"
         )
         self.print_and_status_update(
-            f"Single-block split: {split_at} on cuda:0, "
-            f"{n_single - split_at} on cuda:1"
+            f"Single-block split: {split_at} on {d0}, "
+            f"{n_single - split_at} on {d1}"
         )
 
         # input projections + positional embedder + modulations on d0
@@ -307,8 +347,8 @@ def _patch_force_to() -> None:
         # Move the network container itself first (usually no params).
         try:
             self_n.to(device, dtype)
-        except Exception:
-            pass
+        except Exception as e:
+            print(f"[flux2_dual_gpu] network.to({device}, {dtype}) failed: {e}")
         loras = []
         if hasattr(self_n, "unet_loras"):
             loras += self_n.unet_loras
@@ -368,8 +408,11 @@ def _patch_apply_to_with_lazy_forward() -> None:
             # (apply_to captured the un-wrapped version).
             try:
                 lora.org_module[0].forward = lora.forward
-            except Exception:
-                pass
+            except Exception as e:
+                print(
+                    "[flux2_dual_gpu] could not rebind org_module forward for "
+                    f"{getattr(lora, 'lora_name', lora)}: {e}"
+                )
             lora._dual_gpu_wrapped = True
         return ret
 

--- a/extensions_built_in/diffusion_models/flux2/flux2_dual_gpu.py
+++ b/extensions_built_in/diffusion_models/flux2/flux2_dual_gpu.py
@@ -1,0 +1,420 @@
+"""Dual-GPU model-parallel path for FLUX.2 LoRA training.
+
+Activates when FLUX2_DUAL_GPU=true. Distributes the FLUX.2 transformer
+across two CUDA devices with a single PCIe boundary mid-`single_blocks`,
+keeps Mistral on a configurable device (CPU recommended for 32GB cards),
+and patches ai-toolkit's LoRA machinery to route per-layer LoRA modules
+to the device of the transformer layer they wrap.
+
+Validated 2026-05-10 against 2× RTX 5090 (sm_120) with FLUX.2-dev,
+ai-toolkit FLUX.2 branch, qfloat8 transformer weights. See accompanying
+README for performance numbers and design rationale.
+
+Env vars:
+    FLUX2_DUAL_GPU=true              enable the dual-GPU path
+    FLUX2_TE_DEVICE=cpu              pin text encoder to a specific device
+    FLUX2_DUAL_GPU_SPLIT_AT=24       override single_blocks split index
+                                     (default: n_single_blocks // 2)
+"""
+from __future__ import annotations
+
+import os
+import types
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from .flux2_model import Flux2Model
+
+
+def is_dual_gpu_enabled() -> bool:
+    return os.getenv("FLUX2_DUAL_GPU", "false").lower() == "true"
+
+
+def get_te_device_override() -> torch.device | None:
+    """Returns the text-encoder device override if FLUX2_TE_DEVICE is set."""
+    val = os.getenv("FLUX2_TE_DEVICE")
+    return torch.device(val) if val else None
+
+
+class Flux2DualGPUMixin:
+    """Mixin for :class:`Flux2Model` that adds the dual-GPU training path.
+
+    The mixin contributes:
+
+    - ``te_device_torch`` attribute (resolved from ``FLUX2_TE_DEVICE`` or
+      defaulting to ``device_torch``). Always present — used even when
+      dual-GPU itself is disabled.
+    - ``text_encoder_to`` override that routes Mistral moves to
+      ``te_device_torch`` instead of ``device_torch``.
+    - ``setup_dual_gpu_distribution(transformer)`` to be called from
+      ``load_model`` after the transformer has been quantized (if applicable)
+      and before the pipeline composes it. Distributes modules across
+      cuda:0/cuda:1, replaces ``Flux2.forward`` with a split-aware variant,
+      pins ``transformer.to()`` to ignore device arguments, and installs
+      the LoRA / multiplier patches.
+    - ``preserve_dual_gpu_split_on_pipe(pipe)`` — to be called in place of
+      ``pipe.transformer = pipe.transformer.to(self.device_torch)`` so the
+      distributed layout survives pipeline composition.
+    """
+
+    # Set by Flux2Model.__init__ after super().__init__()
+    te_device_torch: torch.device
+
+    # ---------------------------------------------------------------- init
+
+    def init_te_device(self) -> None:
+        """Resolve ``te_device_torch`` from env var or fall back to model device.
+
+        Must be called from :meth:`Flux2Model.__init__` after the base
+        ``__init__`` (which establishes ``self.device_torch``).
+        """
+        override = get_te_device_override()
+        self.te_device_torch = override if override is not None else self.device_torch
+
+    # ----------------------------------------------------------- TE override
+
+    def text_encoder_to(self, *args, **kwargs):
+        """Override of BaseModel.text_encoder_to that honors te_device_torch.
+
+        ai-toolkit's :class:`SDTrainer` hook ``hook_before_train_loop`` calls
+        ``self.sd.text_encoder_to(self.device_torch)`` unconditionally. With
+        ``FLUX2_TE_DEVICE=cpu`` we want Mistral to stay on CPU regardless.
+        """
+        target = self.te_device_torch
+        if isinstance(self.text_encoder, list):
+            for encoder in self.text_encoder:
+                encoder.to(target)
+        else:
+            self.text_encoder.to(target)
+
+    # ------------------------------------------------------------ load hook
+
+    def setup_dual_gpu_distribution(self, transformer, dtype) -> None:
+        """Distribute the FLUX.2 transformer across cuda:0 and cuda:1.
+
+        Layout:
+            cuda:0  — input projections, 3 modulation modules, all 8
+                      DoubleStreamBlocks, first ``split_at`` SingleStreamBlocks
+            cuda:1  — remaining SingleStreamBlocks, final_layer
+
+        Also installs the LoRA / multiplier patches that align downstream
+        ai-toolkit machinery with the split layout.
+        """
+        d0 = torch.device("cuda:0")
+        d1 = torch.device("cuda:1")
+        n_single = len(transformer.single_blocks)
+        override = os.getenv("FLUX2_DUAL_GPU_SPLIT_AT")
+        split_at = int(override) if override else (n_single // 2)
+        self.print_and_status_update(
+            f"Distributing transformer across {d0} and {d1}"
+        )
+        self.print_and_status_update(
+            f"Single-block split: {split_at} on cuda:0, "
+            f"{n_single - split_at} on cuda:1"
+        )
+
+        # input projections + positional embedder + modulations on d0
+        for m in (
+            transformer.img_in,
+            transformer.time_in,
+            transformer.txt_in,
+            transformer.pe_embedder,
+            transformer.double_stream_modulation_img,
+            transformer.double_stream_modulation_txt,
+            transformer.single_stream_modulation,
+        ):
+            m.to(d0, dtype=dtype)
+        if transformer.use_guidance_embed:
+            transformer.guidance_in.to(d0, dtype=dtype)
+
+        # all double_blocks on d0
+        for blk in transformer.double_blocks:
+            blk.to(d0, dtype=dtype)
+
+        # split single_blocks at the configured index
+        for i, blk in enumerate(transformer.single_blocks):
+            blk.to(d0 if i < split_at else d1, dtype=dtype)
+
+        # final_layer on d1
+        transformer.final_layer.to(d1, dtype=dtype)
+
+        # Wire up the split-aware forward and pin .to()
+        transformer.forward = types.MethodType(
+            _make_split_forward(split_at), transformer
+        )
+        _pin_transformer_to(transformer)
+
+        # External-class patches (LoRA placement + multiplier device align)
+        _install_external_patches()
+
+    # ----------------------------------------------------- pipeline composer
+
+    def preserve_dual_gpu_split_on_pipe(self, pipe) -> bool:
+        """Return True if we've already distributed; caller should skip the
+        single-device ``pipe.transformer.to(device)`` call."""
+        return is_dual_gpu_enabled()
+
+
+# ---------------------------------------------------------------- helpers
+
+
+def _make_split_forward(split_at: int):
+    """Create a Flux2.forward variant that inserts a cuda:1 boundary at
+    ``single_blocks[split_at]``.
+
+    The original Flux2.forward expects all modules on a single device; we
+    replace it with one that:
+      1. Runs input projections + double_blocks loop on cuda:0
+      2. Concatenates txt/img and pe_ctx/pe_x
+      3. Runs single_blocks[0:split_at] on cuda:0
+      4. At index split_at, .to(cuda:1) on img, pe, and single_block_mod
+      5. Runs single_blocks[split_at:n] + final_layer on cuda:1
+      6. Returns output on cuda:0 for downstream loss/scatter ops
+    """
+    import torch.utils.checkpoint as _ckpt
+
+    def forward(
+        self,
+        x,
+        x_ids,
+        timesteps,
+        ctx,
+        ctx_ids,
+        guidance=None,
+    ):
+        # Resolve timestep_embedding from the module containing the original
+        # forward (it's defined at module scope alongside Flux2 itself).
+        from .src.model import timestep_embedding  # type: ignore
+
+        num_txt_tokens = ctx.shape[1]
+        timestep_emb = timestep_embedding(timesteps, 256)
+        vec = self.time_in(timestep_emb)
+        if self.use_guidance_embed:
+            guidance_emb = timestep_embedding(guidance, 256)
+            vec = vec + self.guidance_in(guidance_emb)
+
+        double_block_mod_img = self.double_stream_modulation_img(vec)
+        double_block_mod_txt = self.double_stream_modulation_txt(vec)
+        single_block_mod, _ = self.single_stream_modulation(vec)
+
+        img = self.img_in(x)
+        txt = self.txt_in(ctx)
+        pe_x = self.pe_embedder(x_ids)
+        pe_ctx = self.pe_embedder(ctx_ids)
+
+        # double_blocks on cuda:0
+        for block in self.double_blocks:
+            if torch.is_grad_enabled() and self.gradient_checkpointing:
+                img, txt = _ckpt.checkpoint(
+                    block, img, txt, pe_x, pe_ctx,
+                    double_block_mod_img, double_block_mod_txt,
+                    use_reentrant=False,
+                )
+            else:
+                img, txt = block(
+                    img, txt, pe_x, pe_ctx,
+                    double_block_mod_img, double_block_mod_txt,
+                )
+
+        img = torch.cat((txt, img), dim=1)
+        pe = torch.cat((pe_ctx, pe_x), dim=2)
+
+        d0_dev = next(self.single_blocks[0].parameters()).device
+        d1_dev = next(self.single_blocks[split_at].parameters()).device
+
+        for i, block in enumerate(self.single_blocks):
+            if i == split_at and d1_dev != d0_dev:
+                img = img.to(d1_dev)
+                pe = pe.to(d1_dev)
+                single_block_mod = (
+                    tuple(t.to(d1_dev) for t in single_block_mod)
+                    if isinstance(single_block_mod, tuple)
+                    else single_block_mod.to(d1_dev)
+                )
+            if torch.is_grad_enabled() and self.gradient_checkpointing:
+                img = _ckpt.checkpoint(
+                    block, img, pe, single_block_mod,
+                    use_reentrant=False,
+                )
+            else:
+                img = block(img, pe, single_block_mod)
+
+        img = img[:, num_txt_tokens:, ...]
+        vec_for_final = vec.to(d1_dev) if vec.device != d1_dev else vec
+        img = self.final_layer(img, vec_for_final)
+
+        # Return on d0 so downstream loss / scatter ops on img_ids (which
+        # live on d0) work without a device-mismatch error.
+        if img.device != d0_dev:
+            img = img.to(d0_dev)
+        return img
+
+    return forward
+
+
+def _pin_transformer_to(transformer) -> None:
+    """Wrap ``transformer.to()`` so device arguments are stripped (the model
+    is already distributed) while dtype changes still pass through.
+
+    Without this, ai-toolkit hooks like ``set_device_state`` (called every
+    training step) and ``pipe.transformer.to(self.device_torch)`` (the
+    pipeline composer) would silently re-collect the split onto cuda:0.
+    """
+    _orig_to = transformer.to
+
+    def _split_preserving_to(*args, **kwargs):
+        filtered_args = [
+            a for a in args
+            if not isinstance(a, (str, torch.device, int))
+        ]
+        filtered_kwargs = {k: v for k, v in kwargs.items() if k != "device"}
+        if not filtered_args and not filtered_kwargs:
+            return transformer
+        return _orig_to(*filtered_args, **filtered_kwargs)
+
+    transformer.to = _split_preserving_to
+
+
+def _install_external_patches() -> None:
+    """Idempotently install the LoRA-placement and multiplier-device patches.
+
+    These hook external ai-toolkit classes (``ToolkitNetworkMixin``,
+    ``LoRANetwork``, ``network_mixins.broadcast_and_multiply``) — done as
+    runtime patches so this file remains a self-contained addition.
+
+    For maintainability, each patch is a small no-op if dual-GPU isn't
+    actually distributing (heuristic: if ``lora.org_module[0]``'s parameter
+    device matches the requested device, nothing changes).
+    """
+    _patch_force_to()
+    _patch_apply_to_with_lazy_forward()
+    _patch_broadcast_and_multiply()
+
+
+def _patch_force_to() -> None:
+    """``ToolkitNetworkMixin.force_to`` moves the network's submodules to a
+    single device. Override so each LoRA module follows the device of the
+    layer it wraps.
+    """
+    from toolkit.network_mixins import ToolkitNetworkMixin
+
+    if getattr(ToolkitNetworkMixin, "_dual_gpu_patched", False):
+        return
+
+    def _per_layer_force_to(self_n, device, dtype):
+        # Move the network container itself first (usually no params).
+        try:
+            self_n.to(device, dtype)
+        except Exception:
+            pass
+        loras = []
+        if hasattr(self_n, "unet_loras"):
+            loras += self_n.unet_loras
+        if hasattr(self_n, "text_encoder_loras"):
+            loras += self_n.text_encoder_loras
+        for lora in loras:
+            tgt = device
+            try:
+                parent = lora.org_module[0]
+                p = next(parent.parameters(), None)
+                if p is not None:
+                    tgt = p.device
+            except Exception:
+                pass
+            lora.to(tgt, dtype)
+            # Also explicitly route children — defense in depth.
+            for attr in ("lora_down", "lora_up", "lora_mid"):
+                m = getattr(lora, attr, None)
+                if m is not None:
+                    try:
+                        m.to(tgt, dtype)
+                    except Exception:
+                        pass
+
+    ToolkitNetworkMixin.force_to = _per_layer_force_to
+    ToolkitNetworkMixin._dual_gpu_patched = True
+
+
+def _patch_apply_to_with_lazy_forward() -> None:
+    """``LoRANetwork.apply_to`` creates wrapped LoRA modules and registers
+    them as submodules. After it runs, each LoRA's forward is wrapped to
+    lazily re-pin parameters to the input's device on every call.
+
+    The lazy-pin is the load-bearing safety net — any later ai-toolkit hook
+    that calls ``network.to(device)`` (e.g., from accelerate.prepare) is
+    silently corrected on the next forward.
+    """
+    from toolkit.kohya_lora import LoRANetwork
+
+    if getattr(LoRANetwork, "_dual_gpu_apply_patched", False):
+        return
+
+    _orig_apply_to = LoRANetwork.apply_to
+
+    def _redistribute_apply_to(self_n, *args, **kwargs):
+        ret = _orig_apply_to(self_n, *args, **kwargs)
+        loras = []
+        if hasattr(self_n, "unet_loras"):
+            loras += self_n.unet_loras
+        if hasattr(self_n, "text_encoder_loras"):
+            loras += self_n.text_encoder_loras
+        for lora in loras:
+            if getattr(lora, "_dual_gpu_wrapped", False):
+                continue
+            lora.forward = _make_pinned_forward(lora, lora.forward)
+            # Re-bind org_module.forward so it sees our pinned wrapper
+            # (apply_to captured the un-wrapped version).
+            try:
+                lora.org_module[0].forward = lora.forward
+            except Exception:
+                pass
+            lora._dual_gpu_wrapped = True
+        return ret
+
+    LoRANetwork.apply_to = _redistribute_apply_to
+    LoRANetwork._dual_gpu_apply_patched = True
+
+
+def _make_pinned_forward(lora, orig_forward):
+    """Wrap a LoRA module's forward to re-pin its parameters to the input
+    tensor's device on each call. Cheap no-op when devices already match.
+    """
+    def _pinned(*fargs, **fkwargs):
+        in_dev = None
+        for a in fargs:
+            if hasattr(a, "device") and getattr(a, "is_cuda", False):
+                in_dev = a.device
+                break
+        if in_dev is None:
+            return orig_forward(*fargs, **fkwargs)
+        p = next(lora.parameters(), None)
+        if p is not None and p.device != in_dev:
+            lora.to(in_dev)
+        return orig_forward(*fargs, **fkwargs)
+    return _pinned
+
+
+def _patch_broadcast_and_multiply() -> None:
+    """``network_mixins.broadcast_and_multiply(tensor, multiplier)`` fails
+    when ``tensor`` and ``multiplier`` live on different devices. Auto-move
+    the multiplier to match.
+    """
+    from toolkit import network_mixins as _nm
+
+    if getattr(_nm, "_dual_gpu_bm_patched", False):
+        return
+
+    _orig_bm = _nm.broadcast_and_multiply
+
+    def _device_aware_bm(tensor, multiplier):
+        try:
+            if hasattr(multiplier, "device") and multiplier.device != tensor.device:
+                multiplier = multiplier.to(tensor.device)
+        except Exception:
+            pass
+        return _orig_bm(tensor, multiplier)
+
+    _nm.broadcast_and_multiply = _device_aware_bm
+    _nm._dual_gpu_bm_patched = True

--- a/extensions_built_in/diffusion_models/flux2/flux2_dual_gpu.py
+++ b/extensions_built_in/diffusion_models/flux2/flux2_dual_gpu.py
@@ -109,24 +109,16 @@ class Flux2DualGPUMixin:
         Also installs the LoRA / multiplier patches that align downstream
         ai-toolkit machinery with the split layout.
         """
-        # Primary device follows the model's configured device (normally
-        # cuda:0); the second half goes on the next CUDA ordinal.
-        d0 = self.device_torch
-        if d0.type != "cuda":
+        # Split lives on cuda:0 + cuda:1. (Quanto QTensors don't move cleanly
+        # to a bare "cuda" device, so keep these explicitly indexed.)
+        if not torch.cuda.is_available() or torch.cuda.device_count() < 2:
             raise RuntimeError(
-                f"FLUX2_DUAL_GPU=true requires a CUDA device; got {d0}. "
-                "Unset FLUX2_DUAL_GPU for non-CUDA training."
+                "FLUX2_DUAL_GPU=true needs at least 2 CUDA devices (cuda:0 + "
+                f"cuda:1); found {torch.cuda.device_count() if torch.cuda.is_available() else 0}. "
+                "Unset FLUX2_DUAL_GPU for single-GPU training."
             )
-        n_cuda = torch.cuda.device_count() if torch.cuda.is_available() else 0
-        d1_index = (d0.index or 0) + 1
-        if n_cuda < d1_index + 1:
-            raise RuntimeError(
-                f"FLUX2_DUAL_GPU=true needs at least {d1_index + 1} CUDA "
-                f"device(s) — to use cuda:{d0.index or 0} + cuda:{d1_index} — "
-                f"but found {n_cuda}. Unset FLUX2_DUAL_GPU for single-GPU "
-                "training."
-            )
-        d1 = torch.device(f"cuda:{d1_index}")
+        d0 = torch.device("cuda:0")
+        d1 = torch.device("cuda:1")
 
         n_single = len(transformer.single_blocks)
         override = os.getenv("FLUX2_DUAL_GPU_SPLIT_AT")

--- a/extensions_built_in/diffusion_models/flux2/flux2_model.py
+++ b/extensions_built_in/diffusion_models/flux2/flux2_model.py
@@ -22,6 +22,7 @@ from transformers import AutoProcessor, Mistral3ForConditionalGeneration
 from .src.model import Flux2, Flux2Params
 from .src.pipeline import Flux2Pipeline
 from .src.autoencoder import AutoEncoder, AutoEncoderParams, AutoEncoderSmallDecoderParams
+from .flux2_dual_gpu import Flux2DualGPUMixin, is_dual_gpu_enabled
 from safetensors.torch import load_file, save_file
 from PIL import Image
 import torch.nn.functional as F
@@ -46,14 +47,16 @@ scheduler_config = {
     "use_dynamic_shifting": True,
 }
 
-MISTRAL_PATH = "mistralai/Mistral-Small-3.1-24B-Instruct-2503"
+MISTRAL_PATH = os.getenv(
+    "FLUX2_MISTRAL_PATH", "mistralai/Mistral-Small-3.1-24B-Instruct-2503"
+)
 FLUX2_VAE_FILENAME = "ae.safetensors"
 FLUX2_TRANSFORMER_FILENAME = "flux2-dev.safetensors"
 
 HF_TOKEN = os.getenv("HF_TOKEN", None)
 
 
-class Flux2Model(BaseModel):
+class Flux2Model(Flux2DualGPUMixin, BaseModel):
     arch = "flux2"
     flux2_te_type: str = "mistral"  # "mistral" or "qwen"
     flux2_vae_path: str = None
@@ -72,6 +75,10 @@ class Flux2Model(BaseModel):
         super().__init__(
             device, model_config, dtype, custom_pipeline, noise_scheduler, **kwargs
         )
+        # Resolve te_device_torch from FLUX2_TE_DEVICE env var (or default to
+        # self.device_torch). Mixin attribute used throughout the model below
+        # and overrides text_encoder_to().
+        self.init_te_device()
         self.is_flow_matching = True
         self.is_transformer = True
         self.target_lora_modules = ["Flux2"]
@@ -101,15 +108,21 @@ class Flux2Model(BaseModel):
                 torch_dtype=dtype,
             )
         )
-        text_encoder.to(self.device_torch, dtype=dtype)
-
-        flush()
-
+        # Quantize on CPU FIRST to avoid the ~48GB bf16 transient when moving
+        # Mistral to GPU. Mirrors the transformer load pattern. Critical on
+        # 32GB cards where the unquantized model won't fit during transit, and
+        # prevents WDDM unified-memory paging on Windows.
         if self.model_config.quantize_te:
+            self.print_and_status_update("Keeping Mistral on CPU for quantization")
             self.print_and_status_update("Quantizing Mistral")
-            quantize(text_encoder, weights=get_qtype(self.model_config.qtype))
+            quantize(text_encoder, weights=get_qtype(self.model_config.qtype_te))
             freeze(text_encoder)
             flush()
+            text_encoder.to(self.te_device_torch)
+        else:
+            text_encoder.to(self.te_device_torch, dtype=dtype)
+
+        flush()
 
         if (
             self.model_config.layer_offloading
@@ -117,7 +130,7 @@ class Flux2Model(BaseModel):
         ):
             MemoryManager.attach(
                 text_encoder,
-                self.device_torch,
+                self.te_device_torch,
                 offload_percent=self.model_config.layer_offloading_text_encoder_percent,
             )
 
@@ -163,9 +176,16 @@ class Flux2Model(BaseModel):
             self.print_and_status_update("Quantizing Transformer")
             quantize_model(self, transformer)
             flush()
+        elif is_dual_gpu_enabled():
+            # When splitting across two GPUs we distribute modules below.
+            # Skip the single-device .to() to keep the model on CPU until split.
+            pass
         else:
             transformer.to(self.device_torch, dtype=dtype)
         flush()
+
+        if is_dual_gpu_enabled():
+            self.setup_dual_gpu_distribution(transformer, dtype)
 
         if (
             self.model_config.layer_offloading
@@ -206,14 +226,14 @@ class Flux2Model(BaseModel):
                 filename=vae_filename,
                 token=HF_TOKEN,
             )
-        
+
         vae_state_dict = load_file(vae_path, device="cpu")
-        
+
         autoencoder_params = AutoEncoderParams()
         if vae_state_dict['decoder.up.0.block.0.conv1.bias'].shape[0] == 96:
             # this is the small decoder version
             autoencoder_params = AutoEncoderSmallDecoderParams()
-        
+
         with torch.device("meta"):
             vae = AutoEncoder(autoencoder_params)
 
@@ -249,11 +269,14 @@ class Flux2Model(BaseModel):
         if self.model_config.low_vram:
             text_encoder[0].to("cpu")
         else:
-            text_encoder[0].to(self.device_torch)
+            text_encoder[0].to(self.te_device_torch)
         text_encoder[0].requires_grad_(False)
         text_encoder[0].eval()
         if self.model_config.low_vram:
             pipe.transformer = pipe.transformer.to("cpu")
+        elif is_dual_gpu_enabled():
+            # transformer is already distributed across cuda:0/cuda:1
+            pass
         else:
             pipe.transformer = pipe.transformer.to(self.device_torch)
         flush()
@@ -464,12 +487,15 @@ class Flux2Model(BaseModel):
         return noise_pred
 
     def get_prompt_embeds(self, prompt: str) -> PromptEmbeds:
-        if self.pipeline.text_encoder.device != self.device_torch:
-            self.pipeline.text_encoder.to(self.device_torch)
+        if self.pipeline.text_encoder.device != self.te_device_torch:
+            self.pipeline.text_encoder.to(self.te_device_torch)
 
         prompt_embeds, prompt_embeds_mask = self.pipeline.encode_prompt(
-            prompt, device=self.device_torch
+            prompt, device=self.te_device_torch
         )
+        # move embeds to the transformer's device for downstream consumption
+        if self.te_device_torch != self.device_torch:
+            prompt_embeds = prompt_embeds.to(self.device_torch)
         pe = PromptEmbeds(prompt_embeds)
         return pe
 
@@ -535,7 +561,7 @@ class Flux2Model(BaseModel):
         latents = self.vae.encode(images)
 
         return latents
-    
+
     def decode_latents(self, latents, device=None, dtype=None):
         if device is None:
             device = self.vae_device_torch

--- a/extensions_built_in/diffusion_models/flux2/flux2_model.py
+++ b/extensions_built_in/diffusion_models/flux2/flux2_model.py
@@ -197,7 +197,10 @@ class Flux2Model(Flux2DualGPUMixin, BaseModel):
                 offload_percent=self.model_config.layer_offloading_transformer_percent,
             )
 
-        if self.model_config.low_vram:
+        if self.model_config.low_vram and not is_dual_gpu_enabled():
+            # With the dual-GPU split active the transformer is statically
+            # distributed and transformer.to() is a no-op for device moves —
+            # low_vram offloading does not apply, so skip the (misleading) move.
             self.print_and_status_update("Moving transformer to CPU")
             transformer.to("cpu")
 

--- a/extensions_built_in/diffusion_models/flux_kontext/flux_kontext.py
+++ b/extensions_built_in/diffusion_models/flux_kontext/flux_kontext.py
@@ -22,6 +22,7 @@ from transformers import T5TokenizerFast, T5EncoderModel, CLIPTextModel, CLIPTok
 from einops import rearrange, repeat
 import random
 import torch.nn.functional as F
+from .flux_kontext_dual_gpu import FluxKontextDualGPUMixin, is_dual_gpu_enabled
 
 if TYPE_CHECKING:
     from toolkit.data_transfer_object.data_loader import DataLoaderBatchDTO
@@ -38,7 +39,7 @@ scheduler_config = {
 
 
 
-class FluxKontextModel(BaseModel):
+class FluxKontextModel(FluxKontextDualGPUMixin, BaseModel):
     arch = "flux_kontext"
 
     def __init__(
@@ -61,6 +62,7 @@ class FluxKontextModel(BaseModel):
         self.is_flow_matching = True
         self.is_transformer = True
         self.target_lora_modules = ['FluxTransformer2DModel']
+        self.init_te_device()
 
     # static method to get the noise scheduler
     @staticmethod
@@ -111,6 +113,12 @@ class FluxKontextModel(BaseModel):
         else:
             transformer.to(self.device_torch, dtype=dtype)
 
+        if is_dual_gpu_enabled():
+            # After this call, transformer.to() is pinned to ignore device
+            # arguments — the later pipe.transformer.to(self.device_torch)
+            # sites become no-ops and the split layout survives.
+            self.setup_dual_gpu_distribution(transformer, dtype)
+
         flush()
 
         self.print_and_status_update("Loading T5")
@@ -120,7 +128,7 @@ class FluxKontextModel(BaseModel):
         text_encoder_2 = T5EncoderModel.from_pretrained(
             base_model_path, subfolder="text_encoder_2", torch_dtype=dtype
         )
-        text_encoder_2.to(self.device_torch, dtype=dtype)
+        text_encoder_2.to(self.te_device_torch, dtype=dtype)
         flush()
 
         if self.model_config.quantize_te:
@@ -135,7 +143,7 @@ class FluxKontextModel(BaseModel):
             base_model_path, subfolder="text_encoder", torch_dtype=dtype)
         tokenizer = CLIPTokenizer.from_pretrained(
             base_model_path, subfolder="tokenizer", torch_dtype=dtype)
-        text_encoder.to(self.device_torch, dtype=dtype)
+        text_encoder.to(self.te_device_torch, dtype=dtype)
 
         self.print_and_status_update("Loading VAE")
         vae = AutoencoderKL.from_pretrained(
@@ -167,10 +175,10 @@ class FluxKontextModel(BaseModel):
 
         flush()
         # just to make sure everything is on the right device and dtype
-        text_encoder[0].to(self.device_torch)
+        text_encoder[0].to(self.te_device_torch)
         text_encoder[0].requires_grad_(False)
         text_encoder[0].eval()
-        text_encoder[1].to(self.device_torch)
+        text_encoder[1].to(self.te_device_torch)
         text_encoder[1].requires_grad_(False)
         text_encoder[1].eval()
         pipe.transformer = pipe.transformer.to(self.device_torch)
@@ -352,14 +360,24 @@ class FluxKontextModel(BaseModel):
         return noise_pred
     
     def get_prompt_embeds(self, prompt: str) -> PromptEmbeds:
-        if self.pipeline.text_encoder.device != self.device_torch:
-            self.pipeline.text_encoder.to(self.device_torch)
+        # Route to te_device_torch so both CLIP-L and T5 share a device.
+        # encode_prompts_flux uses text_encoder[0].device to place input_ids
+        # for *both* encoders; if CLIP-L is on cuda:0 while T5 stays on cpu
+        # (the FLUX_KONTEXT_TE_DEVICE=cpu case), T5's token_embedding crashes
+        # with "index on cuda:0, weight on cpu".
+        if self.pipeline.text_encoder.device != self.te_device_torch:
+            self.pipeline.text_encoder.to(self.te_device_torch)
         prompt_embeds, pooled_prompt_embeds = train_tools.encode_prompts_flux(
             self.tokenizer,
             self.text_encoder,
             prompt,
             max_length=512,
         )
+        # Bring outputs back to the trainer device.
+        if prompt_embeds.device != self.device_torch:
+            prompt_embeds = prompt_embeds.to(self.device_torch)
+        if pooled_prompt_embeds.device != self.device_torch:
+            pooled_prompt_embeds = pooled_prompt_embeds.to(self.device_torch)
         pe = PromptEmbeds(
             prompt_embeds
         )

--- a/extensions_built_in/diffusion_models/flux_kontext/flux_kontext_dual_gpu.py
+++ b/extensions_built_in/diffusion_models/flux_kontext/flux_kontext_dual_gpu.py
@@ -1,0 +1,576 @@
+"""Dual-GPU model-parallel path for FLUX.1-Kontext LoRA training.
+
+Activates when ``FLUX_KONTEXT_DUAL_GPU=true``. Distributes the diffusers
+``FluxTransformer2DModel`` (the FLUX.1 transformer that
+``FluxKontextModel`` imports directly from ``diffusers``) across two CUDA
+devices with a single PCIe boundary mid-``single_transformer_blocks``,
+keeps the two FLUX text encoders (CLIP-L, T5-XXL) on a configurable
+device, and reuses the same LoRA / multiplier patches the FLUX.2 /
+Wan 2.2 / LTX-2 / Qwen-Image / HiDream / Chroma paths install (those
+hook ai-toolkit-wide classes, not model-specific ones, so they apply
+unchanged here — the per-target patch flags make calling them all safe).
+
+Targets the ai-toolkit FLUX.1-Kontext trainer
+(``extensions_built_in/diffusion_models/flux_kontext/flux_kontext.py``).
+Integration is a small edit at the call site:
+
+1. Make ``FluxKontextModel`` inherit from ``FluxKontextDualGPUMixin``
+   first (MRO ordering: mixin before ``BaseModel``).
+2. In ``FluxKontextModel.__init__``, call ``self.init_te_device()`` after
+   the base ``__init__`` to resolve ``te_device_torch``.
+3. In ``FluxKontextModel.load_model``, after quantize, call
+   ``self.setup_dual_gpu_distribution(transformer, dtype)`` gated by
+   ``is_dual_gpu_enabled()``. Route the four TE ``.to()`` sites (T5
+   post-load, CLIP post-load, the two move-back loop entries) to
+   ``self.te_device_torch``.
+
+``FluxTransformer2DModel`` has the FLUX.1 shape: ``x_embedder`` +
+``context_embedder`` + ``time_text_embed`` + ``pos_embed``, then a
+sequence of ``transformer_blocks`` (19 — joint stream), then
+``single_transformer_blocks`` (38 — also returning both
+``encoder_hidden_states`` and ``hidden_states``; recent diffusers
+refactor), then ``norm_out`` + ``proj_out``. Both block loops consume
+the same precomputed ``temb`` + ``image_rotary_emb``, so a single
+forward replacement covers the whole split.
+
+Layout: all 19 ``transformer_blocks`` plus
+``single_transformer_blocks[:split_at]`` live on cuda:0; the remaining
+``single_transformer_blocks`` plus ``norm_out`` + ``proj_out`` live on
+cuda:1, with one PCIe boundary inside the single-block loop. Default
+``split_at = num_single // 2 = 19``.
+
+Env vars:
+    FLUX_KONTEXT_DUAL_GPU=true              enable the dual-GPU path
+    FLUX_KONTEXT_TE_DEVICE=cpu              pin the two text encoders
+    FLUX_KONTEXT_DUAL_GPU_SPLIT_AT=19       override split index
+                                            (default: num_single // 2)
+"""
+from __future__ import annotations
+
+import os
+import types
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from diffusers.utils import logging
+
+if TYPE_CHECKING:
+    from .flux_kontext import FluxKontextModel  # noqa: F401
+
+logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
+
+
+def is_dual_gpu_enabled() -> bool:
+    return os.getenv("FLUX_KONTEXT_DUAL_GPU", "false").lower() == "true"
+
+
+def get_te_device_override() -> torch.device | None:
+    """Returns the text-encoder device override if FLUX_KONTEXT_TE_DEVICE is set."""
+    val = os.getenv("FLUX_KONTEXT_TE_DEVICE")
+    return torch.device(val) if val else None
+
+
+class FluxKontextDualGPUMixin:
+    """Mixin for :class:`FluxKontextModel` that adds the dual-GPU training path.
+
+    The mixin contributes:
+
+    - ``te_device_torch`` attribute (resolved from
+      ``FLUX_KONTEXT_TE_DEVICE`` or defaulting to ``device_torch``).
+      Always present — used even when dual-GPU itself is disabled.
+    - ``text_encoder_to`` override that routes the two FLUX text encoders
+      (CLIP-L, T5-XXL) to ``te_device_torch`` instead of ``device_torch``.
+    - ``setup_dual_gpu_distribution(transformer, dtype)`` to be called
+      from ``load_model`` after the transformer has been quantized (if
+      applicable) and before the pipeline composes it. Distributes
+      modules across cuda:0/cuda:1, replaces
+      ``FluxTransformer2DModel.forward`` with a split-aware variant,
+      pins ``transformer.to()`` to ignore device arguments, and installs
+      the LoRA / multiplier patches.
+    """
+
+    te_device_torch: torch.device
+
+    # ---------------------------------------------------------------- init
+
+    def init_te_device(self) -> None:
+        """Resolve ``te_device_torch`` from env var or fall back to model device.
+
+        Must be called from :meth:`FluxKontextModel.__init__` after the
+        base ``__init__`` (which establishes ``self.device_torch``).
+        """
+        override = get_te_device_override()
+        self.te_device_torch = override if override is not None else self.device_torch  # type: ignore[attr-defined]
+        if self.te_device_torch.type == "cpu":
+            self.print_and_status_update(  # type: ignore[attr-defined]
+                "FLUX_KONTEXT_TE_DEVICE=cpu — the two FLUX text encoders "
+                "(CLIP-L + T5-XXL) will run on CPU. Set "
+                "`cache_text_embeddings: true` in your config so they run "
+                "once at startup; otherwise they run on CPU every step."
+            )
+
+    # ----------------------------------------------------------- TE override
+
+    def text_encoder_to(self, *args: Any, **kwargs: Any) -> None:
+        """Override of BaseModel.text_encoder_to that honors te_device_torch."""
+        target = self.te_device_torch
+        if isinstance(self.text_encoder, list):  # type: ignore[attr-defined]
+            for encoder in self.text_encoder:  # type: ignore[attr-defined]
+                encoder.to(target)
+        else:
+            self.text_encoder.to(target)  # type: ignore[attr-defined]
+
+    # ------------------------------------------------------------ load hook
+
+    def setup_dual_gpu_distribution(self, transformer: torch.nn.Module, dtype: torch.dtype) -> None:
+        """Distribute the FLUX.1 transformer across cuda:0 and cuda:1.
+
+        Layout:
+            cuda:0  — ``x_embedder``, ``context_embedder``,
+                      ``time_text_embed``, ``pos_embed``, ALL
+                      ``transformer_blocks``,
+                      ``single_transformer_blocks[:split_at]``
+            cuda:1  — ``single_transformer_blocks[split_at:]``,
+                      ``norm_out``, ``proj_out``
+
+        ``FluxTransformer2DModel`` has no module-level ``nn.Parameter``
+        attributes — every weight lives inside a sub-module. ``pos_embed``
+        (``FluxPosEmbed``) has no parameters either; RoPE freqs are
+        computed dynamically from ``params.theta`` inside its forward.
+
+        Also installs the LoRA / multiplier patches that align downstream
+        ai-toolkit machinery with the split layout.
+        """
+        if not torch.cuda.is_available() or torch.cuda.device_count() < 2:
+            raise RuntimeError(
+                "FLUX_KONTEXT_DUAL_GPU=true needs at least 2 CUDA devices "
+                f"(cuda:0 + cuda:1); found "
+                f"{torch.cuda.device_count() if torch.cuda.is_available() else 0}. "
+                "Unset FLUX_KONTEXT_DUAL_GPU for single-GPU training."
+            )
+
+        d0 = torch.device("cuda:0")
+        d1 = torch.device("cuda:1")
+        n_single = len(transformer.single_transformer_blocks)
+        override = os.getenv("FLUX_KONTEXT_DUAL_GPU_SPLIT_AT")
+        if override is not None:
+            try:
+                split_at = int(override)
+            except ValueError:
+                raise ValueError(
+                    "FLUX_KONTEXT_DUAL_GPU_SPLIT_AT must be an integer; "
+                    f"got {override!r}."
+                )
+            if not (1 <= split_at < n_single):
+                raise ValueError(
+                    f"FLUX_KONTEXT_DUAL_GPU_SPLIT_AT={split_at} is out of "
+                    f"range; must be in [1, {n_single - 1}] for a model "
+                    f"with {n_single} single_transformer_blocks."
+                )
+        else:
+            split_at = n_single // 2
+
+        self.print_and_status_update(  # type: ignore[attr-defined]
+            f"Distributing transformer across {d0} and {d1}"
+        )
+        self.print_and_status_update(  # type: ignore[attr-defined]
+            f"Single-block split: {split_at} on {d0}, "
+            f"{n_single - split_at} on {d1}"
+        )
+
+        # --- cuda:0: input projections, time/text/guidance embedder,
+        #     positional embedder, all joint blocks, first half of single
+        #     blocks
+        transformer.x_embedder.to(d0, dtype=dtype)
+        transformer.context_embedder.to(d0, dtype=dtype)
+        transformer.time_text_embed.to(d0, dtype=dtype)
+        # pos_embed (FluxPosEmbed) has no parameters; the .to() is a no-op
+        # but call it for consistency in case future versions add buffers.
+        transformer.pos_embed.to(d0, dtype=dtype)
+
+        for blk in transformer.transformer_blocks:
+            blk.to(d0, dtype=dtype)
+
+        for i, blk in enumerate(transformer.single_transformer_blocks):
+            blk.to(d0 if i < split_at else d1, dtype=dtype)
+
+        # --- cuda:1: final norm + projection
+        transformer.norm_out.to(d1, dtype=dtype)
+        transformer.proj_out.to(d1, dtype=dtype)
+
+        transformer.forward = types.MethodType(
+            _make_split_forward(split_at), transformer
+        )
+        _pin_transformer_to(transformer)
+
+        _install_external_patches()
+
+
+# ---------------------------------------------------------------- helpers
+
+
+def _make_split_forward(split_at: int):
+    """Create a ``FluxTransformer2DModel.forward`` variant that inserts a
+    cuda:1 boundary at ``single_transformer_blocks[split_at]``.
+
+    Recreates the diffusers ``FluxTransformer2DModel.forward``
+    (``diffusers/models/transformers/transformer_flux.py``, verified
+    identical between the mac and box installs at the time of porting)
+    with one addition:
+
+      At ``single_transformer_blocks[split_at]`` — the single PCIe
+      boundary — bridge to cuda:1 every tensor the downstream single
+      blocks + ``norm_out`` + ``proj_out`` consume: ``hidden_states``,
+      ``encoder_hidden_states``, ``temb``, the two ``image_rotary_emb``
+      tensors (``cos``, ``sin``), and any tensor entries in
+      ``joint_attention_kwargs`` (e.g. ``ip_hidden_states`` for
+      IP-Adapter). After ``proj_out`` the output is moved back to cuda:0
+      so downstream loss ops (which run on the model's nominal device)
+      work without a device-mismatch error.
+
+    Controlnet residual branches are preserved verbatim — they're
+    consumed inside the per-block step on whichever device the block
+    lives on, so caller-supplied controlnet samples on the wrong device
+    would fail. Out of scope for this LoRA-training path; left intact for
+    parity with the vendored forward.
+
+    Signature and return type match the vendored forward exactly.
+    """
+    import numpy as np
+    from diffusers.models.modeling_outputs import Transformer2DModelOutput
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor = None,
+        pooled_projections: torch.Tensor = None,
+        timestep: torch.LongTensor = None,
+        img_ids: torch.Tensor = None,
+        txt_ids: torch.Tensor = None,
+        guidance: torch.Tensor = None,
+        joint_attention_kwargs: dict[str, Any] | None = None,
+        controlnet_block_samples=None,
+        controlnet_single_block_samples=None,
+        return_dict: bool = True,
+        controlnet_blocks_repeat: bool = False,
+    ):
+        # Devices of the first single block on each side of the boundary.
+        # transformer_blocks[*] + single_transformer_blocks[:split_at] all
+        # live on d0_dev; single_transformer_blocks[split_at:] + norm_out +
+        # proj_out live on d1_dev.
+        d0_dev = next(self.single_transformer_blocks[0].parameters()).device
+        d1_dev = next(self.single_transformer_blocks[split_at].parameters()).device
+
+        # Ensure inputs match the cuda:0 input projections.
+        if hidden_states.device != d0_dev:
+            hidden_states = hidden_states.to(d0_dev)
+        if encoder_hidden_states is not None and encoder_hidden_states.device != d0_dev:
+            encoder_hidden_states = encoder_hidden_states.to(d0_dev)
+        if pooled_projections is not None and pooled_projections.device != d0_dev:
+            pooled_projections = pooled_projections.to(d0_dev)
+        if timestep is not None and timestep.device != d0_dev:
+            timestep = timestep.to(d0_dev)
+        if guidance is not None and guidance.device != d0_dev:
+            guidance = guidance.to(d0_dev)
+        if img_ids is not None and img_ids.device != d0_dev:
+            img_ids = img_ids.to(d0_dev)
+        if txt_ids is not None and txt_ids.device != d0_dev:
+            txt_ids = txt_ids.to(d0_dev)
+
+        hidden_states = self.x_embedder(hidden_states)
+
+        timestep = timestep.to(hidden_states.dtype) * 1000
+        if guidance is not None:
+            guidance = guidance.to(hidden_states.dtype) * 1000
+
+        temb = (
+            self.time_text_embed(timestep, pooled_projections)
+            if guidance is None
+            else self.time_text_embed(timestep, guidance, pooled_projections)
+        )
+        encoder_hidden_states = self.context_embedder(encoder_hidden_states)
+
+        if txt_ids.ndim == 3:
+            logger.warning(
+                "Passing `txt_ids` 3d torch.Tensor is deprecated."
+                "Please remove the batch dimension and pass it as a 2d torch Tensor"
+            )
+            txt_ids = txt_ids[0]
+        if img_ids.ndim == 3:
+            logger.warning(
+                "Passing `img_ids` 3d torch.Tensor is deprecated."
+                "Please remove the batch dimension and pass it as a 2d torch Tensor"
+            )
+            img_ids = img_ids[0]
+
+        ids = torch.cat((txt_ids, img_ids), dim=0)
+        image_rotary_emb = self.pos_embed(ids)
+
+        if joint_attention_kwargs is not None and "ip_adapter_image_embeds" in joint_attention_kwargs:
+            ip_adapter_image_embeds = joint_attention_kwargs.pop("ip_adapter_image_embeds")
+            ip_hidden_states = self.encoder_hid_proj(ip_adapter_image_embeds)
+            joint_attention_kwargs.update({"ip_hidden_states": ip_hidden_states})
+
+        # --- transformer_blocks: all on cuda:0
+        for index_block, block in enumerate(self.transformer_blocks):
+            if torch.is_grad_enabled() and self.gradient_checkpointing:
+                encoder_hidden_states, hidden_states = self._gradient_checkpointing_func(
+                    block,
+                    hidden_states,
+                    encoder_hidden_states,
+                    temb,
+                    image_rotary_emb,
+                    joint_attention_kwargs,
+                )
+            else:
+                encoder_hidden_states, hidden_states = block(
+                    hidden_states=hidden_states,
+                    encoder_hidden_states=encoder_hidden_states,
+                    temb=temb,
+                    image_rotary_emb=image_rotary_emb,
+                    joint_attention_kwargs=joint_attention_kwargs,
+                )
+
+            if controlnet_block_samples is not None:
+                interval_control = len(self.transformer_blocks) / len(controlnet_block_samples)
+                interval_control = int(np.ceil(interval_control))
+                if controlnet_blocks_repeat:
+                    hidden_states = (
+                        hidden_states
+                        + controlnet_block_samples[index_block % len(controlnet_block_samples)]
+                    )
+                else:
+                    hidden_states = (
+                        hidden_states + controlnet_block_samples[index_block // interval_control]
+                    )
+
+        # --- single_transformer_blocks: PCIe boundary at split_at
+        for index_block, block in enumerate(self.single_transformer_blocks):
+            if index_block == split_at and d1_dev != d0_dev:
+                # PCIe boundary: bridge every tensor the downstream blocks +
+                # norm_out + proj_out consume to cuda:1. image_rotary_emb is
+                # a (cos, sin) tuple of tensors.
+                hidden_states = hidden_states.to(d1_dev)
+                encoder_hidden_states = encoder_hidden_states.to(d1_dev)
+                temb = temb.to(d1_dev)
+                if isinstance(image_rotary_emb, (tuple, list)):
+                    image_rotary_emb = tuple(
+                        t.to(d1_dev) if hasattr(t, "to") else t for t in image_rotary_emb
+                    )
+                elif hasattr(image_rotary_emb, "to"):
+                    image_rotary_emb = image_rotary_emb.to(d1_dev)
+                if joint_attention_kwargs is not None:
+                    # Bridge tensor entries only; leave non-tensor kwargs
+                    # (scales, flags) alone. Build a NEW dict — do not
+                    # mutate the cuda:0 view (gradient-checkpoint backward
+                    # in cuda:0 blocks captures the dict by reference and
+                    # re-reads it; mutating would corrupt that re-read,
+                    # the Qwen-Image lesson).
+                    joint_attention_kwargs = {
+                        k: (v.to(d1_dev) if hasattr(v, "to") and hasattr(v, "device") else v)
+                        for k, v in joint_attention_kwargs.items()
+                    }
+
+            if torch.is_grad_enabled() and self.gradient_checkpointing:
+                encoder_hidden_states, hidden_states = self._gradient_checkpointing_func(
+                    block,
+                    hidden_states,
+                    encoder_hidden_states,
+                    temb,
+                    image_rotary_emb,
+                    joint_attention_kwargs,
+                )
+            else:
+                encoder_hidden_states, hidden_states = block(
+                    hidden_states=hidden_states,
+                    encoder_hidden_states=encoder_hidden_states,
+                    temb=temb,
+                    image_rotary_emb=image_rotary_emb,
+                    joint_attention_kwargs=joint_attention_kwargs,
+                )
+
+            if controlnet_single_block_samples is not None:
+                interval_control = len(self.single_transformer_blocks) / len(controlnet_single_block_samples)
+                interval_control = int(np.ceil(interval_control))
+                hidden_states = (
+                    hidden_states + controlnet_single_block_samples[index_block // interval_control]
+                )
+
+        hidden_states = self.norm_out(hidden_states, temb)
+        output = self.proj_out(hidden_states)
+
+        # Return on cuda:0 so downstream loss / scatter ops (which run on
+        # the model's nominal device) work without a device-mismatch error.
+        if output.device != d0_dev:
+            output = output.to(d0_dev)
+
+        if not return_dict:
+            return (output,)
+        return Transformer2DModelOutput(sample=output)
+
+    return forward
+
+
+def _pin_transformer_to(transformer: torch.nn.Module) -> None:
+    """Wrap ``transformer.to()`` so device arguments are stripped (the model
+    is already distributed) while dtype changes still pass through.
+
+    Without this, ai-toolkit hooks like ``set_device_state`` (called every
+    training step) and ``pipe.transformer.to(self.device_torch)`` (the
+    pipeline composer at the bottom of ``FluxKontextModel.load_model``)
+    would silently re-collect the split onto cuda:0.
+    """
+    _orig_to = transformer.to
+
+    def _split_preserving_to(*args: Any, **kwargs: Any):
+        filtered_args = [
+            a for a in args
+            if not isinstance(a, (str, torch.device, int))
+        ]
+        filtered_kwargs = {k: v for k, v in kwargs.items() if k != "device"}
+        if not filtered_args and not filtered_kwargs:
+            return transformer
+        return _orig_to(*filtered_args, **filtered_kwargs)
+
+    transformer.to = _split_preserving_to  # type: ignore[assignment]
+
+
+# Module-level idempotency flag. The external patches hook
+# ai-toolkit-wide classes (``ToolkitNetworkMixin``, ``LoRANetwork``,
+# ``network_mixins.broadcast_and_multiply``) — not Kontext-specific code —
+# so they're already installed by the FLUX.2 / Wan / LTX-2 / Qwen-Image /
+# HiDream / Chroma paths if any ran first. Gate all three installers
+# behind a single module flag plus per-target attribute flags (defense in
+# depth).
+_PATCHES_INSTALLED = False
+
+
+def _install_external_patches() -> None:
+    """Idempotently install the LoRA-placement and multiplier-device patches."""
+    global _PATCHES_INSTALLED
+    if _PATCHES_INSTALLED:
+        return
+    _patch_force_to()
+    _patch_apply_to_with_lazy_forward()
+    _patch_broadcast_and_multiply()
+    _PATCHES_INSTALLED = True
+
+
+def _patch_force_to() -> None:
+    """``ToolkitNetworkMixin.force_to`` moves the network's submodules to a
+    single device. Override so each LoRA module follows the device of the
+    layer it wraps.
+    """
+    from toolkit.network_mixins import ToolkitNetworkMixin
+
+    if getattr(ToolkitNetworkMixin, "_dual_gpu_patched", False):
+        return
+
+    def _per_layer_force_to(self_n, device, dtype):
+        try:
+            self_n.to(device, dtype)
+        except Exception:
+            pass
+        loras = []
+        if hasattr(self_n, "unet_loras"):
+            loras += self_n.unet_loras
+        if hasattr(self_n, "text_encoder_loras"):
+            loras += self_n.text_encoder_loras
+        for lora in loras:
+            tgt = device
+            try:
+                parent = lora.org_module[0]
+                p = next(parent.parameters(), None)
+                if p is not None:
+                    tgt = p.device
+            except Exception:
+                pass
+            lora.to(tgt, dtype)
+            for attr in ("lora_down", "lora_up", "lora_mid"):
+                m = getattr(lora, attr, None)
+                if m is not None:
+                    try:
+                        m.to(tgt, dtype)
+                    except Exception:
+                        pass
+
+    ToolkitNetworkMixin.force_to = _per_layer_force_to
+    ToolkitNetworkMixin._dual_gpu_patched = True
+
+
+def _patch_apply_to_with_lazy_forward() -> None:
+    """``LoRANetwork.apply_to`` creates wrapped LoRA modules and registers
+    them as submodules. After it runs, each LoRA's forward is wrapped to
+    lazily re-pin parameters to the input's device on every call.
+    """
+    from toolkit.kohya_lora import LoRANetwork
+
+    if getattr(LoRANetwork, "_dual_gpu_apply_patched", False):
+        return
+
+    _orig_apply_to = LoRANetwork.apply_to
+
+    def _redistribute_apply_to(self_n, *args, **kwargs):
+        ret = _orig_apply_to(self_n, *args, **kwargs)
+        loras = []
+        if hasattr(self_n, "unet_loras"):
+            loras += self_n.unet_loras
+        if hasattr(self_n, "text_encoder_loras"):
+            loras += self_n.text_encoder_loras
+        for lora in loras:
+            if getattr(lora, "_dual_gpu_wrapped", False):
+                continue
+            lora.forward = _make_pinned_forward(lora, lora.forward)
+            try:
+                lora.org_module[0].forward = lora.forward
+            except Exception:
+                pass
+            lora._dual_gpu_wrapped = True
+        return ret
+
+    LoRANetwork.apply_to = _redistribute_apply_to
+    LoRANetwork._dual_gpu_apply_patched = True
+
+
+def _make_pinned_forward(lora, orig_forward):
+    """Wrap a LoRA module's forward to re-pin its parameters to the input
+    tensor's device on each call. Cheap no-op when devices already match.
+    """
+    def _pinned(*fargs, **fkwargs):
+        in_dev = None
+        for a in fargs:
+            if hasattr(a, "device") and getattr(a, "is_cuda", False):
+                in_dev = a.device
+                break
+        if in_dev is None:
+            return orig_forward(*fargs, **fkwargs)
+        p = next(lora.parameters(), None)
+        if p is not None and p.device != in_dev:
+            lora.to(in_dev)
+        return orig_forward(*fargs, **fkwargs)
+    return _pinned
+
+
+def _patch_broadcast_and_multiply() -> None:
+    """``network_mixins.broadcast_and_multiply(tensor, multiplier)`` fails
+    when ``tensor`` and ``multiplier`` live on different devices. Auto-move
+    the multiplier to match.
+    """
+    from toolkit import network_mixins as _nm
+
+    if getattr(_nm, "_dual_gpu_bm_patched", False):
+        return
+
+    _orig_bm = _nm.broadcast_and_multiply
+
+    def _device_aware_bm(tensor, multiplier):
+        try:
+            if hasattr(multiplier, "device") and multiplier.device != tensor.device:
+                multiplier = multiplier.to(tensor.device)
+        except Exception:
+            pass
+        return _orig_bm(tensor, multiplier)
+
+    _nm.broadcast_and_multiply = _device_aware_bm
+    _nm._dual_gpu_bm_patched = True

--- a/extensions_built_in/diffusion_models/hidream/hidream_dual_gpu.py
+++ b/extensions_built_in/diffusion_models/hidream/hidream_dual_gpu.py
@@ -1,0 +1,616 @@
+"""Dual-GPU model-parallel path for HiDream-I1 LoRA training.
+
+Activates when ``HIDREAM_DUAL_GPU=true``. Distributes the
+``HiDreamImageTransformer2DModel`` (ai-toolkit's vendored copy under
+``hidream/src/models/transformers/`` — NOT the diffusers-package class,
+which has a substantially different forward) across two CUDA devices with a single
+PCIe boundary mid-``single_stream_blocks``, keeps the four HiDream text
+encoders (CLIP-L, CLIP-G, T5-XXL, Llama-3.1-8B) on a configurable device
+(CPU recommended for 32 GB cards — the Llama encoder alone is ~30 GB),
+and reuses the same LoRA / multiplier patches the FLUX.2 / Wan 2.2 /
+LTX-2 / Qwen-Image dual-GPU paths install (those hook ai-toolkit-wide
+classes, not model-specific ones, so they apply unchanged here — the
+shared ``_PATCHES_INSTALLED`` flag makes calling all of them safe).
+
+Targets the ai-toolkit HiDream trainer
+(``extensions_built_in/diffusion_models/hidream/hidream_model.py``).
+Integration is a small edit at the call site:
+
+1. Make ``HidreamModel`` inherit from ``HiDreamDualGPUMixin`` first
+   (MRO ordering: mixin before ``BaseModel``).
+2. In ``HidreamModel.load_model``, after quantize, call
+   ``self.setup_dual_gpu_distribution(transformer, dtype)`` gated by
+   ``is_dual_gpu_enabled()`` — and keep the transformer on CPU through
+   quantize so the mixin can distribute afterward.
+
+Unlike FLUX.2's per-block hooks, HiDream (like Qwen-Image / Wan 2.2 /
+LTX-2) precomputes all loop-invariant tensors (``temb``, the RoPE
+``image_rotary_emb``, the ``caption_projection`` of the encoder states)
+once before the two block loops, so a single-boundary ``forward``
+replacement is sufficient. HiDream has two sequential block loops —
+``double_stream_blocks`` then ``single_stream_blocks`` — that both
+consume the precomputed context. All ``double_stream_blocks`` plus the
+first half of ``single_stream_blocks`` live on cuda:0; the remaining
+``single_stream_blocks`` plus ``final_layer`` live on cuda:1, with one
+PCIe boundary inside the single-stream loop.
+
+Env vars:
+    HIDREAM_DUAL_GPU=true              enable the dual-GPU path
+    HIDREAM_TE_DEVICE=cpu             pin the four text encoders
+    HIDREAM_DUAL_GPU_SPLIT_AT=16      override single_stream_blocks split
+                                      index (default: num_single_layers // 2)
+"""
+from __future__ import annotations
+
+import os
+import types
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from diffusers.utils import logging
+
+if TYPE_CHECKING:
+    from .hidream_model import HidreamModel  # noqa: F401
+
+logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
+
+
+def is_dual_gpu_enabled() -> bool:
+    return os.getenv("HIDREAM_DUAL_GPU", "false").lower() == "true"
+
+
+def get_te_device_override() -> torch.device | None:
+    """Returns the text-encoder device override if HIDREAM_TE_DEVICE is set."""
+    val = os.getenv("HIDREAM_TE_DEVICE")
+    return torch.device(val) if val else None
+
+
+class HiDreamDualGPUMixin:
+    """Mixin for :class:`HidreamModel` that adds the dual-GPU training path.
+
+    The mixin contributes:
+
+    - ``te_device_torch`` attribute (resolved from ``HIDREAM_TE_DEVICE``
+      or defaulting to ``device_torch``). Always present — used even when
+      dual-GPU itself is disabled.
+    - ``text_encoder_to`` override that routes the four HiDream text
+      encoders to ``te_device_torch`` instead of ``device_torch``.
+    - ``setup_dual_gpu_distribution(transformer, dtype)`` to be called
+      from ``load_model`` after the transformer has been quantized (if
+      applicable) and before the pipeline composes it. Distributes
+      modules across cuda:0/cuda:1, replaces
+      ``HiDreamImageTransformer2DModel.forward`` with a split-aware
+      variant, pins ``transformer.to()`` to ignore device arguments, and
+      installs the LoRA / multiplier patches.
+    - ``preserve_dual_gpu_split_on_pipe(pipe)`` — to be checked in place
+      of the single-device ``pipe.transformer.to(self.device_torch)``
+      call so the distributed layout survives pipeline composition.
+
+    Note on diffusers ``_no_split_modules`` (``HiDreamImageTransformerBlock``
+    + ``HiDreamImageSingleTransformerBlock``): that attribute governs
+    HuggingFace ``accelerate`` device-map sharding (it forbids splitting
+    *within* a block). Our split is *between* blocks at a configurable
+    boundary, so the attribute is informational only and does not
+    constrain us. HiDream's MoE (``MoEGate`` / ``MOEFeedForwardSwiGLU``)
+    lives inside the blocks, so it distributes with them transparently —
+    no special handling.
+    """
+
+    te_device_torch: torch.device
+
+    # ---------------------------------------------------------------- init
+
+    def init_te_device(self) -> None:
+        """Resolve ``te_device_torch`` from env var or fall back to model device.
+
+        Must be called from :meth:`HidreamModel.__init__` after the base
+        ``__init__`` (which establishes ``self.device_torch``).
+        """
+        override = get_te_device_override()
+        self.te_device_torch = override if override is not None else self.device_torch  # type: ignore[attr-defined]
+        if self.te_device_torch.type == "cpu":
+            self.print_and_status_update(  # type: ignore[attr-defined]
+                "HIDREAM_TE_DEVICE=cpu — the four HiDream text encoders "
+                "(incl. the ~30 GB Llama-3.1-8B) will run on CPU. Set "
+                "`cache_text_embeddings: true` in your config so they run "
+                "once at startup; otherwise they run on CPU every step."
+            )
+
+    # ----------------------------------------------------------- TE override
+
+    def text_encoder_to(self, *args: Any, **kwargs: Any) -> None:
+        """Override of BaseModel.text_encoder_to that honors te_device_torch.
+
+        ai-toolkit's :class:`SDTrainer` hook ``hook_before_train_loop``
+        calls ``self.sd.text_encoder_to(self.device_torch)``
+        unconditionally. With ``HIDREAM_TE_DEVICE=cpu`` we want all four
+        HiDream text encoders to stay on CPU regardless. HiDream stores
+        them as a list (``text_encoder_list`` — CLIP-L, CLIP-G, T5-XXL,
+        Llama-3.1-8B), so iterate it; fall back to a single encoder for
+        safety.
+        """
+        target = self.te_device_torch
+        if isinstance(self.text_encoder, list):  # type: ignore[attr-defined]
+            for encoder in self.text_encoder:  # type: ignore[attr-defined]
+                encoder.to(target)
+        else:
+            self.text_encoder.to(target)  # type: ignore[attr-defined]
+
+    # ------------------------------------------------------------ load hook
+
+    def setup_dual_gpu_distribution(self, transformer: torch.nn.Module, dtype: torch.dtype) -> None:
+        """Distribute the HiDream transformer across cuda:0 and cuda:1.
+
+        Layout:
+            cuda:0  — ``x_embedder``, ``t_embedder``, ``p_embedder``,
+                      ``pe_embedder``, ``caption_projection``, ALL
+                      ``double_stream_blocks``, ``single_stream_blocks[:split_at]``
+            cuda:1  — ``single_stream_blocks[split_at:]``, ``final_layer``
+
+        ``HiDreamImageTransformer2DModel`` has no module-level
+        ``nn.Parameter`` attributes (unlike Wan/LTX-2's
+        ``scale_shift_table``); every weight lives inside a sub-module —
+        including the MoE gating ``weight`` inside ``MoEGate``, which is
+        nested inside the blocks — so plain ``.to()`` reaches all of
+        them. RoPE is computed dynamically inside ``forward`` (no
+        plain-attribute freq tensor to move).
+
+        Also installs the LoRA / multiplier patches that align downstream
+        ai-toolkit machinery with the split layout.
+        """
+        if not torch.cuda.is_available() or torch.cuda.device_count() < 2:
+            raise RuntimeError(
+                "HIDREAM_DUAL_GPU=true needs at least 2 CUDA devices (cuda:0 + "
+                f"cuda:1); found {torch.cuda.device_count() if torch.cuda.is_available() else 0}. "
+                "Unset HIDREAM_DUAL_GPU for single-GPU training."
+            )
+
+        d0 = torch.device("cuda:0")
+        d1 = torch.device("cuda:1")
+        n_single = len(transformer.single_stream_blocks)
+        override = os.getenv("HIDREAM_DUAL_GPU_SPLIT_AT")
+        if override is not None:
+            try:
+                split_at = int(override)
+            except ValueError:
+                raise ValueError(
+                    "HIDREAM_DUAL_GPU_SPLIT_AT must be an integer; got "
+                    f"{override!r}."
+                )
+            if not (1 <= split_at < n_single):
+                raise ValueError(
+                    f"HIDREAM_DUAL_GPU_SPLIT_AT={split_at} is out of range; "
+                    f"must be in [1, {n_single - 1}] for a model with "
+                    f"{n_single} single_stream_blocks."
+                )
+        else:
+            split_at = n_single // 2
+
+        self.print_and_status_update(  # type: ignore[attr-defined]
+            f"Distributing transformer across {d0} and {d1}"
+        )
+        self.print_and_status_update(  # type: ignore[attr-defined]
+            f"Single-block split: {split_at} on {d0}, "
+            f"{n_single - split_at} on {d1}"
+        )
+
+        # --- cuda:0: embedders, caption projection, double-stream blocks,
+        #     first half of single-stream blocks
+        transformer.x_embedder.to(d0, dtype=dtype)
+        transformer.t_embedder.to(d0, dtype=dtype)
+        transformer.p_embedder.to(d0, dtype=dtype)
+        # pe_embedder (HiDreamImageEmbedND) has no parameters — RoPE is
+        # computed via torch.arange inside its forward — but move it for
+        # consistency so its forward runs on cuda:0.
+        transformer.pe_embedder.to(d0, dtype=dtype)
+        # caption_projection is consumed once, before the block loops, to
+        # project every encoder state; keep it on cuda:0.
+        transformer.caption_projection.to(d0, dtype=dtype)
+
+        for blk in transformer.double_stream_blocks:
+            blk.to(d0, dtype=dtype)
+
+        for i, blk in enumerate(transformer.single_stream_blocks):
+            blk.to(d0 if i < split_at else d1, dtype=dtype)
+
+        # --- cuda:1: final output layer
+        transformer.final_layer.to(d1, dtype=dtype)
+
+        transformer.forward = types.MethodType(
+            _make_split_forward(split_at), transformer
+        )
+        _pin_transformer_to(transformer)
+
+        _install_external_patches()
+
+    # ----------------------------------------------------- pipeline composer
+
+    def preserve_dual_gpu_split_on_pipe(self, pipe: Any) -> bool:
+        """Return True if we've already distributed; caller should skip the
+        single-device ``pipe.transformer.to(device)`` call."""
+        return is_dual_gpu_enabled()
+
+
+# ---------------------------------------------------------------- helpers
+
+
+def _make_split_forward(split_at: int):
+    """Create a ``HiDreamImageTransformer2DModel.forward`` variant that
+    inserts a cuda:1 boundary at ``single_stream_blocks[split_at]``.
+
+    Recreates ai-toolkit's *vendored* ``HiDreamImageTransformer2DModel.forward``
+    (``src/models/transformers/transformer_hidream_image.py`` — the copy the
+    hidream extension actually imports, NOT the diffusers-package copy) with
+    two additions:
+
+      1. The ``double_stream_blocks`` loop runs entirely on cuda:0. Its
+         outputs (``hidden_states`` + the threaded
+         ``initial_encoder_hidden_states``) are concatenated and fed into
+         the ``single_stream_blocks`` loop, also starting on cuda:0.
+      2. At ``single_stream_blocks[split_at]`` — the single PCIe boundary
+         — bridge to cuda:1 every tensor the downstream single blocks +
+         ``final_layer`` consume: ``hidden_states``, ``image_tokens_masks``,
+         ``adaln_input``, ``rope``, and every remaining
+         ``encoder_hidden_states`` entry indexed by ``block_id`` in the
+         loop tail. After ``final_layer`` / ``unpatchify`` the output is
+         moved back to cuda:0 so downstream loss ops (which run on the
+         model's nominal device) work without a device-mismatch error.
+
+    Signature and return type match the vendored forward exactly:
+    ``tuple[torch.Tensor, torch.Tensor] | Transformer2DModelOutput`` (the
+    vendored forward returns ``(output, image_tokens_masks)`` /
+    ``Transformer2DModelOutput(sample=output, mask=image_tokens_masks)``).
+    """
+    from diffusers.models.modeling_outputs import Transformer2DModelOutput
+    from diffusers.utils import USE_PEFT_BACKEND, scale_lora_layers, unscale_lora_layers
+    from einops import repeat
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        timesteps: torch.LongTensor = None,
+        encoder_hidden_states: torch.Tensor = None,
+        pooled_embeds: torch.Tensor = None,
+        img_sizes: Any = None,
+        img_ids: Any = None,
+        joint_attention_kwargs: dict[str, Any] | None = None,
+        return_dict: bool = True,
+    ):
+        if joint_attention_kwargs is not None:
+            joint_attention_kwargs = joint_attention_kwargs.copy()
+            lora_scale = joint_attention_kwargs.pop("scale", 1.0)
+        else:
+            lora_scale = 1.0
+
+        if USE_PEFT_BACKEND:
+            # weight the lora layers by setting `lora_scale` for each PEFT layer
+            scale_lora_layers(self, lora_scale)
+        else:
+            if joint_attention_kwargs is not None and joint_attention_kwargs.get("scale", None) is not None:
+                logger.warning(
+                    "Passing `scale` via `joint_attention_kwargs` when not using the PEFT backend is ineffective."
+                )
+
+        # spatial forward
+        batch_size = hidden_states.shape[0]
+        hidden_states_type = hidden_states.dtype
+
+        # 0. time
+        timesteps = self.expand_timesteps(timesteps, batch_size, hidden_states.device)
+        timesteps = self.t_embedder(timesteps, hidden_states_type)
+        p_embedder = self.p_embedder(pooled_embeds)
+        adaln_input = timesteps + p_embedder
+
+        hidden_states, image_tokens_masks, img_sizes = self.patchify(hidden_states, self.max_seq, img_sizes)
+        if image_tokens_masks is None:
+            pH, pW = img_sizes[0]
+            img_ids = torch.zeros(pH, pW, 3, device=hidden_states.device)
+            img_ids[..., 1] = img_ids[..., 1] + torch.arange(pH, device=hidden_states.device)[:, None]
+            img_ids[..., 2] = img_ids[..., 2] + torch.arange(pW, device=hidden_states.device)[None, :]
+            img_ids = repeat(img_ids, "h w c -> b (h w) c", b=batch_size)
+        hidden_states = self.x_embedder(hidden_states)
+
+        T5_encoder_hidden_states = encoder_hidden_states[0]
+        encoder_hidden_states = encoder_hidden_states[-1]
+        encoder_hidden_states = [encoder_hidden_states[k] for k in self.llama_layers]
+
+        if self.caption_projection is not None:
+            new_encoder_hidden_states = []
+            for i, enc_hidden_state in enumerate(encoder_hidden_states):
+                enc_hidden_state = self.caption_projection[i](enc_hidden_state)
+                enc_hidden_state = enc_hidden_state.view(batch_size, -1, hidden_states.shape[-1])
+                new_encoder_hidden_states.append(enc_hidden_state)
+            encoder_hidden_states = new_encoder_hidden_states
+            T5_encoder_hidden_states = self.caption_projection[-1](T5_encoder_hidden_states)
+            T5_encoder_hidden_states = T5_encoder_hidden_states.view(batch_size, -1, hidden_states.shape[-1])
+            encoder_hidden_states.append(T5_encoder_hidden_states)
+
+        txt_ids = torch.zeros(
+            batch_size,
+            encoder_hidden_states[-1].shape[1] + encoder_hidden_states[-2].shape[1] + encoder_hidden_states[0].shape[1],
+            3,
+            device=img_ids.device, dtype=img_ids.dtype
+        )
+        ids = torch.cat((img_ids, txt_ids), dim=1)
+        rope = self.pe_embedder(ids)
+
+        # Devices of the first single block on each side of the boundary.
+        # The double-stream blocks + single_stream_blocks[:split_at] all
+        # live on d0_dev; single_stream_blocks[split_at:] + final_layer
+        # live on d1_dev.
+        d0_dev = next(self.single_stream_blocks[0].parameters()).device
+        d1_dev = next(self.single_stream_blocks[split_at].parameters()).device
+
+        # 2. Blocks
+        block_id = 0
+        initial_encoder_hidden_states = torch.cat([encoder_hidden_states[-1], encoder_hidden_states[-2]], dim=1)
+        initial_encoder_hidden_states_seq_len = initial_encoder_hidden_states.shape[1]
+        for bid, block in enumerate(self.double_stream_blocks):
+            cur_llama31_encoder_hidden_states = encoder_hidden_states[block_id].detach()
+            cur_encoder_hidden_states = torch.cat([initial_encoder_hidden_states, cur_llama31_encoder_hidden_states], dim=1)
+            if torch.is_grad_enabled() and self.gradient_checkpointing:
+                hidden_states, initial_encoder_hidden_states = self._gradient_checkpointing_func(
+                    block,
+                    hidden_states,
+                    image_tokens_masks,
+                    cur_encoder_hidden_states,
+                    adaln_input.clone(),
+                    rope.clone(),
+                )
+
+            else:
+                hidden_states, initial_encoder_hidden_states = block(
+                    image_tokens = hidden_states,
+                    image_tokens_masks = image_tokens_masks,
+                    text_tokens = cur_encoder_hidden_states,
+                    adaln_input = adaln_input,
+                    rope = rope,
+                )
+            initial_encoder_hidden_states = initial_encoder_hidden_states[:, :initial_encoder_hidden_states_seq_len]
+            block_id += 1
+
+        image_tokens_seq_len = hidden_states.shape[1]
+        hidden_states = torch.cat([hidden_states, initial_encoder_hidden_states], dim=1)
+        hidden_states_seq_len = hidden_states.shape[1]
+        if image_tokens_masks is not None:
+            encoder_attention_mask_ones = torch.ones(
+                (batch_size, initial_encoder_hidden_states.shape[1] + cur_llama31_encoder_hidden_states.shape[1]),
+                device=image_tokens_masks.device, dtype=image_tokens_masks.dtype
+            )
+            image_tokens_masks = torch.cat([image_tokens_masks, encoder_attention_mask_ones], dim=1)
+
+        for bid, block in enumerate(self.single_stream_blocks):
+            if bid == split_at and d1_dev != d0_dev:
+                # PCIe boundary: bridge every tensor the downstream single
+                # blocks + final_layer consume to cuda:1. The remaining
+                # encoder_hidden_states entries (indexed by block_id in the
+                # loop body) are bridged here in one pass; adaln_input is
+                # reused by final_layer too.
+                hidden_states = hidden_states.to(d1_dev)
+                adaln_input = adaln_input.to(d1_dev)
+                rope = rope.to(d1_dev)
+                if image_tokens_masks is not None:
+                    image_tokens_masks = image_tokens_masks.to(d1_dev)
+                encoder_hidden_states = [
+                    ehs.to(d1_dev) if idx >= block_id else ehs
+                    for idx, ehs in enumerate(encoder_hidden_states)
+                ]
+            cur_llama31_encoder_hidden_states = encoder_hidden_states[block_id].detach()
+            hidden_states = torch.cat([hidden_states, cur_llama31_encoder_hidden_states], dim=1)
+            if torch.is_grad_enabled() and self.gradient_checkpointing:
+                hidden_states = self._gradient_checkpointing_func(
+                    block,
+                    hidden_states,
+                    image_tokens_masks,
+                    None,
+                    adaln_input.clone(),
+                    rope.clone(),
+                )
+            else:
+                hidden_states = block(
+                    image_tokens = hidden_states,
+                    image_tokens_masks = image_tokens_masks,
+                    text_tokens = None,
+                    adaln_input = adaln_input,
+                    rope = rope,
+                )
+            hidden_states = hidden_states[:, :hidden_states_seq_len]
+            block_id += 1
+
+        hidden_states = hidden_states[:, :image_tokens_seq_len, ...]
+        # final_layer lives on cuda:1; adaln_input was bridged at the boundary
+        # above (when split_at < n_single it always runs), so it already matches.
+        output = self.final_layer(hidden_states, adaln_input)
+        output = self.unpatchify(output, img_sizes, self.training)
+        if image_tokens_masks is not None:
+            image_tokens_masks = image_tokens_masks[:, :image_tokens_seq_len]
+
+        if USE_PEFT_BACKEND:
+            # remove `lora_scale` from each PEFT layer
+            unscale_lora_layers(self, lora_scale)
+
+        # Return on cuda:0 so downstream loss / scatter ops (which run on the
+        # model's nominal device) work without a device-mismatch error.
+        if output.device != d0_dev:
+            output = output.to(d0_dev)
+        if image_tokens_masks is not None and image_tokens_masks.device != d0_dev:
+            image_tokens_masks = image_tokens_masks.to(d0_dev)
+
+        if not return_dict:
+            return (output, image_tokens_masks)
+        return Transformer2DModelOutput(sample=output, mask=image_tokens_masks)
+
+    return forward
+
+
+def _pin_transformer_to(transformer: torch.nn.Module) -> None:
+    """Wrap ``transformer.to()`` so device arguments are stripped (the model
+    is already distributed) while dtype changes still pass through.
+
+    Without this, ai-toolkit hooks like ``set_device_state`` (called every
+    training step) and ``pipe.transformer.to(self.device_torch)`` (the
+    pipeline composer) would silently re-collect the split onto cuda:0.
+    """
+    _orig_to = transformer.to
+
+    def _split_preserving_to(*args: Any, **kwargs: Any):
+        filtered_args = [
+            a for a in args
+            if not isinstance(a, (str, torch.device, int))
+        ]
+        filtered_kwargs = {k: v for k, v in kwargs.items() if k != "device"}
+        if not filtered_args and not filtered_kwargs:
+            return transformer
+        return _orig_to(*filtered_args, **filtered_kwargs)
+
+    transformer.to = _split_preserving_to  # type: ignore[assignment]
+
+
+# Module-level idempotency flag. The external patches hook
+# ai-toolkit-wide classes (``ToolkitNetworkMixin``, ``LoRANetwork``,
+# ``network_mixins.broadcast_and_multiply``) — not HiDream-specific
+# code — so they're already installed by the FLUX.2 / Wan / LTX-2 /
+# Qwen-Image paths if any ran first. Gate all three installers behind a
+# single module flag plus per-target attribute flags (defense in depth).
+_PATCHES_INSTALLED = False
+
+
+def _install_external_patches() -> None:
+    """Idempotently install the LoRA-placement and multiplier-device patches.
+
+    These hook external ai-toolkit classes — done as runtime patches so
+    this file remains a self-contained addition. Safe to call alongside
+    the FLUX.2 / Wan / LTX-2 / Qwen-Image helpers; all gate on the same
+    per-target flags.
+    """
+    global _PATCHES_INSTALLED
+    if _PATCHES_INSTALLED:
+        return
+    _patch_force_to()
+    _patch_apply_to_with_lazy_forward()
+    _patch_broadcast_and_multiply()
+    _PATCHES_INSTALLED = True
+
+
+def _patch_force_to() -> None:
+    """``ToolkitNetworkMixin.force_to`` moves the network's submodules to a
+    single device. Override so each LoRA module follows the device of the
+    layer it wraps.
+    """
+    from toolkit.network_mixins import ToolkitNetworkMixin
+
+    if getattr(ToolkitNetworkMixin, "_dual_gpu_patched", False):
+        return
+
+    def _per_layer_force_to(self_n, device, dtype):
+        try:
+            self_n.to(device, dtype)
+        except Exception:
+            pass
+        loras = []
+        if hasattr(self_n, "unet_loras"):
+            loras += self_n.unet_loras
+        if hasattr(self_n, "text_encoder_loras"):
+            loras += self_n.text_encoder_loras
+        for lora in loras:
+            tgt = device
+            try:
+                parent = lora.org_module[0]
+                p = next(parent.parameters(), None)
+                if p is not None:
+                    tgt = p.device
+            except Exception:
+                pass
+            lora.to(tgt, dtype)
+            for attr in ("lora_down", "lora_up", "lora_mid"):
+                m = getattr(lora, attr, None)
+                if m is not None:
+                    try:
+                        m.to(tgt, dtype)
+                    except Exception:
+                        pass
+
+    ToolkitNetworkMixin.force_to = _per_layer_force_to
+    ToolkitNetworkMixin._dual_gpu_patched = True
+
+
+def _patch_apply_to_with_lazy_forward() -> None:
+    """``LoRANetwork.apply_to`` creates wrapped LoRA modules and registers
+    them as submodules. After it runs, each LoRA's forward is wrapped to
+    lazily re-pin parameters to the input's device on every call.
+
+    The lazy-pin is the load-bearing safety net — any later ai-toolkit
+    hook that calls ``network.to(device)`` (e.g., from
+    ``accelerate.prepare``) is silently corrected on the next forward.
+    """
+    from toolkit.kohya_lora import LoRANetwork
+
+    if getattr(LoRANetwork, "_dual_gpu_apply_patched", False):
+        return
+
+    _orig_apply_to = LoRANetwork.apply_to
+
+    def _redistribute_apply_to(self_n, *args, **kwargs):
+        ret = _orig_apply_to(self_n, *args, **kwargs)
+        loras = []
+        if hasattr(self_n, "unet_loras"):
+            loras += self_n.unet_loras
+        if hasattr(self_n, "text_encoder_loras"):
+            loras += self_n.text_encoder_loras
+        for lora in loras:
+            if getattr(lora, "_dual_gpu_wrapped", False):
+                continue
+            lora.forward = _make_pinned_forward(lora, lora.forward)
+            try:
+                lora.org_module[0].forward = lora.forward
+            except Exception:
+                pass
+            lora._dual_gpu_wrapped = True
+        return ret
+
+    LoRANetwork.apply_to = _redistribute_apply_to
+    LoRANetwork._dual_gpu_apply_patched = True
+
+
+def _make_pinned_forward(lora, orig_forward):
+    """Wrap a LoRA module's forward to re-pin its parameters to the input
+    tensor's device on each call. Cheap no-op when devices already match.
+    """
+    def _pinned(*fargs, **fkwargs):
+        in_dev = None
+        for a in fargs:
+            if hasattr(a, "device") and getattr(a, "is_cuda", False):
+                in_dev = a.device
+                break
+        if in_dev is None:
+            return orig_forward(*fargs, **fkwargs)
+        p = next(lora.parameters(), None)
+        if p is not None and p.device != in_dev:
+            lora.to(in_dev)
+        return orig_forward(*fargs, **fkwargs)
+    return _pinned
+
+
+def _patch_broadcast_and_multiply() -> None:
+    """``network_mixins.broadcast_and_multiply(tensor, multiplier)`` fails
+    when ``tensor`` and ``multiplier`` live on different devices. Auto-move
+    the multiplier to match.
+    """
+    from toolkit import network_mixins as _nm
+
+    if getattr(_nm, "_dual_gpu_bm_patched", False):
+        return
+
+    _orig_bm = _nm.broadcast_and_multiply
+
+    def _device_aware_bm(tensor, multiplier):
+        try:
+            if hasattr(multiplier, "device") and multiplier.device != tensor.device:
+                multiplier = multiplier.to(tensor.device)
+        except Exception:
+            pass
+        return _orig_bm(tensor, multiplier)
+
+    _nm.broadcast_and_multiply = _device_aware_bm
+    _nm._dual_gpu_bm_patched = True

--- a/extensions_built_in/diffusion_models/hidream/hidream_model.py
+++ b/extensions_built_in/diffusion_models/hidream/hidream_model.py
@@ -23,6 +23,7 @@ from transformers import T5TokenizerFast, T5EncoderModel, CLIPTextModel, CLIPTok
 from .src.pipelines.hidream_image.pipeline_hidream_image import HiDreamImagePipeline
 from .src.models.transformers.transformer_hidream_image import HiDreamImageTransformer2DModel
 from .src.schedulers.fm_solvers_unipc import FlowUniPCMultistepScheduler
+from .hidream_dual_gpu import HiDreamDualGPUMixin, is_dual_gpu_enabled
 from transformers import LlamaForCausalLM, PreTrainedTokenizerFast
 from einops import rearrange, repeat
 import random
@@ -50,7 +51,10 @@ LLAMA_MODEL_PATH = "unsloth/Meta-Llama-3.1-8B-Instruct"
 BASE_MODEL_PATH = "HiDream-ai/HiDream-I1-Full"
 
 
-class HidreamModel(BaseModel):
+# HiDreamDualGPUMixin is first in the MRO so its text_encoder_to override
+# and setup_dual_gpu_distribution take precedence over BaseModel. The
+# dual-GPU path itself stays inert unless HIDREAM_DUAL_GPU=true.
+class HidreamModel(HiDreamDualGPUMixin, BaseModel):
     arch = "hidream"
     hidream_transformer_class = HiDreamImageTransformer2DModel
     hidream_pipeline_class = HiDreamImagePipeline
@@ -75,6 +79,9 @@ class HidreamModel(BaseModel):
         self.is_flow_matching = True
         self.is_transformer = True
         self.target_lora_modules = ['HiDreamImageTransformer2DModel']
+        # Resolve te_device_torch (HIDREAM_TE_DEVICE or device_torch). Always
+        # present; used even when the dual-GPU path itself is disabled.
+        self.init_te_device()
 
     # static method to get the noise scheduler
     @staticmethod
@@ -109,7 +116,9 @@ class HidreamModel(BaseModel):
             output_attentions=True,
             torch_dtype=torch.bfloat16,
         )
-        text_encoder_4.to(self.device_torch, dtype=dtype)
+        # te_device_torch, not device_torch: under HIDREAM_DUAL_GPU the ~30 GB
+        # Llama-3.1-8B encoder must land on CPU to free VRAM for the split transformer.
+        text_encoder_4.to(self.te_device_torch, dtype=dtype)
         
         if self.model_config.quantize_te:
             self.print_and_status_update("Quantizing llama 8b model")
@@ -126,14 +135,17 @@ class HidreamModel(BaseModel):
         self.print_and_status_update("Loading transformer")
             
         transformer = self.hidream_transformer_class.from_pretrained(
-            model_path, 
-            subfolder="transformer", 
+            model_path,
+            subfolder="transformer",
             torch_dtype=torch.bfloat16
         )
-        
-        if not self.low_vram:
+
+        # Under HIDREAM_DUAL_GPU keep the transformer on CPU through quantize so
+        # the mixin can distribute its modules across cuda:0/cuda:1 cleanly after.
+        use_dual_gpu = is_dual_gpu_enabled()
+        if not self.low_vram and not use_dual_gpu:
             transformer.to(self.device_torch, dtype=dtype)
-        
+
         if self.model_config.quantize:
             self.print_and_status_update("Quantizing transformer")
             quantization_type = get_qtype(self.model_config.qtype)
@@ -152,14 +164,22 @@ class HidreamModel(BaseModel):
                 transformer.to(self.device_torch, dtype=dtype)
                 quantize(transformer, weights=quantization_type)
                 freeze(transformer)
-            else: 
+            else:
                 quantize(transformer, weights=quantization_type)
                 freeze(transformer)
-            
-        if self.low_vram:
+
+        # Dual-GPU model-parallel path (HIDREAM_DUAL_GPU=true). The transformer
+        # is still on CPU here, so the mixin can distribute its modules across
+        # cuda:0/cuda:1 cleanly. After this returns the transformer's .to() is
+        # pinned to ignore device moves.
+        if use_dual_gpu:
+            self.setup_dual_gpu_distribution(transformer, dtype)
+            flush()
+
+        if self.low_vram and not use_dual_gpu:
             # unload it for now
             transformer.to('cpu')
-        
+
         flush()
         
         self.print_and_status_update("Loading vae")
@@ -173,22 +193,25 @@ class HidreamModel(BaseModel):
         
         self.print_and_status_update("Loading clip encoders")
         
+        # te_device_torch, not device_torch: under HIDREAM_DUAL_GPU the text
+        # encoders are offloaded (typically to CPU) to free VRAM for the split transformer.
         text_encoder = CLIPTextModelWithProjection.from_pretrained(
             extras_path,
             subfolder="text_encoder",
             torch_dtype=torch.bfloat16
-        ).to(self.device_torch, dtype=dtype)
-        
+        ).to(self.te_device_torch, dtype=dtype)
+
         tokenizer = CLIPTokenizer.from_pretrained(
             extras_path,
             subfolder="tokenizer"
         )
-        
+
+        # te_device_torch, not device_torch: text encoders offloaded under HIDREAM_DUAL_GPU.
         text_encoder_2 = CLIPTextModelWithProjection.from_pretrained(
             extras_path,
             subfolder="text_encoder_2",
             torch_dtype=torch.bfloat16
-        ).to(self.device_torch, dtype=dtype)
+        ).to(self.te_device_torch, dtype=dtype)
         
         tokenizer_2 = CLIPTokenizer.from_pretrained(
             extras_path,
@@ -198,11 +221,12 @@ class HidreamModel(BaseModel):
         flush()
         self.print_and_status_update("Loading T5 encoders")
         
+        # te_device_torch, not device_torch: text encoders offloaded under HIDREAM_DUAL_GPU.
         text_encoder_3 = T5EncoderModel.from_pretrained(
             extras_path,
             subfolder="text_encoder_3",
             torch_dtype=torch.bfloat16
-        ).to(self.device_torch, dtype=dtype)
+        ).to(self.te_device_torch, dtype=dtype)
         
         if self.model_config.quantize_te:
             self.print_and_status_update("Quantizing T5")
@@ -219,13 +243,16 @@ class HidreamModel(BaseModel):
         
         if self.low_vram:
             self.print_and_status_update("Moving everything to device")
-            # move it all back
-            transformer.to(self.device_torch, dtype=dtype)
+            # move it all back. Under HIDREAM_DUAL_GPU the transformer is
+            # already distributed (and its .to() pinned), so leave it; the
+            # text encoders route to te_device_torch to keep VRAM free.
+            if not use_dual_gpu:
+                transformer.to(self.device_torch, dtype=dtype)
             vae.to(self.device_torch, dtype=dtype)
-            text_encoder.to(self.device_torch, dtype=dtype)
-            text_encoder_2.to(self.device_torch, dtype=dtype)
-            text_encoder_4.to(self.device_torch, dtype=dtype)
-            text_encoder_3.to(self.device_torch, dtype=dtype)
+            text_encoder.to(self.te_device_torch, dtype=dtype)
+            text_encoder_2.to(self.te_device_torch, dtype=dtype)
+            text_encoder_4.to(self.te_device_torch, dtype=dtype)
+            text_encoder_3.to(self.te_device_torch, dtype=dtype)
             
         # set to eval mode
         # transformer.eval()
@@ -255,8 +282,10 @@ class HidreamModel(BaseModel):
         tokenizer_list = [tokenizer, tokenizer_2, tokenizer_3, tokenizer_4]
         
         for te in text_encoder_list:
-            # set the dtype
-            te.to(self.device_torch, dtype=dtype)
+            # set the dtype. te_device_torch, not device_torch: under
+            # HIDREAM_DUAL_GPU the text encoders stay off the GPUs holding
+            # the split transformer.
+            te.to(self.te_device_torch, dtype=dtype)
             # freeze the model
             freeze(te)
             # set to eval mode
@@ -389,16 +418,34 @@ class HidreamModel(BaseModel):
     def get_prompt_embeds(self, prompt: str) -> PromptEmbeds:
         self.text_encoder_to(self.device_torch, dtype=self.torch_dtype)
         max_sequence_length = 128
+        # Route tokenization + encoding through the TE device. Under
+        # HIDREAM_TE_DEVICE=cpu the 4 text encoders live on CPU, and
+        # _encode_prompt uses ``device`` to place input_ids before calling
+        # each text_encoder. Mismatched device crashes inside CLIP's
+        # token_embedding (RuntimeError: index on cuda:0, weight on cpu).
         prompt_embeds, pooled_prompt_embeds = self.pipeline._encode_prompt(
             prompt = prompt,
             prompt_2 = prompt,
             prompt_3 = prompt,
             prompt_4 = prompt,
-            device = self.device_torch,
+            device = self.te_device_torch,
             dtype = self.torch_dtype,
             num_images_per_prompt = 1,
             max_sequence_length = max_sequence_length,
         )
+        # Bring outputs back to the trainer device so downstream pipeline
+        # ops (which run on device_torch) match. HiDream's _encode_prompt
+        # returns prompt_embeds as a *list* of per-encoder tensors (one
+        # per of the 4 text encoders) and pooled_prompt_embeds as a
+        # single tensor — move both shapes element-wise.
+        def _to_device(x):
+            if isinstance(x, (list, tuple)):
+                return type(x)(_to_device(v) for v in x)
+            if hasattr(x, "to") and getattr(x, "device", None) != self.device_torch:
+                return x.to(self.device_torch)
+            return x
+        prompt_embeds = _to_device(prompt_embeds)
+        pooled_prompt_embeds = _to_device(pooled_prompt_embeds)
         pe = PromptEmbeds(
             [prompt_embeds, pooled_prompt_embeds]
         )

--- a/extensions_built_in/diffusion_models/ltx2/ltx2.py
+++ b/extensions_built_in/diffusion_models/ltx2/ltx2.py
@@ -23,6 +23,8 @@ from safetensors.torch import load_file
 from PIL import Image
 import huggingface_hub
 
+from .ltx2_dual_gpu import LTX2DualGPUMixin, is_dual_gpu_enabled
+
 try:
     from diffusers import LTX2Pipeline, LTX2ImageToVideoPipeline
     from diffusers.models.autoencoders import (
@@ -198,7 +200,10 @@ class AudioProcessor(torch.nn.Module):
         return mel.permute(0, 1, 3, 2).contiguous()
 
 
-class LTX2Model(BaseModel):
+# LTX2DualGPUMixin is first in the MRO so its text_encoder_to override and
+# setup_dual_gpu_distribution take precedence over BaseModel. The dual-GPU
+# path itself stays inert unless LTX2_DUAL_GPU=true.
+class LTX2Model(LTX2DualGPUMixin, BaseModel):
     arch = "ltx2"
     ltx_version = "2.0"
     ltx_te_path = None
@@ -215,6 +220,9 @@ class LTX2Model(BaseModel):
         super().__init__(
             device, model_config, dtype, custom_pipeline, noise_scheduler, **kwargs
         )
+        # resolve te_device_torch (LTX2_TE_DEVICE override or device_torch);
+        # always set, used even when the dual-GPU path is disabled.
+        self.init_te_device()
         self.is_flow_matching = True
         self.is_transformer = True
         self.target_lora_modules = ["LTX2VideoTransformer3DModel"]
@@ -296,8 +304,19 @@ class LTX2Model(BaseModel):
             quantize_model(self, transformer)
             flush()
 
+        # Dual-GPU model-parallel path (LTX2_DUAL_GPU=true). The transformer
+        # is still on CPU here (diffusers from_pretrained loads to CPU and
+        # quantize_model runs in place), so the mixin can distribute its
+        # modules across cuda:0/cuda:1 cleanly. After this returns the
+        # transformer's .to() is pinned to ignore device moves.
+        use_dual_gpu = is_dual_gpu_enabled()
+        if use_dual_gpu:
+            self.setup_dual_gpu_distribution(transformer, dtype)
+            flush()
+
         if (
-            self.model_config.layer_offloading
+            not use_dual_gpu
+            and self.model_config.layer_offloading
             and self.model_config.layer_offloading_transformer_percent > 0
         ):
             ignore_modules = []
@@ -315,7 +334,7 @@ class LTX2Model(BaseModel):
                 ignore_modules=ignore_modules,
             )
 
-        if self.model_config.low_vram:
+        if self.model_config.low_vram and not use_dual_gpu:
             self.print_and_status_update("Moving transformer to CPU")
             transformer.to("cpu")
 
@@ -444,7 +463,11 @@ class LTX2Model(BaseModel):
                 ],
             )
 
-        text_encoder.to(self.device_torch, dtype=dtype)
+        # Route to te_device_torch, not device_torch: under LTX2_DUAL_GPU the
+        # transformer already occupies cuda:0/cuda:1, so the 12B Gemma3 TE must
+        # land on CPU (LTX2_TE_DEVICE=cpu). te_device_torch == device_torch when
+        # the dual-GPU path is inactive, so this is a no-op change otherwise.
+        text_encoder.to(self.te_device_torch, dtype=dtype)
         flush()
 
         self.print_and_status_update("Loading VAEs and other components")
@@ -522,13 +545,18 @@ class LTX2Model(BaseModel):
         text_encoder = [pipe.text_encoder]
         tokenizer = [pipe.tokenizer]
 
-        # leave it on cpu for now
-        if not self.low_vram:
+        # leave it on cpu for now. When dual-GPU is active the transformer is
+        # already distributed across cuda:0/cuda:1 and its .to() is pinned, so
+        # skip the single-device move (preserve_dual_gpu_split_on_pipe).
+        if not self.low_vram and not self.preserve_dual_gpu_split_on_pipe(pipe):
             pipe.transformer = pipe.transformer.to(self.device_torch)
 
         flush()
-        # just to make sure everything is on the right device and dtype
-        text_encoder[0].to(self.device_torch)
+        # just to make sure everything is on the right device and dtype.
+        # te_device_torch, not device_torch: under LTX2_DUAL_GPU this keeps the
+        # 12B Gemma3 TE on CPU (the transformer owns cuda:0/cuda:1). No-op
+        # change when the dual-GPU path is inactive.
+        text_encoder[0].to(self.te_device_torch)
         text_encoder[0].requires_grad_(False)
         text_encoder[0].eval()
         flush()
@@ -862,6 +890,17 @@ class LTX2Model(BaseModel):
 
             video_timestep = timestep.clone()
 
+            # Under LTX2_DUAL_GPU the transformer is split across cuda:0/cuda:1;
+            # diffusers' `.device` (first-parameter device) is ambiguous for a
+            # split model and can resolve to cuda:1. The split's I/O convention
+            # is cuda:0 — input enters and output leaves there — so pin helper
+            # modules (connectors, audio latents) to that. No-op otherwise.
+            transformer_io_device = (
+                torch.device("cuda:0")
+                if is_dual_gpu_enabled()
+                else self.transformer.device
+            )
+
             # i2v from first frame
             if batch.dataset_config.do_i2v and batch.num_frames > 1:
                 # check to see if we had it cached
@@ -965,13 +1004,13 @@ class LTX2Model(BaseModel):
                     num_mel_bins=num_mel_bins,
                     noise_scale=0.0,
                     dtype=torch.float32,
-                    device=self.transformer.device,
+                    device=transformer_io_device,
                     generator=None,
                     latents=None,
                 )
 
-            if self.pipeline.connectors.device != self.transformer.device:
-                self.pipeline.connectors.to(self.transformer.device)
+            if self.pipeline.connectors.device != transformer_io_device:
+                self.pipeline.connectors.to(transformer_io_device)
 
             # Padding side for default Gemma3-12B text encoder
             tokenizer_padding_side = "left"
@@ -1046,10 +1085,15 @@ class LTX2Model(BaseModel):
         return unpacked_output
 
     def get_prompt_embeds(self, prompt: str) -> PromptEmbeds:
-        if self.pipeline.text_encoder.device != self.device_torch:
-            self.pipeline.text_encoder.to(self.device_torch)
+        # te_device_torch, not device_torch: under LTX2_DUAL_GPU the transformer
+        # owns cuda:0/cuda:1, so the 12B Gemma3 TE encodes on CPU. With
+        # cache_text_embeddings this runs once at training start; the tokenized
+        # inputs below follow the TE onto te_device_torch. No-op when the
+        # dual-GPU path is inactive (te_device_torch == device_torch).
+        if self.pipeline.text_encoder.device != self.te_device_torch:
+            self.pipeline.text_encoder.to(self.te_device_torch)
 
-        device = self.device_torch
+        device = self.te_device_torch
         scale_factor = 8
         batch_size = len(prompt)
         # Gemma expects left padding for chat-style prompts

--- a/extensions_built_in/diffusion_models/ltx2/ltx2_dual_gpu.py
+++ b/extensions_built_in/diffusion_models/ltx2/ltx2_dual_gpu.py
@@ -1,0 +1,721 @@
+"""Dual-GPU model-parallel path for LTX-2 video+audio LoRA training.
+
+Activates when ``LTX2_DUAL_GPU=true``. Distributes the diffusers
+``LTX2VideoTransformer3DModel`` across two CUDA devices with a single
+PCIe boundary mid-``transformer_blocks``, keeps the Gemma3 text encoder
+on a configurable device (CPU recommended for 32 GB cards), and reuses
+the same LoRA / multiplier patches the FLUX.2 and Wan 2.2 dual-GPU paths
+install (those hook ai-toolkit-wide classes, not model-specific ones, so
+they apply unchanged here — the shared ``_PATCHES_INSTALLED`` flag makes
+calling all three safe).
+
+Targets the ai-toolkit LTX-2 trainer
+(``extensions_built_in/diffusion_models/ltx2/ltx2.py``). Integration is a
+small edit at the call site:
+
+1. Make ``LTX2Model`` inherit from ``LTX2DualGPUMixin`` first
+   (MRO ordering: mixin before ``BaseModel``).
+2. In ``LTX2Model.load_model``, after ``quantize_model(...)``, call
+   ``self.setup_dual_gpu_distribution(transformer, dtype)`` gated by
+   ``is_dual_gpu_enabled()`` — and keep the transformer on CPU through
+   quantize so the mixin can distribute afterward.
+
+Unlike FLUX.2's per-block hooks, LTX-2 (like Wan 2.2) precomputes all
+loop-invariant modulation tensors once before the block loop, so a
+single-boundary ``forward`` replacement is sufficient.
+
+Env vars:
+    LTX2_DUAL_GPU=true            enable the dual-GPU path
+    LTX2_TE_DEVICE=cpu            pin the Gemma3 text encoder to a device
+    LTX2_DUAL_GPU_SPLIT_AT=24     override transformer_blocks split index
+                                  (default: num_layers // 2)
+"""
+from __future__ import annotations
+
+import os
+import types
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+if TYPE_CHECKING:
+    from .ltx2 import LTX2Model  # noqa: F401
+
+
+def is_dual_gpu_enabled() -> bool:
+    return os.getenv("LTX2_DUAL_GPU", "false").lower() == "true"
+
+
+def get_te_device_override() -> torch.device | None:
+    """Returns the text-encoder device override if LTX2_TE_DEVICE is set."""
+    val = os.getenv("LTX2_TE_DEVICE")
+    return torch.device(val) if val else None
+
+
+class LTX2DualGPUMixin:
+    """Mixin for :class:`LTX2Model` that adds the dual-GPU training path.
+
+    The mixin contributes:
+
+    - ``te_device_torch`` attribute (resolved from ``LTX2_TE_DEVICE`` or
+      defaulting to ``device_torch``). Always present — used even when
+      dual-GPU itself is disabled.
+    - ``text_encoder_to`` override that routes Gemma3 moves to
+      ``te_device_torch`` instead of ``device_torch``.
+    - ``setup_dual_gpu_distribution(transformer, dtype)`` to be called
+      from ``load_model`` after the transformer has been quantized (if
+      applicable) and before the pipeline composes it. Distributes
+      modules across cuda:0/cuda:1, replaces
+      ``LTX2VideoTransformer3DModel.forward`` with a split-aware variant,
+      pins ``transformer.to()`` to ignore device arguments, and installs
+      the LoRA / multiplier patches.
+    - ``preserve_dual_gpu_split_on_pipe(pipe)`` — to be checked in place
+      of the single-device ``pipe.transformer.to(self.device_torch)``
+      call so the distributed layout survives pipeline composition.
+    """
+
+    te_device_torch: torch.device
+
+    # ---------------------------------------------------------------- init
+
+    def init_te_device(self) -> None:
+        """Resolve ``te_device_torch`` from env var or fall back to model device.
+
+        Must be called from :meth:`LTX2Model.__init__` after the base
+        ``__init__`` (which establishes ``self.device_torch``).
+        """
+        override = get_te_device_override()
+        self.te_device_torch = override if override is not None else self.device_torch  # type: ignore[attr-defined]
+
+    # ----------------------------------------------------------- TE override
+
+    def text_encoder_to(self, *args: Any, **kwargs: Any) -> None:
+        """Override of BaseModel.text_encoder_to that honors te_device_torch.
+
+        ai-toolkit's :class:`SDTrainer` hook ``hook_before_train_loop``
+        calls ``self.sd.text_encoder_to(self.device_torch)``
+        unconditionally. With ``LTX2_TE_DEVICE=cpu`` we want Gemma3 to
+        stay on CPU regardless. LTX-2 stores the text encoder as a list.
+        """
+        target = self.te_device_torch
+        if isinstance(self.text_encoder, list):  # type: ignore[attr-defined]
+            for encoder in self.text_encoder:  # type: ignore[attr-defined]
+                encoder.to(target)
+        else:
+            self.text_encoder.to(target)  # type: ignore[attr-defined]
+
+    # ------------------------------------------------------------ load hook
+
+    def setup_dual_gpu_distribution(self, transformer: torch.nn.Module, dtype: torch.dtype) -> None:
+        """Distribute the LTX-2 transformer across cuda:0 and cuda:1.
+
+        Layout:
+            cuda:0  — ``proj_in``, ``audio_proj_in``, ``caption_projection``,
+                      ``audio_caption_projection``, the timestep/modulation
+                      embedders (``time_embed``, ``audio_time_embed``,
+                      ``av_cross_attn_*``, ``prompt_adaln`` /
+                      ``audio_prompt_adaln`` if present), all four RoPE
+                      modules (``rope``, ``audio_rope``, ``cross_attn_rope``,
+                      ``cross_attn_audio_rope``), and
+                      ``transformer_blocks[:split_at]``
+            cuda:1  — ``transformer_blocks[split_at:]``, the output norm/proj
+                      layers (``norm_out``, ``proj_out``, ``audio_norm_out``,
+                      ``audio_proj_out``), and the output-layer
+                      ``scale_shift_table`` / ``audio_scale_shift_table``
+                      Parameters
+
+        Also installs the LoRA / multiplier patches that align downstream
+        ai-toolkit machinery with the split layout.
+        """
+        if torch.cuda.device_count() < 2:
+            raise RuntimeError(
+                f"LTX2_DUAL_GPU=true requires >=2 CUDA devices, found "
+                f"{torch.cuda.device_count()}."
+            )
+
+        d0 = torch.device("cuda:0")
+        d1 = torch.device("cuda:1")
+        n_blocks = len(transformer.transformer_blocks)
+        override = os.getenv("LTX2_DUAL_GPU_SPLIT_AT")
+        split_at = int(override) if override else (n_blocks // 2)
+        if not 0 < split_at < n_blocks:
+            raise RuntimeError(
+                f"LTX2_DUAL_GPU_SPLIT_AT={split_at} out of range "
+                f"(transformer has {n_blocks} blocks)."
+            )
+
+        self.print_and_status_update(  # type: ignore[attr-defined]
+            f"Distributing transformer across {d0} and {d1}"
+        )
+        self.print_and_status_update(  # type: ignore[attr-defined]
+            f"Block split: {split_at} on cuda:0, "
+            f"{n_blocks - split_at} on cuda:1"
+        )
+
+        # --- cuda:0: input projections, embedders, RoPE, first block half
+        transformer.proj_in.to(d0, dtype=dtype)
+        transformer.audio_proj_in.to(d0, dtype=dtype)
+
+        # caption projections only exist on LTX-2.0 (use_prompt_embeddings)
+        for attr in ("caption_projection", "audio_caption_projection"):
+            mod = getattr(transformer, attr, None)
+            if mod is not None:
+                mod.to(d0, dtype=dtype)
+
+        transformer.time_embed.to(d0, dtype=dtype)
+        transformer.audio_time_embed.to(d0, dtype=dtype)
+        transformer.av_cross_attn_video_scale_shift.to(d0, dtype=dtype)
+        transformer.av_cross_attn_audio_scale_shift.to(d0, dtype=dtype)
+        transformer.av_cross_attn_video_a2v_gate.to(d0, dtype=dtype)
+        transformer.av_cross_attn_audio_v2a_gate.to(d0, dtype=dtype)
+
+        # prompt modulation adaln layers only exist on LTX-2.3
+        for attr in ("prompt_adaln", "audio_prompt_adaln"):
+            mod = getattr(transformer, attr, None)
+            if mod is not None:
+                mod.to(d0, dtype=dtype)
+
+        # All four RoPE modules are nn.Module subclasses, so .to() traverses
+        # any registered buffers/params they hold (no plain-attribute gotcha).
+        transformer.rope.to(d0)
+        transformer.audio_rope.to(d0)
+        transformer.cross_attn_rope.to(d0)
+        transformer.cross_attn_audio_rope.to(d0)
+
+        for blk in transformer.transformer_blocks[:split_at]:
+            blk.to(d0, dtype=dtype)
+
+        # --- cuda:1: second block half + output layers
+        for blk in transformer.transformer_blocks[split_at:]:
+            blk.to(d1, dtype=dtype)
+
+        transformer.norm_out.to(d1)
+        transformer.proj_out.to(d1, dtype=dtype)
+        transformer.audio_norm_out.to(d1)
+        transformer.audio_proj_out.to(d1, dtype=dtype)
+
+        # scale_shift_table / audio_scale_shift_table are nn.Parameters, not
+        # sub-modules; moving the containing module won't reach them because
+        # they're referenced directly. Move the underlying storage in-place
+        # under no_grad. They are consumed only by the output layers (cuda:1).
+        with torch.no_grad():
+            transformer.scale_shift_table.data = transformer.scale_shift_table.data.to(d1)
+            transformer.audio_scale_shift_table.data = transformer.audio_scale_shift_table.data.to(d1)
+
+        transformer.forward = types.MethodType(
+            _make_split_forward(split_at), transformer
+        )
+        _pin_transformer_to(transformer)
+
+        _install_external_patches()
+
+    # ----------------------------------------------------- pipeline composer
+
+    def preserve_dual_gpu_split_on_pipe(self, pipe: Any) -> bool:
+        """Return True if we've already distributed; caller should skip the
+        single-device ``pipe.transformer.to(device)`` call."""
+        return is_dual_gpu_enabled()
+
+
+# ---------------------------------------------------------------- helpers
+
+
+def _make_split_forward(split_at: int):
+    """Create an ``LTX2VideoTransformer3DModel.forward`` variant that inserts
+    a cuda:1 boundary at ``transformer_blocks[split_at]``.
+
+    Recreates the original forward (see
+    ``diffusers/models/transformers/transformer_ltx2.py``,
+    ``LTX2VideoTransformer3DModel.forward``) with three additions:
+      1. At index ``split_at``, cross BOTH modality streams
+         (``hidden_states`` video + ``audio_hidden_states`` audio), both
+         text-embedding streams, every precomputed modulation tensor
+         (``temb``, ``temb_audio``, the cross-attn scale/shift + gate
+         tensors, ``temb_prompt`` / ``temb_prompt_audio``), the encoder
+         attention masks, and all four computed RoPE tuples to cuda:1.
+      2. After the output layers, move both outputs back to cuda:0 so
+         downstream loss ops (which run on the model's nominal device)
+         work without a device-mismatch error.
+      3. Preserve the ``return_dict`` contract — returns
+         ``(output, audio_output)`` or ``AudioVisualModelOutput``.
+
+    The original forward is wrapped with ``@apply_lora_scale``; that
+    decorator only scales LoRA when ``attention_kwargs`` carries a scale,
+    and ai-toolkit's training path always passes ``attention_kwargs=None``
+    (see ``LTX2Model.get_noise_prediction``), so the decorator is a no-op
+    here — we mirror the Wan mixin and omit it.
+    """
+    from diffusers.models.transformers.transformer_ltx2 import AudioVisualModelOutput
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        audio_hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        audio_encoder_hidden_states: torch.Tensor,
+        timestep: torch.Tensor,
+        audio_timestep: torch.Tensor | None = None,
+        sigma: torch.Tensor | None = None,
+        audio_sigma: torch.Tensor | None = None,
+        encoder_attention_mask: torch.Tensor | None = None,
+        audio_encoder_attention_mask: torch.Tensor | None = None,
+        num_frames: int | None = None,
+        height: int | None = None,
+        width: int | None = None,
+        fps: float = 24.0,
+        audio_num_frames: int | None = None,
+        video_coords: torch.Tensor | None = None,
+        audio_coords: torch.Tensor | None = None,
+        isolate_modalities: bool = False,
+        spatio_temporal_guidance_blocks: list[int] | None = None,
+        perturbation_mask: torch.Tensor | None = None,
+        use_cross_timestep: bool = False,
+        attention_kwargs: dict[str, Any] | None = None,
+        return_dict: bool = True,
+    ):
+        # Determine timestep for audio.
+        audio_timestep = audio_timestep if audio_timestep is not None else timestep
+        audio_sigma = audio_sigma if audio_sigma is not None else sigma
+
+        # convert encoder_attention_mask to a bias the same way we do for attention_mask
+        if encoder_attention_mask is not None and encoder_attention_mask.ndim == 2:
+            encoder_attention_mask = (1 - encoder_attention_mask.to(hidden_states.dtype)) * -10000.0
+            encoder_attention_mask = encoder_attention_mask.unsqueeze(1)
+
+        if audio_encoder_attention_mask is not None and audio_encoder_attention_mask.ndim == 2:
+            audio_encoder_attention_mask = (1 - audio_encoder_attention_mask.to(audio_hidden_states.dtype)) * -10000.0
+            audio_encoder_attention_mask = audio_encoder_attention_mask.unsqueeze(1)
+
+        batch_size = hidden_states.size(0)
+
+        # 1. Prepare RoPE positional embeddings
+        if video_coords is None:
+            video_coords = self.rope.prepare_video_coords(
+                batch_size, num_frames, height, width, hidden_states.device, fps=fps
+            )
+        if audio_coords is None:
+            audio_coords = self.audio_rope.prepare_audio_coords(
+                batch_size, audio_num_frames, audio_hidden_states.device
+            )
+
+        video_rotary_emb = self.rope(video_coords, device=hidden_states.device)
+        audio_rotary_emb = self.audio_rope(audio_coords, device=audio_hidden_states.device)
+
+        video_cross_attn_rotary_emb = self.cross_attn_rope(video_coords[:, 0:1, :], device=hidden_states.device)
+        audio_cross_attn_rotary_emb = self.cross_attn_audio_rope(
+            audio_coords[:, 0:1, :], device=audio_hidden_states.device
+        )
+
+        # 2. Patchify input projections
+        hidden_states = self.proj_in(hidden_states)
+        audio_hidden_states = self.audio_proj_in(audio_hidden_states)
+
+        # 3. Prepare timestep embeddings and modulation parameters
+        timestep_cross_attn_gate_scale_factor = (
+            self.config.cross_attn_timestep_scale_multiplier / self.config.timestep_scale_multiplier
+        )
+
+        # 3.1. Prepare global modality (video and audio) timestep embedding and modulation parameters
+        temb, embedded_timestep = self.time_embed(
+            timestep.flatten(),
+            batch_size=batch_size,
+            hidden_dtype=hidden_states.dtype,
+        )
+        temb = temb.view(batch_size, -1, temb.size(-1))
+        embedded_timestep = embedded_timestep.view(batch_size, -1, embedded_timestep.size(-1))
+
+        temb_audio, audio_embedded_timestep = self.audio_time_embed(
+            audio_timestep.flatten(),
+            batch_size=batch_size,
+            hidden_dtype=audio_hidden_states.dtype,
+        )
+        temb_audio = temb_audio.view(batch_size, -1, temb_audio.size(-1))
+        audio_embedded_timestep = audio_embedded_timestep.view(batch_size, -1, audio_embedded_timestep.size(-1))
+
+        if self.prompt_modulation:
+            # LTX-2.3
+            temb_prompt, _ = self.prompt_adaln(
+                sigma.flatten(), batch_size=batch_size, hidden_dtype=hidden_states.dtype
+            )
+            temb_prompt_audio, _ = self.audio_prompt_adaln(
+                audio_sigma.flatten(), batch_size=batch_size, hidden_dtype=audio_hidden_states.dtype
+            )
+            temb_prompt = temb_prompt.view(batch_size, -1, temb_prompt.size(-1))
+            temb_prompt_audio = temb_prompt_audio.view(batch_size, -1, temb_prompt_audio.size(-1))
+        else:
+            temb_prompt = temb_prompt_audio = None
+
+        # 3.2. Prepare global modality cross attention modulation parameters
+        video_ca_timestep = audio_sigma.flatten() if use_cross_timestep else timestep.flatten()
+        video_cross_attn_scale_shift, _ = self.av_cross_attn_video_scale_shift(
+            video_ca_timestep,
+            batch_size=batch_size,
+            hidden_dtype=hidden_states.dtype,
+        )
+        video_cross_attn_a2v_gate, _ = self.av_cross_attn_video_a2v_gate(
+            video_ca_timestep * timestep_cross_attn_gate_scale_factor,
+            batch_size=batch_size,
+            hidden_dtype=hidden_states.dtype,
+        )
+        video_cross_attn_scale_shift = video_cross_attn_scale_shift.view(
+            batch_size, -1, video_cross_attn_scale_shift.shape[-1]
+        )
+        video_cross_attn_a2v_gate = video_cross_attn_a2v_gate.view(batch_size, -1, video_cross_attn_a2v_gate.shape[-1])
+
+        audio_ca_timestep = sigma.flatten() if use_cross_timestep else audio_timestep.flatten()
+        audio_cross_attn_scale_shift, _ = self.av_cross_attn_audio_scale_shift(
+            audio_ca_timestep,
+            batch_size=batch_size,
+            hidden_dtype=audio_hidden_states.dtype,
+        )
+        audio_cross_attn_v2a_gate, _ = self.av_cross_attn_audio_v2a_gate(
+            audio_ca_timestep * timestep_cross_attn_gate_scale_factor,
+            batch_size=batch_size,
+            hidden_dtype=audio_hidden_states.dtype,
+        )
+        audio_cross_attn_scale_shift = audio_cross_attn_scale_shift.view(
+            batch_size, -1, audio_cross_attn_scale_shift.shape[-1]
+        )
+        audio_cross_attn_v2a_gate = audio_cross_attn_v2a_gate.view(batch_size, -1, audio_cross_attn_v2a_gate.shape[-1])
+
+        # 4. Prepare prompt embeddings (LTX-2.0)
+        if self.config.use_prompt_embeddings:
+            encoder_hidden_states = self.caption_projection(encoder_hidden_states)
+            encoder_hidden_states = encoder_hidden_states.view(batch_size, -1, hidden_states.size(-1))
+
+            audio_encoder_hidden_states = self.audio_caption_projection(audio_encoder_hidden_states)
+            audio_encoder_hidden_states = audio_encoder_hidden_states.view(
+                batch_size, -1, audio_hidden_states.size(-1)
+            )
+
+        # 5. Run transformer blocks
+        spatio_temporal_guidance_blocks = spatio_temporal_guidance_blocks or []
+        if len(spatio_temporal_guidance_blocks) > 0 and perturbation_mask is None:
+            # If STG is being used and perturbation_mask is not supplied, default to perturbing all batch elements.
+            perturbation_mask = torch.zeros((batch_size,))
+        if perturbation_mask is not None and perturbation_mask.ndim == 1:
+            perturbation_mask = perturbation_mask[:, None, None]  # unsqueeze to 3D to broadcast with hidden_states
+        all_perturbed = torch.all(perturbation_mask == 0) if perturbation_mask is not None else False
+        stg_blocks = set(spatio_temporal_guidance_blocks)
+
+        # Devices of the first block on each side of the boundary.
+        d0_dev = next(self.transformer_blocks[0].parameters()).device
+        d1_dev = next(self.transformer_blocks[split_at].parameters()).device
+
+        for block_idx, block in enumerate(self.transformer_blocks):
+            if block_idx == split_at and d1_dev != d0_dev:
+                # PCIe boundary: bridge BOTH modality streams + both text
+                # streams + every precomputed modulation tensor + masks +
+                # all four RoPE tuples to cuda:1.
+                hidden_states = hidden_states.to(d1_dev)
+                audio_hidden_states = audio_hidden_states.to(d1_dev)
+                encoder_hidden_states = encoder_hidden_states.to(d1_dev)
+                audio_encoder_hidden_states = audio_encoder_hidden_states.to(d1_dev)
+                temb = temb.to(d1_dev)
+                temb_audio = temb_audio.to(d1_dev)
+                video_cross_attn_scale_shift = video_cross_attn_scale_shift.to(d1_dev)
+                audio_cross_attn_scale_shift = audio_cross_attn_scale_shift.to(d1_dev)
+                video_cross_attn_a2v_gate = video_cross_attn_a2v_gate.to(d1_dev)
+                audio_cross_attn_v2a_gate = audio_cross_attn_v2a_gate.to(d1_dev)
+                if temb_prompt is not None:
+                    temb_prompt = temb_prompt.to(d1_dev)
+                if temb_prompt_audio is not None:
+                    temb_prompt_audio = temb_prompt_audio.to(d1_dev)
+                if encoder_attention_mask is not None:
+                    encoder_attention_mask = encoder_attention_mask.to(d1_dev)
+                if audio_encoder_attention_mask is not None:
+                    audio_encoder_attention_mask = audio_encoder_attention_mask.to(d1_dev)
+                # Each RoPE result is a tuple of tensors (cos/sin pairs);
+                # move every element across.
+                video_rotary_emb = _move_rope(video_rotary_emb, d1_dev)
+                audio_rotary_emb = _move_rope(audio_rotary_emb, d1_dev)
+                video_cross_attn_rotary_emb = _move_rope(video_cross_attn_rotary_emb, d1_dev)
+                audio_cross_attn_rotary_emb = _move_rope(audio_cross_attn_rotary_emb, d1_dev)
+
+            block_perturbation_mask = perturbation_mask if block_idx in stg_blocks else None
+            block_all_perturbed = all_perturbed if block_idx in stg_blocks else False
+
+            if torch.is_grad_enabled() and self.gradient_checkpointing:
+                hidden_states, audio_hidden_states = self._gradient_checkpointing_func(
+                    block,
+                    hidden_states,
+                    audio_hidden_states,
+                    encoder_hidden_states,
+                    audio_encoder_hidden_states,
+                    temb,
+                    temb_audio,
+                    video_cross_attn_scale_shift,
+                    audio_cross_attn_scale_shift,
+                    video_cross_attn_a2v_gate,
+                    audio_cross_attn_v2a_gate,
+                    temb_prompt,
+                    temb_prompt_audio,
+                    video_rotary_emb,
+                    audio_rotary_emb,
+                    video_cross_attn_rotary_emb,
+                    audio_cross_attn_rotary_emb,
+                    encoder_attention_mask,
+                    audio_encoder_attention_mask,
+                    None,  # self_attention_mask
+                    None,  # audio_self_attention_mask
+                    None,  # a2v_cross_attention_mask
+                    None,  # v2a_cross_attention_mask
+                    not isolate_modalities,  # use_a2v_cross_attention
+                    not isolate_modalities,  # use_v2a_cross_attention
+                    block_perturbation_mask,
+                    block_all_perturbed,
+                )
+            else:
+                hidden_states, audio_hidden_states = block(
+                    hidden_states=hidden_states,
+                    audio_hidden_states=audio_hidden_states,
+                    encoder_hidden_states=encoder_hidden_states,
+                    audio_encoder_hidden_states=audio_encoder_hidden_states,
+                    temb=temb,
+                    temb_audio=temb_audio,
+                    temb_ca_scale_shift=video_cross_attn_scale_shift,
+                    temb_ca_audio_scale_shift=audio_cross_attn_scale_shift,
+                    temb_ca_gate=video_cross_attn_a2v_gate,
+                    temb_ca_audio_gate=audio_cross_attn_v2a_gate,
+                    temb_prompt=temb_prompt,
+                    temb_prompt_audio=temb_prompt_audio,
+                    video_rotary_emb=video_rotary_emb,
+                    audio_rotary_emb=audio_rotary_emb,
+                    ca_video_rotary_emb=video_cross_attn_rotary_emb,
+                    ca_audio_rotary_emb=audio_cross_attn_rotary_emb,
+                    encoder_attention_mask=encoder_attention_mask,
+                    audio_encoder_attention_mask=audio_encoder_attention_mask,
+                    self_attention_mask=None,
+                    audio_self_attention_mask=None,
+                    a2v_cross_attention_mask=None,
+                    v2a_cross_attention_mask=None,
+                    use_a2v_cross_attention=not isolate_modalities,
+                    use_v2a_cross_attention=not isolate_modalities,
+                    perturbation_mask=block_perturbation_mask,
+                    all_perturbed=block_all_perturbed,
+                )
+
+        # 6. Output layers (including unpatchification). norm_out / proj_out
+        # and the scale_shift_table Parameters live on cuda:1; embedded_timestep
+        # came out of the embedders on cuda:0, so bridge it across.
+        out_dev = hidden_states.device
+        if embedded_timestep.device != out_dev:
+            embedded_timestep = embedded_timestep.to(out_dev)
+        if audio_embedded_timestep.device != audio_hidden_states.device:
+            audio_embedded_timestep = audio_embedded_timestep.to(audio_hidden_states.device)
+
+        scale_shift_values = self.scale_shift_table[None, None] + embedded_timestep[:, :, None]
+        shift, scale = scale_shift_values[:, :, 0], scale_shift_values[:, :, 1]
+
+        hidden_states = self.norm_out(hidden_states)
+        hidden_states = hidden_states * (1 + scale) + shift
+        output = self.proj_out(hidden_states)
+
+        audio_scale_shift_values = self.audio_scale_shift_table[None, None] + audio_embedded_timestep[:, :, None]
+        audio_shift, audio_scale = audio_scale_shift_values[:, :, 0], audio_scale_shift_values[:, :, 1]
+
+        audio_hidden_states = self.audio_norm_out(audio_hidden_states)
+        audio_hidden_states = audio_hidden_states * (1 + audio_scale) + audio_shift
+        audio_output = self.audio_proj_out(audio_hidden_states)
+
+        # Return on cuda:0 so downstream loss / scatter ops (which run on the
+        # model's nominal device) work without a device-mismatch error.
+        if output.device != d0_dev:
+            output = output.to(d0_dev)
+        if audio_output.device != d0_dev:
+            audio_output = audio_output.to(d0_dev)
+
+        if not return_dict:
+            return (output, audio_output)
+        return AudioVisualModelOutput(sample=output, audio_sample=audio_output)
+
+    return forward
+
+
+def _move_rope(rope_emb: Any, device: torch.device) -> Any:
+    """Move a RoPE forward result to ``device``.
+
+    Each ``LTX2AudioVideoRotaryPosEmbed.forward`` returns a tuple of
+    tensors (cos/sin pairs); move every tensor element, leaving non-tensor
+    entries (e.g. ``None``) untouched.
+    """
+    if isinstance(rope_emb, torch.Tensor):
+        return rope_emb.to(device)
+    if isinstance(rope_emb, (tuple, list)):
+        moved = [
+            (e.to(device) if isinstance(e, torch.Tensor) else _move_rope(e, device))
+            for e in rope_emb
+        ]
+        return type(rope_emb)(moved)
+    return rope_emb
+
+
+def _pin_transformer_to(transformer: torch.nn.Module) -> None:
+    """Wrap ``transformer.to()`` so device arguments are stripped (the model
+    is already distributed) while dtype changes still pass through.
+
+    Without this, ai-toolkit hooks like ``set_device_state`` (called every
+    training step) and ``pipe.transformer.to(self.device_torch)`` (the
+    pipeline composer) would silently re-collect the split onto cuda:0.
+    """
+    _orig_to = transformer.to
+
+    def _split_preserving_to(*args: Any, **kwargs: Any):
+        filtered_args = [
+            a for a in args
+            if not isinstance(a, (str, torch.device, int))
+        ]
+        filtered_kwargs = {k: v for k, v in kwargs.items() if k != "device"}
+        if not filtered_args and not filtered_kwargs:
+            return transformer
+        return _orig_to(*filtered_args, **filtered_kwargs)
+
+    transformer.to = _split_preserving_to  # type: ignore[assignment]
+
+
+# Module-level idempotency flag. The external patches hook
+# ai-toolkit-wide classes (``ToolkitNetworkMixin``, ``LoRANetwork``,
+# ``network_mixins.broadcast_and_multiply``) — not LTX-2-specific code —
+# so they're already installed by the FLUX.2 / Wan paths if either ran
+# first. Gate all three installers behind a single module flag plus
+# per-target attribute flags (defense in depth).
+_PATCHES_INSTALLED = False
+
+
+def _install_external_patches() -> None:
+    """Idempotently install the LoRA-placement and multiplier-device patches.
+
+    These hook external ai-toolkit classes — done as runtime patches so
+    this file remains a self-contained addition. Safe to call alongside
+    the FLUX.2 / Wan helpers; all gate on the same per-target flags.
+    """
+    global _PATCHES_INSTALLED
+    if _PATCHES_INSTALLED:
+        return
+    _patch_force_to()
+    _patch_apply_to_with_lazy_forward()
+    _patch_broadcast_and_multiply()
+    _PATCHES_INSTALLED = True
+
+
+def _patch_force_to() -> None:
+    """``ToolkitNetworkMixin.force_to`` moves the network's submodules to a
+    single device. Override so each LoRA module follows the device of the
+    layer it wraps.
+    """
+    from toolkit.network_mixins import ToolkitNetworkMixin
+
+    if getattr(ToolkitNetworkMixin, "_dual_gpu_patched", False):
+        return
+
+    def _per_layer_force_to(self_n, device, dtype):
+        try:
+            self_n.to(device, dtype)
+        except Exception:
+            pass
+        loras = []
+        if hasattr(self_n, "unet_loras"):
+            loras += self_n.unet_loras
+        if hasattr(self_n, "text_encoder_loras"):
+            loras += self_n.text_encoder_loras
+        for lora in loras:
+            tgt = device
+            try:
+                parent = lora.org_module[0]
+                p = next(parent.parameters(), None)
+                if p is not None:
+                    tgt = p.device
+            except Exception:
+                pass
+            lora.to(tgt, dtype)
+            for attr in ("lora_down", "lora_up", "lora_mid"):
+                m = getattr(lora, attr, None)
+                if m is not None:
+                    try:
+                        m.to(tgt, dtype)
+                    except Exception:
+                        pass
+
+    ToolkitNetworkMixin.force_to = _per_layer_force_to
+    ToolkitNetworkMixin._dual_gpu_patched = True
+
+
+def _patch_apply_to_with_lazy_forward() -> None:
+    """``LoRANetwork.apply_to`` creates wrapped LoRA modules and registers
+    them as submodules. After it runs, each LoRA's forward is wrapped to
+    lazily re-pin parameters to the input's device on every call.
+
+    The lazy-pin is the load-bearing safety net — any later ai-toolkit
+    hook that calls ``network.to(device)`` (e.g., from
+    ``accelerate.prepare``) is silently corrected on the next forward.
+    """
+    from toolkit.kohya_lora import LoRANetwork
+
+    if getattr(LoRANetwork, "_dual_gpu_apply_patched", False):
+        return
+
+    _orig_apply_to = LoRANetwork.apply_to
+
+    def _redistribute_apply_to(self_n, *args, **kwargs):
+        ret = _orig_apply_to(self_n, *args, **kwargs)
+        loras = []
+        if hasattr(self_n, "unet_loras"):
+            loras += self_n.unet_loras
+        if hasattr(self_n, "text_encoder_loras"):
+            loras += self_n.text_encoder_loras
+        for lora in loras:
+            if getattr(lora, "_dual_gpu_wrapped", False):
+                continue
+            lora.forward = _make_pinned_forward(lora, lora.forward)
+            try:
+                lora.org_module[0].forward = lora.forward
+            except Exception:
+                pass
+            lora._dual_gpu_wrapped = True
+        return ret
+
+    LoRANetwork.apply_to = _redistribute_apply_to
+    LoRANetwork._dual_gpu_apply_patched = True
+
+
+def _make_pinned_forward(lora, orig_forward):
+    """Wrap a LoRA module's forward to re-pin its parameters to the input
+    tensor's device on each call. Cheap no-op when devices already match.
+    """
+    def _pinned(*fargs, **fkwargs):
+        in_dev = None
+        for a in fargs:
+            if hasattr(a, "device") and getattr(a, "is_cuda", False):
+                in_dev = a.device
+                break
+        if in_dev is None:
+            return orig_forward(*fargs, **fkwargs)
+        p = next(lora.parameters(), None)
+        if p is not None and p.device != in_dev:
+            lora.to(in_dev)
+        return orig_forward(*fargs, **fkwargs)
+    return _pinned
+
+
+def _patch_broadcast_and_multiply() -> None:
+    """``network_mixins.broadcast_and_multiply(tensor, multiplier)`` fails
+    when ``tensor`` and ``multiplier`` live on different devices. Auto-move
+    the multiplier to match.
+    """
+    from toolkit import network_mixins as _nm
+
+    if getattr(_nm, "_dual_gpu_bm_patched", False):
+        return
+
+    _orig_bm = _nm.broadcast_and_multiply
+
+    def _device_aware_bm(tensor, multiplier):
+        try:
+            if hasattr(multiplier, "device") and multiplier.device != tensor.device:
+                multiplier = multiplier.to(tensor.device)
+        except Exception:
+            pass
+        return _orig_bm(tensor, multiplier)
+
+    _nm.broadcast_and_multiply = _device_aware_bm
+    _nm._dual_gpu_bm_patched = True

--- a/extensions_built_in/diffusion_models/qwen_image/qwen_image.py
+++ b/extensions_built_in/diffusion_models/qwen_image/qwen_image.py
@@ -31,6 +31,8 @@ from transformers import (
 )
 from tqdm import tqdm
 
+from .qwen_image_dual_gpu import QwenImageDualGPUMixin, is_dual_gpu_enabled
+
 if TYPE_CHECKING:
     from toolkit.data_transfer_object.data_loader import DataLoaderBatchDTO
 
@@ -52,7 +54,10 @@ scheduler_config = {
 }
 
 
-class QwenImageModel(BaseModel):
+# QwenImageDualGPUMixin is first in the MRO so its text_encoder_to override
+# and setup_dual_gpu_distribution take precedence over BaseModel. The
+# dual-GPU path itself stays inert unless QWEN_IMAGE_DUAL_GPU=true.
+class QwenImageModel(QwenImageDualGPUMixin, BaseModel):
     arch = "qwen_image"
     _qwen_image_keep_visual = False
     _qwen_pipeline = QwenImagePipeline
@@ -69,6 +74,10 @@ class QwenImageModel(BaseModel):
         super().__init__(
             device, model_config, dtype, custom_pipeline, noise_scheduler, **kwargs
         )
+        # resolve te_device_torch (QWEN_IMAGE_TE_DEVICE override or
+        # device_torch); always set, used even when the dual-GPU path is
+        # disabled.
+        self.init_te_device()
         self.is_flow_matching = True
         self.is_transformer = True
         self.target_lora_modules = ["QwenImageTransformer2DModel"]
@@ -125,14 +134,28 @@ class QwenImageModel(BaseModel):
             quantize_model(self, transformer)
             flush()
 
-        if self.model_config.layer_offloading and self.model_config.layer_offloading_transformer_percent > 0:
+        # Dual-GPU model-parallel path (QWEN_IMAGE_DUAL_GPU=true). The
+        # transformer is still on CPU here (diffusers from_pretrained loads
+        # to CPU and quantize_model runs in place), so the mixin can
+        # distribute its modules across cuda:0/cuda:1 cleanly. After this
+        # returns the transformer's .to() is pinned to ignore device moves.
+        use_dual_gpu = is_dual_gpu_enabled()
+        if use_dual_gpu:
+            self.setup_dual_gpu_distribution(transformer, dtype)
+            flush()
+
+        if (
+            not use_dual_gpu
+            and self.model_config.layer_offloading
+            and self.model_config.layer_offloading_transformer_percent > 0
+        ):
             MemoryManager.attach(
                 transformer,
                 self.device_torch,
                 offload_percent=self.model_config.layer_offloading_transformer_percent
             )
 
-        if self.model_config.low_vram:
+        if self.model_config.low_vram and not use_dual_gpu:
             self.print_and_status_update("Moving transformer to CPU")
             transformer.to("cpu")
 
@@ -158,7 +181,12 @@ class QwenImageModel(BaseModel):
                 offload_percent=self.model_config.layer_offloading_text_encoder_percent
             )
 
-        text_encoder.to(self.device_torch, dtype=dtype)
+        # Route to te_device_torch, not device_torch: under
+        # QWEN_IMAGE_DUAL_GPU the transformer already occupies
+        # cuda:0/cuda:1, so the Qwen2.5-VL TE must land on CPU
+        # (QWEN_IMAGE_TE_DEVICE=cpu). te_device_torch == device_torch when
+        # the dual-GPU path is inactive, so this is a no-op change otherwise.
+        text_encoder.to(self.te_device_torch, dtype=dtype)
         flush()
 
         if self.model_config.quantize_te:
@@ -206,13 +234,18 @@ class QwenImageModel(BaseModel):
         text_encoder = [pipe.text_encoder]
         tokenizer = [pipe.tokenizer]
 
-        # leave it on cpu for now
-        if not self.low_vram:
+        # leave it on cpu for now. When dual-GPU is active the transformer
+        # is already distributed across cuda:0/cuda:1 and its .to() is
+        # pinned, so skip the single-device move (preserve_dual_gpu_split_on_pipe).
+        if not self.low_vram and not self.preserve_dual_gpu_split_on_pipe(pipe):
             pipe.transformer = pipe.transformer.to(self.device_torch)
 
         flush()
-        # just to make sure everything is on the right device and dtype
-        text_encoder[0].to(self.device_torch)
+        # just to make sure everything is on the right device and dtype.
+        # te_device_torch, not device_torch: under QWEN_IMAGE_DUAL_GPU this
+        # keeps the Qwen2.5-VL TE on CPU (the transformer owns cuda:0/cuda:1).
+        # No-op change when the dual-GPU path is inactive.
+        text_encoder[0].to(self.te_device_torch)
         text_encoder[0].requires_grad_(False)
         text_encoder[0].eval()
         flush()
@@ -352,12 +385,17 @@ class QwenImageModel(BaseModel):
         return noise_pred
 
     def get_prompt_embeds(self, prompt: str) -> PromptEmbeds:
-        if self.pipeline.text_encoder.device != self.device_torch:
-            self.pipeline.text_encoder.to(self.device_torch)
-        
+        # te_device_torch, not device_torch: under QWEN_IMAGE_DUAL_GPU the
+        # transformer owns cuda:0/cuda:1, so the Qwen2.5-VL TE encodes on
+        # CPU. encode_prompt's `device` arg must follow the TE so its
+        # tokenized inputs land on the same device. No-op when the
+        # dual-GPU path is inactive (te_device_torch == device_torch).
+        if self.pipeline.text_encoder.device != self.te_device_torch:
+            self.pipeline.text_encoder.to(self.te_device_torch)
+
         prompt_embeds, prompt_embeds_mask = self.pipeline.encode_prompt(
             prompt,
-            device=self.device_torch,
+            device=self.te_device_torch,
             num_images_per_prompt=1,
         )
         # diffusers >=0.37 returns None when all tokens are valid (no padding)

--- a/extensions_built_in/diffusion_models/qwen_image/qwen_image_dual_gpu.py
+++ b/extensions_built_in/diffusion_models/qwen_image/qwen_image_dual_gpu.py
@@ -1,0 +1,569 @@
+"""Dual-GPU model-parallel path for Qwen-Image LoRA training.
+
+Activates when ``QWEN_IMAGE_DUAL_GPU=true``. Distributes the diffusers
+``QwenImageTransformer2DModel`` across two CUDA devices with a single
+PCIe boundary mid-``transformer_blocks``, keeps the Qwen2.5-VL text
+encoder on a configurable device (CPU recommended for 32 GB cards), and
+reuses the same LoRA / multiplier patches the FLUX.2 / Wan 2.2 / LTX-2
+dual-GPU paths install (those hook ai-toolkit-wide classes, not
+model-specific ones, so they apply unchanged here — the shared
+``_PATCHES_INSTALLED`` flag makes calling all four safe).
+
+Targets the ai-toolkit Qwen-Image trainer
+(``extensions_built_in/diffusion_models/qwen_image/qwen_image.py``).
+Integration is a small edit at the call site:
+
+1. Make ``QwenImageModel`` inherit from ``QwenImageDualGPUMixin`` first
+   (MRO ordering: mixin before ``BaseModel``).
+2. In ``QwenImageModel.load_model``, after ``quantize_model(...)``, call
+   ``self.setup_dual_gpu_distribution(transformer, dtype)`` gated by
+   ``is_dual_gpu_enabled()`` — and keep the transformer on CPU through
+   quantize so the mixin can distribute afterward.
+
+Unlike FLUX.2's per-block hooks, Qwen-Image (like Wan 2.2 / LTX-2)
+precomputes all loop-invariant tensors (``temb``, the RoPE tuple, the
+joint attention-mask kwargs) once before the block loop, so a
+single-boundary ``forward`` replacement is sufficient.
+
+Env vars:
+    QWEN_IMAGE_DUAL_GPU=true            enable the dual-GPU path
+    QWEN_IMAGE_TE_DEVICE=cpu            pin the Qwen2.5-VL text encoder
+    QWEN_IMAGE_DUAL_GPU_SPLIT_AT=30     override transformer_blocks split
+                                       index (default: num_layers // 2)
+"""
+from __future__ import annotations
+
+import os
+import types
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+if TYPE_CHECKING:
+    from .qwen_image import QwenImageModel  # noqa: F401
+
+
+def is_dual_gpu_enabled() -> bool:
+    return os.getenv("QWEN_IMAGE_DUAL_GPU", "false").lower() == "true"
+
+
+def get_te_device_override() -> torch.device | None:
+    """Returns the text-encoder device override if QWEN_IMAGE_TE_DEVICE is set."""
+    val = os.getenv("QWEN_IMAGE_TE_DEVICE")
+    return torch.device(val) if val else None
+
+
+class QwenImageDualGPUMixin:
+    """Mixin for :class:`QwenImageModel` that adds the dual-GPU training path.
+
+    The mixin contributes:
+
+    - ``te_device_torch`` attribute (resolved from ``QWEN_IMAGE_TE_DEVICE``
+      or defaulting to ``device_torch``). Always present — used even when
+      dual-GPU itself is disabled.
+    - ``text_encoder_to`` override that routes Qwen2.5-VL moves to
+      ``te_device_torch`` instead of ``device_torch``.
+    - ``setup_dual_gpu_distribution(transformer, dtype)`` to be called
+      from ``load_model`` after the transformer has been quantized (if
+      applicable) and before the pipeline composes it. Distributes
+      modules across cuda:0/cuda:1, replaces
+      ``QwenImageTransformer2DModel.forward`` with a split-aware variant,
+      pins ``transformer.to()`` to ignore device arguments, and installs
+      the LoRA / multiplier patches.
+    - ``preserve_dual_gpu_split_on_pipe(pipe)`` — to be checked in place
+      of the single-device ``pipe.transformer.to(self.device_torch)``
+      call so the distributed layout survives pipeline composition.
+
+    Note on diffusers ``_no_split_modules = ["QwenImageTransformerBlock"]``:
+    that attribute governs HuggingFace ``accelerate`` device-map sharding
+    (it forbids splitting *within* a block). Our split is *between*
+    blocks at a configurable boundary, so the attribute is informational
+    only and does not constrain us.
+    """
+
+    te_device_torch: torch.device
+
+    # ---------------------------------------------------------------- init
+
+    def init_te_device(self) -> None:
+        """Resolve ``te_device_torch`` from env var or fall back to model device.
+
+        Must be called from :meth:`QwenImageModel.__init__` after the base
+        ``__init__`` (which establishes ``self.device_torch``).
+        """
+        override = get_te_device_override()
+        self.te_device_torch = override if override is not None else self.device_torch  # type: ignore[attr-defined]
+
+    # ----------------------------------------------------------- TE override
+
+    def text_encoder_to(self, *args: Any, **kwargs: Any) -> None:
+        """Override of BaseModel.text_encoder_to that honors te_device_torch.
+
+        ai-toolkit's :class:`SDTrainer` hook ``hook_before_train_loop``
+        calls ``self.sd.text_encoder_to(self.device_torch)``
+        unconditionally. With ``QWEN_IMAGE_TE_DEVICE=cpu`` we want the
+        Qwen2.5-VL text encoder to stay on CPU regardless. Qwen-Image
+        stores the text encoder as a list.
+        """
+        target = self.te_device_torch
+        if isinstance(self.text_encoder, list):  # type: ignore[attr-defined]
+            for encoder in self.text_encoder:  # type: ignore[attr-defined]
+                encoder.to(target)
+        else:
+            self.text_encoder.to(target)  # type: ignore[attr-defined]
+
+    # ------------------------------------------------------------ load hook
+
+    def setup_dual_gpu_distribution(self, transformer: torch.nn.Module, dtype: torch.dtype) -> None:
+        """Distribute the Qwen-Image transformer across cuda:0 and cuda:1.
+
+        Layout:
+            cuda:0  — ``pos_embed`` (RoPE), ``time_text_embed``,
+                      ``txt_norm``, ``img_in``, ``txt_in``,
+                      ``transformer_blocks[:split_at]``
+            cuda:1  — ``transformer_blocks[split_at:]``, ``norm_out``,
+                      ``proj_out``
+
+        ``QwenImageTransformer2DModel`` has no module-level ``nn.Parameter``
+        attributes (unlike Wan/LTX-2's ``scale_shift_table``); every weight
+        lives inside a sub-module, so plain ``.to()`` reaches all of them.
+
+        Also installs the LoRA / multiplier patches that align downstream
+        ai-toolkit machinery with the split layout.
+        """
+        if torch.cuda.device_count() < 2:
+            raise RuntimeError(
+                f"QWEN_IMAGE_DUAL_GPU=true requires >=2 CUDA devices, found "
+                f"{torch.cuda.device_count()}."
+            )
+
+        d0 = torch.device("cuda:0")
+        d1 = torch.device("cuda:1")
+        n_blocks = len(transformer.transformer_blocks)
+        override = os.getenv("QWEN_IMAGE_DUAL_GPU_SPLIT_AT")
+        split_at = int(override) if override else (n_blocks // 2)
+        if not 0 < split_at < n_blocks:
+            raise RuntimeError(
+                f"QWEN_IMAGE_DUAL_GPU_SPLIT_AT={split_at} out of range "
+                f"(transformer has {n_blocks} blocks)."
+            )
+
+        self.print_and_status_update(  # type: ignore[attr-defined]
+            f"Distributing transformer across {d0} and {d1}"
+        )
+        self.print_and_status_update(  # type: ignore[attr-defined]
+            f"Block split: {split_at} on cuda:0, "
+            f"{n_blocks - split_at} on cuda:1"
+        )
+
+        # --- cuda:0: RoPE, embedders, input projections, first block half
+        # pos_embed is an nn.Module (QwenEmbedRope / QwenEmbedLayer3DRope).
+        # Its pos_freqs/neg_freqs are plain attributes (NOT registered
+        # buffers — a comment in the source notes register_buffer drops the
+        # imaginary part of the complex freqs), so .to() will not move them.
+        # That is fine: the forward transfers them lazily per-device via
+        # _get_device_freqs(device) and we feed it cuda:0 there.
+        transformer.pos_embed.to(d0)
+        transformer.time_text_embed.to(d0, dtype=dtype)
+        transformer.txt_norm.to(d0, dtype=dtype)
+        transformer.img_in.to(d0, dtype=dtype)
+        transformer.txt_in.to(d0, dtype=dtype)
+
+        for blk in transformer.transformer_blocks[:split_at]:
+            blk.to(d0, dtype=dtype)
+
+        # --- cuda:1: second block half + output layers
+        for blk in transformer.transformer_blocks[split_at:]:
+            blk.to(d1, dtype=dtype)
+
+        transformer.norm_out.to(d1, dtype=dtype)
+        transformer.proj_out.to(d1, dtype=dtype)
+
+        transformer.forward = types.MethodType(
+            _make_split_forward(split_at), transformer
+        )
+        _pin_transformer_to(transformer)
+
+        _install_external_patches()
+
+    # ----------------------------------------------------- pipeline composer
+
+    def preserve_dual_gpu_split_on_pipe(self, pipe: Any) -> bool:
+        """Return True if we've already distributed; caller should skip the
+        single-device ``pipe.transformer.to(device)`` call."""
+        return is_dual_gpu_enabled()
+
+
+# ---------------------------------------------------------------- helpers
+
+
+def _make_split_forward(split_at: int):
+    """Create a ``QwenImageTransformer2DModel.forward`` variant that inserts
+    a cuda:1 boundary at ``transformer_blocks[split_at]``.
+
+    Recreates the original forward (see
+    ``diffusers/models/transformers/transformer_qwenimage.py``,
+    ``QwenImageTransformer2DModel.forward``) with three additions:
+      1. At index ``split_at``, cross BOTH streams threaded through the
+         block loop (``hidden_states`` image + ``encoder_hidden_states``
+         text — the block returns ``(encoder_hidden_states, hidden_states)``)
+         plus every precomputed loop-invariant tensor: ``temb``, the
+         ``(img_freqs, txt_freqs)`` RoPE tuple, the ``attention_mask``
+         entry inside ``block_attention_kwargs``, and ``modulate_index``.
+      2. After ``proj_out``, move the output back to cuda:0 so downstream
+         loss ops (which run on the model's nominal device) work without
+         a device-mismatch error.
+      3. Preserve the ``return_dict`` contract — returns ``(output,)`` or
+         ``Transformer2DModelOutput``.
+
+    The original forward is wrapped with ``@apply_lora_scale("attention_kwargs")``;
+    that decorator only scales LoRA when ``attention_kwargs`` carries a
+    scale, and ai-toolkit's training path always passes
+    ``attention_kwargs=None`` (see ``QwenImageModel.get_noise_prediction``),
+    so the decorator is a no-op here — we mirror the Wan / LTX-2 mixins
+    and omit it.
+    """
+    from math import prod
+
+    import numpy as np
+    from diffusers.models.modeling_outputs import Transformer2DModelOutput
+    from diffusers.models.transformers.transformer_qwenimage import (
+        compute_text_seq_len_from_mask,
+    )
+    from diffusers.utils import deprecate
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor = None,
+        encoder_hidden_states_mask: torch.Tensor = None,
+        timestep: torch.LongTensor = None,
+        img_shapes: list[tuple[int, int, int]] | None = None,
+        txt_seq_lens: list[int] | None = None,
+        guidance: torch.Tensor = None,  # TODO: this should probably be removed
+        attention_kwargs: dict[str, Any] | None = None,
+        controlnet_block_samples=None,
+        additional_t_cond=None,
+        return_dict: bool = True,
+    ):
+        if txt_seq_lens is not None:
+            deprecate(
+                "txt_seq_lens",
+                "0.39.0",
+                "Passing `txt_seq_lens` is deprecated and will be removed in version 0.39.0. "
+                "Please use `encoder_hidden_states_mask` instead. "
+                "The mask-based approach is more flexible and supports variable-length sequences.",
+                standard_warn=False,
+            )
+
+        hidden_states = self.img_in(hidden_states)
+
+        timestep = timestep.to(hidden_states.dtype)
+
+        if self.zero_cond_t:
+            timestep = torch.cat([timestep, timestep * 0], dim=0)
+            modulate_index = torch.tensor(
+                [[0] * prod(sample[0]) + [1] * sum([prod(s) for s in sample[1:]]) for sample in img_shapes],
+                device=timestep.device,
+                dtype=torch.int,
+            )
+        else:
+            modulate_index = None
+
+        encoder_hidden_states = self.txt_norm(encoder_hidden_states)
+        encoder_hidden_states = self.txt_in(encoder_hidden_states)
+
+        # Use the encoder_hidden_states sequence length for RoPE computation
+        # and normalize mask.
+        text_seq_len, _, encoder_hidden_states_mask = compute_text_seq_len_from_mask(
+            encoder_hidden_states, encoder_hidden_states_mask
+        )
+
+        if guidance is not None:
+            guidance = guidance.to(hidden_states.dtype) * 1000
+
+        temb = (
+            self.time_text_embed(timestep, hidden_states, additional_t_cond)
+            if guidance is None
+            else self.time_text_embed(timestep, guidance, hidden_states, additional_t_cond)
+        )
+
+        # pos_embed feeds the freqs onto hidden_states.device (cuda:0 here)
+        # via its lazy _get_device_freqs(device) path — no plain-attribute
+        # .to() gotcha. The resulting (img_freqs, txt_freqs) tuple is
+        # bridged to cuda:1 at the boundary below.
+        image_rotary_emb = self.pos_embed(img_shapes, max_txt_seq_len=text_seq_len, device=hidden_states.device)
+
+        # Construct joint attention mask once to avoid reconstructing in
+        # every block.
+        block_attention_kwargs = attention_kwargs.copy() if attention_kwargs is not None else {}
+        if encoder_hidden_states_mask is not None:
+            batch_size, image_seq_len = hidden_states.shape[:2]
+            image_mask = torch.ones((batch_size, image_seq_len), dtype=torch.bool, device=hidden_states.device)
+            joint_attention_mask = torch.cat([encoder_hidden_states_mask, image_mask], dim=1)
+            joint_attention_mask = joint_attention_mask[:, None, None, :]
+            block_attention_kwargs["attention_mask"] = joint_attention_mask
+
+        # Devices of the first block on each side of the boundary.
+        d0_dev = next(self.transformer_blocks[0].parameters()).device
+        d1_dev = next(self.transformer_blocks[split_at].parameters()).device
+
+        # block_attention_kwargs is a dict captured *by reference* in each
+        # block's gradient-checkpoint closure. Mutating it in place at the
+        # boundary would corrupt the cuda:0 blocks' backward recompute — they
+        # would read the cuda:1 mask and hit a device mismatch. Keep the cuda:0
+        # dict immutable; build a separate cuda:1 dict at the boundary and
+        # hand each block the dict for its own side. (The looped *tensors*
+        # below are reassigned to new objects rather than mutated, so each
+        # block's closure keeps its own correct-device copy.)
+        block_attention_kwargs_d1 = block_attention_kwargs
+
+        for index_block, block in enumerate(self.transformer_blocks):
+            if index_block == split_at and d1_dev != d0_dev:
+                # PCIe boundary: bridge BOTH looped streams + every
+                # precomputed loop-invariant tensor to cuda:1.
+                hidden_states = hidden_states.to(d1_dev)
+                encoder_hidden_states = encoder_hidden_states.to(d1_dev)
+                temb = temb.to(d1_dev)
+                # image_rotary_emb is a tuple (img_freqs, txt_freqs).
+                image_rotary_emb = (
+                    image_rotary_emb[0].to(d1_dev),
+                    image_rotary_emb[1].to(d1_dev),
+                )
+                # Separate cuda:1 dict — do NOT mutate the cuda:0 one.
+                block_attention_kwargs_d1 = dict(block_attention_kwargs)
+                if "attention_mask" in block_attention_kwargs_d1:
+                    block_attention_kwargs_d1["attention_mask"] = (
+                        block_attention_kwargs_d1["attention_mask"].to(d1_dev)
+                    )
+                if modulate_index is not None:
+                    modulate_index = modulate_index.to(d1_dev)
+
+            cur_attention_kwargs = (
+                block_attention_kwargs_d1
+                if index_block >= split_at
+                else block_attention_kwargs
+            )
+
+            if torch.is_grad_enabled() and self.gradient_checkpointing:
+                encoder_hidden_states, hidden_states = self._gradient_checkpointing_func(
+                    block,
+                    hidden_states,
+                    encoder_hidden_states,
+                    None,  # Don't pass encoder_hidden_states_mask (using attention_mask instead)
+                    temb,
+                    image_rotary_emb,
+                    cur_attention_kwargs,
+                    modulate_index,
+                )
+            else:
+                encoder_hidden_states, hidden_states = block(
+                    hidden_states=hidden_states,
+                    encoder_hidden_states=encoder_hidden_states,
+                    encoder_hidden_states_mask=None,  # Don't pass (using attention_mask instead)
+                    temb=temb,
+                    image_rotary_emb=image_rotary_emb,
+                    joint_attention_kwargs=cur_attention_kwargs,
+                    modulate_index=modulate_index,
+                )
+
+            # controlnet residual
+            if controlnet_block_samples is not None:
+                interval_control = len(self.transformer_blocks) / len(controlnet_block_samples)
+                interval_control = int(np.ceil(interval_control))
+                residual = controlnet_block_samples[index_block // interval_control]
+                if residual.device != hidden_states.device:
+                    residual = residual.to(hidden_states.device)
+                hidden_states = hidden_states + residual
+
+        if self.zero_cond_t:
+            temb = temb.chunk(2, dim=0)[0]
+        # norm_out / proj_out live on cuda:1; temb came out of the
+        # embedders on cuda:0 and is bridged at the boundary above, so it
+        # already matches hidden_states here. Use only the image part.
+        hidden_states = self.norm_out(hidden_states, temb)
+        output = self.proj_out(hidden_states)
+
+        # Return on cuda:0 so downstream loss / scatter ops (which run on
+        # the model's nominal device) work without a device-mismatch error.
+        if output.device != d0_dev:
+            output = output.to(d0_dev)
+
+        if not return_dict:
+            return (output,)
+
+        return Transformer2DModelOutput(sample=output)
+
+    return forward
+
+
+def _pin_transformer_to(transformer: torch.nn.Module) -> None:
+    """Wrap ``transformer.to()`` so device arguments are stripped (the model
+    is already distributed) while dtype changes still pass through.
+
+    Without this, ai-toolkit hooks like ``set_device_state`` (called every
+    training step) and ``pipe.transformer.to(self.device_torch)`` (the
+    pipeline composer) would silently re-collect the split onto cuda:0.
+    """
+    _orig_to = transformer.to
+
+    def _split_preserving_to(*args: Any, **kwargs: Any):
+        filtered_args = [
+            a for a in args
+            if not isinstance(a, (str, torch.device, int))
+        ]
+        filtered_kwargs = {k: v for k, v in kwargs.items() if k != "device"}
+        if not filtered_args and not filtered_kwargs:
+            return transformer
+        return _orig_to(*filtered_args, **filtered_kwargs)
+
+    transformer.to = _split_preserving_to  # type: ignore[assignment]
+
+
+# Module-level idempotency flag. The external patches hook
+# ai-toolkit-wide classes (``ToolkitNetworkMixin``, ``LoRANetwork``,
+# ``network_mixins.broadcast_and_multiply``) — not Qwen-Image-specific
+# code — so they're already installed by the FLUX.2 / Wan / LTX-2 paths
+# if any ran first. Gate all three installers behind a single module
+# flag plus per-target attribute flags (defense in depth).
+_PATCHES_INSTALLED = False
+
+
+def _install_external_patches() -> None:
+    """Idempotently install the LoRA-placement and multiplier-device patches.
+
+    These hook external ai-toolkit classes — done as runtime patches so
+    this file remains a self-contained addition. Safe to call alongside
+    the FLUX.2 / Wan / LTX-2 helpers; all gate on the same per-target
+    flags.
+    """
+    global _PATCHES_INSTALLED
+    if _PATCHES_INSTALLED:
+        return
+    _patch_force_to()
+    _patch_apply_to_with_lazy_forward()
+    _patch_broadcast_and_multiply()
+    _PATCHES_INSTALLED = True
+
+
+def _patch_force_to() -> None:
+    """``ToolkitNetworkMixin.force_to`` moves the network's submodules to a
+    single device. Override so each LoRA module follows the device of the
+    layer it wraps.
+    """
+    from toolkit.network_mixins import ToolkitNetworkMixin
+
+    if getattr(ToolkitNetworkMixin, "_dual_gpu_patched", False):
+        return
+
+    def _per_layer_force_to(self_n, device, dtype):
+        try:
+            self_n.to(device, dtype)
+        except Exception:
+            pass
+        loras = []
+        if hasattr(self_n, "unet_loras"):
+            loras += self_n.unet_loras
+        if hasattr(self_n, "text_encoder_loras"):
+            loras += self_n.text_encoder_loras
+        for lora in loras:
+            tgt = device
+            try:
+                parent = lora.org_module[0]
+                p = next(parent.parameters(), None)
+                if p is not None:
+                    tgt = p.device
+            except Exception:
+                pass
+            lora.to(tgt, dtype)
+            for attr in ("lora_down", "lora_up", "lora_mid"):
+                m = getattr(lora, attr, None)
+                if m is not None:
+                    try:
+                        m.to(tgt, dtype)
+                    except Exception:
+                        pass
+
+    ToolkitNetworkMixin.force_to = _per_layer_force_to
+    ToolkitNetworkMixin._dual_gpu_patched = True
+
+
+def _patch_apply_to_with_lazy_forward() -> None:
+    """``LoRANetwork.apply_to`` creates wrapped LoRA modules and registers
+    them as submodules. After it runs, each LoRA's forward is wrapped to
+    lazily re-pin parameters to the input's device on every call.
+
+    The lazy-pin is the load-bearing safety net — any later ai-toolkit
+    hook that calls ``network.to(device)`` (e.g., from
+    ``accelerate.prepare``) is silently corrected on the next forward.
+    """
+    from toolkit.kohya_lora import LoRANetwork
+
+    if getattr(LoRANetwork, "_dual_gpu_apply_patched", False):
+        return
+
+    _orig_apply_to = LoRANetwork.apply_to
+
+    def _redistribute_apply_to(self_n, *args, **kwargs):
+        ret = _orig_apply_to(self_n, *args, **kwargs)
+        loras = []
+        if hasattr(self_n, "unet_loras"):
+            loras += self_n.unet_loras
+        if hasattr(self_n, "text_encoder_loras"):
+            loras += self_n.text_encoder_loras
+        for lora in loras:
+            if getattr(lora, "_dual_gpu_wrapped", False):
+                continue
+            lora.forward = _make_pinned_forward(lora, lora.forward)
+            try:
+                lora.org_module[0].forward = lora.forward
+            except Exception:
+                pass
+            lora._dual_gpu_wrapped = True
+        return ret
+
+    LoRANetwork.apply_to = _redistribute_apply_to
+    LoRANetwork._dual_gpu_apply_patched = True
+
+
+def _make_pinned_forward(lora, orig_forward):
+    """Wrap a LoRA module's forward to re-pin its parameters to the input
+    tensor's device on each call. Cheap no-op when devices already match.
+    """
+    def _pinned(*fargs, **fkwargs):
+        in_dev = None
+        for a in fargs:
+            if hasattr(a, "device") and getattr(a, "is_cuda", False):
+                in_dev = a.device
+                break
+        if in_dev is None:
+            return orig_forward(*fargs, **fkwargs)
+        p = next(lora.parameters(), None)
+        if p is not None and p.device != in_dev:
+            lora.to(in_dev)
+        return orig_forward(*fargs, **fkwargs)
+    return _pinned
+
+
+def _patch_broadcast_and_multiply() -> None:
+    """``network_mixins.broadcast_and_multiply(tensor, multiplier)`` fails
+    when ``tensor`` and ``multiplier`` live on different devices. Auto-move
+    the multiplier to match.
+    """
+    from toolkit import network_mixins as _nm
+
+    if getattr(_nm, "_dual_gpu_bm_patched", False):
+        return
+
+    _orig_bm = _nm.broadcast_and_multiply
+
+    def _device_aware_bm(tensor, multiplier):
+        try:
+            if hasattr(multiplier, "device") and multiplier.device != tensor.device:
+                multiplier = multiplier.to(tensor.device)
+        except Exception:
+            pass
+        return _orig_bm(tensor, multiplier)
+
+    _nm.broadcast_and_multiply = _device_aware_bm
+    _nm._dual_gpu_bm_patched = True

--- a/extensions_built_in/diffusion_models/wan22/wan22_14b_model.py
+++ b/extensions_built_in/diffusion_models/wan22/wan22_14b_model.py
@@ -23,6 +23,7 @@ from toolkit.data_transfer_object.data_loader import DataLoaderBatchDTO
 from torchvision.transforms import functional as TF
 
 from toolkit.models.wan21.wan21 import Wan21
+from .wan22_dual_gpu import Wan22DualGPUMixin
 from .wan22_5b_model import (
     scheduler_config,
     time_text_monkeypatch,
@@ -161,7 +162,7 @@ class DualWanTransformer3DModel(torch.nn.Module):
         return self
 
 
-class Wan2214bModel(Wan21):
+class Wan2214bModel(Wan22DualGPUMixin, Wan21):
     arch = "wan22_14b"
     _wan_generation_scheduler_config = scheduler_configUniPC
     _wan_expand_timesteps = False
@@ -244,7 +245,16 @@ class Wan2214bModel(Wan21):
         return 16
 
     def load_wan_transformer(self, transformer_path, subfolder=None):
-        if self.model_config.split_model_over_gpus:
+        # Dual-GPU model-parallel: distribute each of the two transformers
+        # (high-noise + low-noise experts) across cuda:0/cuda:1 individually.
+        # The DualWanTransformer3DModel wrapper still routes by timestep
+        # boundary; whichever expert it picks now runs through our split
+        # forward. Activates when WAN_DUAL_GPU=true.
+        use_dual_gpu = (
+            hasattr(self, 'setup_dual_gpu_distribution')
+            and os.getenv("WAN_DUAL_GPU", "false").lower() == "true"
+        )
+        if self.model_config.split_model_over_gpus and not use_dual_gpu:
             raise ValueError(
                 "Splitting model over gpus is not supported for Wan2.2 models"
             )
@@ -289,8 +299,8 @@ class Wan2214bModel(Wan21):
 
         flush()
 
-        if self.model_config.low_vram:
-            # quantize on the device
+        if self.model_config.low_vram or use_dual_gpu:
+            # quantize on CPU; for dual-GPU, distribution happens post-quant
             transformer_1.to('cpu', dtype=dtype)
             flush()
         else:
@@ -303,7 +313,11 @@ class Wan2214bModel(Wan21):
             quantize_model(self, transformer_1)
             flush()
 
-        if self.model_config.low_vram:
+        if use_dual_gpu:
+            self.print_and_status_update("Distributing Transformer 1 across cuda:0/cuda:1")
+            self.setup_dual_gpu_distribution(transformer_1, dtype)
+            flush()
+        elif self.model_config.low_vram:
             self.print_and_status_update("Moving transformer 1 to CPU")
             transformer_1.to("cpu")
         else:
@@ -319,8 +333,8 @@ class Wan2214bModel(Wan21):
 
         flush()
 
-        if self.model_config.low_vram:
-            # quantize on the device
+        if self.model_config.low_vram or use_dual_gpu:
+            # quantize on CPU; for dual-GPU, distribution happens post-quant
             transformer_2.to('cpu', dtype=dtype)
             flush()
         else:
@@ -333,7 +347,11 @@ class Wan2214bModel(Wan21):
             quantize_model(self, transformer_2)
             flush()
 
-        if self.model_config.low_vram:
+        if use_dual_gpu:
+            self.print_and_status_update("Distributing Transformer 2 across cuda:0/cuda:1")
+            self.setup_dual_gpu_distribution(transformer_2, dtype)
+            flush()
+        elif self.model_config.low_vram:
             self.print_and_status_update("Moving transformer 2 to CPU")
             transformer_2.to("cpu")
         else:

--- a/extensions_built_in/diffusion_models/wan22/wan22_5b_model.py
+++ b/extensions_built_in/diffusion_models/wan22/wan22_5b_model.py
@@ -15,6 +15,7 @@ from torchvision.transforms import functional as TF
 
 from toolkit.models.wan21.wan21 import Wan21, AggressiveWanUnloadPipeline
 from toolkit.models.wan21.wan_utils import add_first_frame_conditioning_v22
+from .wan22_dual_gpu import Wan22DualGPUMixin
 
 
 # for generation only?
@@ -80,7 +81,7 @@ def time_text_monkeypatch(
 
     return temb, timestep_proj, encoder_hidden_states, encoder_hidden_states_image
 
-class Wan225bModel(Wan21):
+class Wan225bModel(Wan22DualGPUMixin, Wan21):
     arch = "wan22_5b"
     _wan_generation_scheduler_config = scheduler_configUniPC
     _wan_expand_timesteps = True

--- a/extensions_built_in/diffusion_models/wan22/wan22_dual_gpu.py
+++ b/extensions_built_in/diffusion_models/wan22/wan22_dual_gpu.py
@@ -1,0 +1,472 @@
+"""Dual-GPU model-parallel path for Wan 2.2 5B LoRA training.
+
+Activates when WAN_DUAL_GPU=true. Distributes the diffusers
+``WanTransformer3DModel`` across two CUDA devices with a single PCIe
+boundary mid-``blocks``, keeps UMT5 on a configurable device (CPU
+recommended for 32 GB cards), and reuses the same LoRA / multiplier
+patches the FLUX.2 dual-GPU path installs (those hook ai-toolkit-wide
+classes, not FLUX-specific ones, so they apply unchanged here).
+
+Targets the ai-toolkit Wan 2.2 5B trainer
+(``extensions_built_in/diffusion_models/wan22/wan22_5b_model.py``).
+Integration is a two-line edit at the call site:
+
+1. Make ``Wan225bModel`` inherit from ``Wan22DualGPUMixin`` first
+   (MRO ordering: mixin before ``Wan21``).
+2. In ``Wan21.load_wan_transformer``, replace::
+
+       if self.model_config.split_model_over_gpus:
+           raise ValueError("Splitting model over gpus is not supported for Wan2.1 models")
+
+   with a call to ``self.setup_dual_gpu_distribution(transformer, dtype)``
+   (gated by ``is_dual_gpu_enabled()``).
+
+This file is the standalone mixin; the integration edits live elsewhere.
+
+Env vars:
+    WAN_DUAL_GPU=true              enable the dual-GPU path
+    WAN_TE_DEVICE=cpu              pin UMT5 to a specific device
+    WAN_DUAL_GPU_SPLIT_AT=20       override blocks split index
+                                   (default: n_blocks // 2)
+"""
+from __future__ import annotations
+
+import os
+import types
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+if TYPE_CHECKING:
+    from .wan22_5b_model import Wan225bModel  # noqa: F401
+
+
+def is_dual_gpu_enabled() -> bool:
+    return os.getenv("WAN_DUAL_GPU", "false").lower() == "true"
+
+
+def get_te_device_override() -> torch.device | None:
+    """Returns the text-encoder device override if WAN_TE_DEVICE is set."""
+    val = os.getenv("WAN_TE_DEVICE")
+    return torch.device(val) if val else None
+
+
+class Wan22DualGPUMixin:
+    """Mixin for :class:`Wan225bModel` that adds the dual-GPU training path.
+
+    The mixin contributes:
+
+    - ``te_device_torch`` attribute (resolved from ``WAN_TE_DEVICE`` or
+      defaulting to ``device_torch``). Always present — used even when
+      dual-GPU itself is disabled.
+    - ``text_encoder_to`` override that routes UMT5 moves to
+      ``te_device_torch`` instead of ``device_torch``.
+    - ``setup_dual_gpu_distribution(transformer, dtype)`` to be called
+      from ``load_wan_transformer`` after the transformer has been
+      quantized (if applicable) and before the pipeline composes it.
+      Distributes modules across cuda:0/cuda:1, replaces
+      ``WanTransformer3DModel.forward`` with a split-aware variant, pins
+      ``transformer.to()`` to ignore device arguments, and installs the
+      LoRA / multiplier patches.
+    - ``preserve_dual_gpu_split_on_pipe(pipe)`` — to be called in place
+      of ``pipe.transformer = pipe.transformer.to(self.device_torch)``
+      so the distributed layout survives pipeline composition.
+
+    Note on diffusers ``_no_split_modules = ["WanTransformerBlock"]``:
+    that attribute governs HuggingFace ``accelerate`` device-map sharding
+    (it forbids splitting *within* a block). Our split is *between*
+    blocks at a configurable boundary, so the attribute is informational
+    only and does not constrain us.
+    """
+
+    te_device_torch: torch.device
+
+    # ---------------------------------------------------------------- init
+
+    def init_te_device(self) -> None:
+        """Resolve ``te_device_torch`` from env var or fall back to model device.
+
+        Must be called from :meth:`Wan225bModel.__init__` after the base
+        ``__init__`` (which establishes ``self.device_torch``).
+        """
+        override = get_te_device_override()
+        self.te_device_torch = override if override is not None else self.device_torch  # type: ignore[attr-defined]
+
+    # ----------------------------------------------------------- TE override
+
+    def text_encoder_to(self, *args: Any, **kwargs: Any) -> None:
+        """Override of BaseModel.text_encoder_to that honors te_device_torch.
+
+        ai-toolkit's :class:`SDTrainer` hook ``hook_before_train_loop``
+        calls ``self.sd.text_encoder_to(self.device_torch)``
+        unconditionally. With ``WAN_TE_DEVICE=cpu`` we want UMT5 to stay
+        on CPU regardless.
+        """
+        target = self.te_device_torch
+        if isinstance(self.text_encoder, list):  # type: ignore[attr-defined]
+            for encoder in self.text_encoder:  # type: ignore[attr-defined]
+                encoder.to(target)
+        else:
+            self.text_encoder.to(target)  # type: ignore[attr-defined]
+
+    # ------------------------------------------------------------ load hook
+
+    def setup_dual_gpu_distribution(self, transformer: torch.nn.Module, dtype: torch.dtype) -> None:
+        """Distribute the Wan transformer across cuda:0 and cuda:1.
+
+        Layout:
+            cuda:0  — ``rope``, ``patch_embedding``, ``condition_embedder``,
+                      ``blocks[:split_at]``
+            cuda:1  — ``blocks[split_at:]``, ``norm_out``, ``proj_out``,
+                      ``scale_shift_table``
+
+        Also installs the LoRA / multiplier patches that align downstream
+        ai-toolkit machinery with the split layout.
+        """
+        if torch.cuda.device_count() < 2:
+            raise RuntimeError(
+                f"WAN_DUAL_GPU=true requires >=2 CUDA devices, found "
+                f"{torch.cuda.device_count()}."
+            )
+
+        d0 = torch.device("cuda:0")
+        d1 = torch.device("cuda:1")
+        n_blocks = len(transformer.blocks)
+        override = os.getenv("WAN_DUAL_GPU_SPLIT_AT")
+        split_at = int(override) if override else (n_blocks // 2)
+        if not 0 < split_at < n_blocks:
+            raise RuntimeError(
+                f"WAN_DUAL_GPU_SPLIT_AT={split_at} out of range "
+                f"(transformer has {n_blocks} blocks)."
+            )
+
+        self.print_and_status_update(  # type: ignore[attr-defined]
+            f"Distributing transformer across {d0} and {d1}"
+        )
+        self.print_and_status_update(  # type: ignore[attr-defined]
+            f"Block split: {split_at} on cuda:0, "
+            f"{n_blocks - split_at} on cuda:1"
+        )
+
+        transformer.rope.to(d0)
+        transformer.patch_embedding.to(d0, dtype=dtype)
+        transformer.condition_embedder.to(d0, dtype=dtype)
+
+        for blk in transformer.blocks[:split_at]:
+            blk.to(d0, dtype=dtype)
+        for blk in transformer.blocks[split_at:]:
+            blk.to(d1, dtype=dtype)
+
+        transformer.norm_out.to(d1)
+        transformer.proj_out.to(d1, dtype=dtype)
+
+        # scale_shift_table is an nn.Parameter, not a sub-module; moving
+        # the containing module won't reach it because it's referenced
+        # directly. Move the underlying storage in-place under no_grad.
+        with torch.no_grad():
+            transformer.scale_shift_table.data = transformer.scale_shift_table.data.to(d1)
+
+        transformer.forward = types.MethodType(
+            _make_split_forward(split_at), transformer
+        )
+        _pin_transformer_to(transformer)
+
+        _install_external_patches()
+
+    # ----------------------------------------------------- pipeline composer
+
+    def preserve_dual_gpu_split_on_pipe(self, pipe: Any) -> bool:
+        """Return True if we've already distributed; caller should skip the
+        single-device ``pipe.transformer.to(device)`` call."""
+        return is_dual_gpu_enabled()
+
+
+# ---------------------------------------------------------------- helpers
+
+
+def _make_split_forward(split_at: int):
+    """Create a WanTransformer3DModel.forward variant that inserts a
+    cuda:1 boundary at ``blocks[split_at]``.
+
+    Recreates the original forward (see
+    ``diffusers/models/transformers/transformer_wan.py``,
+    ``WanTransformer3DModel.forward``) with three additions:
+      1. At index ``split_at``, cross ``hidden_states``,
+         ``encoder_hidden_states``, ``timestep_proj``, and the
+         ``(cos, sin)`` rotary tuple to cuda:1.
+      2. After ``proj_out``, move output back to cuda:0 so downstream
+         loss ops (which run on the model's nominal device) work.
+      3. Preserve the ``timestep.ndim == 2`` branch used by Wan 2.2
+         ti2v for per-sequence-position timesteps.
+    """
+    from diffusers.models.modeling_outputs import Transformer2DModelOutput
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        timestep: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        encoder_hidden_states_image: torch.Tensor | None = None,
+        return_dict: bool = True,
+        attention_kwargs: dict[str, Any] | None = None,
+    ):
+        batch_size, _, num_frames, height, width = hidden_states.shape
+        p_t, p_h, p_w = self.config.patch_size
+        post_patch_num_frames = num_frames // p_t
+        post_patch_height = height // p_h
+        post_patch_width = width // p_w
+
+        rotary_emb = self.rope(hidden_states)
+
+        hidden_states = self.patch_embedding(hidden_states)
+        hidden_states = hidden_states.flatten(2).transpose(1, 2)
+
+        if timestep.ndim == 2:
+            ts_seq_len = timestep.shape[1]
+            timestep = timestep.flatten()
+        else:
+            ts_seq_len = None
+
+        temb, timestep_proj, encoder_hidden_states, encoder_hidden_states_image = self.condition_embedder(
+            timestep, encoder_hidden_states, encoder_hidden_states_image, timestep_seq_len=ts_seq_len
+        )
+        if ts_seq_len is not None:
+            timestep_proj = timestep_proj.unflatten(2, (6, -1))
+        else:
+            timestep_proj = timestep_proj.unflatten(1, (6, -1))
+
+        if encoder_hidden_states_image is not None:
+            encoder_hidden_states = torch.concat(
+                [encoder_hidden_states_image, encoder_hidden_states], dim=1
+            )
+
+        d0_dev = next(self.blocks[0].parameters()).device
+        d1_dev = next(self.blocks[split_at].parameters()).device
+
+        for i, block in enumerate(self.blocks):
+            if i == split_at and d1_dev != d0_dev:
+                hidden_states = hidden_states.to(d1_dev)
+                encoder_hidden_states = encoder_hidden_states.to(d1_dev)
+                timestep_proj = timestep_proj.to(d1_dev)
+                # rotary_emb is a tuple (cos, sin); both must move.
+                rotary_emb = (
+                    rotary_emb[0].to(d1_dev),
+                    rotary_emb[1].to(d1_dev),
+                )
+            if torch.is_grad_enabled() and self.gradient_checkpointing:
+                hidden_states = self._gradient_checkpointing_func(
+                    block, hidden_states, encoder_hidden_states, timestep_proj, rotary_emb
+                )
+            else:
+                hidden_states = block(hidden_states, encoder_hidden_states, timestep_proj, rotary_emb)
+
+        # temb came out of condition_embedder on d0; the norm_out math
+        # below runs on d1 with hidden_states. Move temb across.
+        out_dev = hidden_states.device
+        if temb.device != out_dev:
+            temb = temb.to(out_dev)
+
+        if temb.ndim == 3:
+            shift, scale = (
+                self.scale_shift_table.unsqueeze(0).to(temb.device) + temb.unsqueeze(2)
+            ).chunk(2, dim=2)
+            shift = shift.squeeze(2)
+            scale = scale.squeeze(2)
+        else:
+            shift, scale = (
+                self.scale_shift_table.to(temb.device) + temb.unsqueeze(1)
+            ).chunk(2, dim=1)
+
+        shift = shift.to(hidden_states.device)
+        scale = scale.to(hidden_states.device)
+
+        hidden_states = (self.norm_out(hidden_states.float()) * (1 + scale) + shift).type_as(hidden_states)
+        hidden_states = self.proj_out(hidden_states)
+
+        hidden_states = hidden_states.reshape(
+            batch_size, post_patch_num_frames, post_patch_height, post_patch_width, p_t, p_h, p_w, -1
+        )
+        hidden_states = hidden_states.permute(0, 7, 1, 4, 2, 5, 3, 6)
+        output = hidden_states.flatten(6, 7).flatten(4, 5).flatten(2, 3)
+
+        # Return on d0 so downstream loss / scatter ops (which run on
+        # the model's nominal device) work without a device-mismatch error.
+        if output.device != d0_dev:
+            output = output.to(d0_dev)
+
+        if not return_dict:
+            return (output,)
+        return Transformer2DModelOutput(sample=output)
+
+    return forward
+
+
+def _pin_transformer_to(transformer: torch.nn.Module) -> None:
+    """Wrap ``transformer.to()`` so device arguments are stripped (the model
+    is already distributed) while dtype changes still pass through.
+
+    Without this, ai-toolkit hooks like ``set_device_state`` (called every
+    training step) and ``pipe.transformer.to(self.device_torch)`` (the
+    pipeline composer) would silently re-collect the split onto cuda:0.
+    """
+    _orig_to = transformer.to
+
+    def _split_preserving_to(*args: Any, **kwargs: Any):
+        filtered_args = [
+            a for a in args
+            if not isinstance(a, (str, torch.device, int))
+        ]
+        filtered_kwargs = {k: v for k, v in kwargs.items() if k != "device"}
+        if not filtered_args and not filtered_kwargs:
+            return transformer
+        return _orig_to(*filtered_args, **filtered_kwargs)
+
+    transformer.to = _split_preserving_to  # type: ignore[assignment]
+
+
+# Module-level idempotency flag. The external patches hook
+# ai-toolkit-wide classes (``ToolkitNetworkMixin``, ``LoRANetwork``,
+# ``network_mixins.broadcast_and_multiply``) — not Wan-specific code —
+# so they're already installed by the FLUX.2 path if it ran first. Gate
+# all three installers behind a single module flag plus per-target
+# attribute flags (defense in depth).
+_PATCHES_INSTALLED = False
+
+
+def _install_external_patches() -> None:
+    """Idempotently install the LoRA-placement and multiplier-device patches.
+
+    These hook external ai-toolkit classes — done as runtime patches so
+    this file remains a self-contained addition. Safe to call alongside
+    the FLUX.2 helper; both gate on the same per-target flags.
+    """
+    global _PATCHES_INSTALLED
+    if _PATCHES_INSTALLED:
+        return
+    _patch_force_to()
+    _patch_apply_to_with_lazy_forward()
+    _patch_broadcast_and_multiply()
+    _PATCHES_INSTALLED = True
+
+
+def _patch_force_to() -> None:
+    """``ToolkitNetworkMixin.force_to`` moves the network's submodules to a
+    single device. Override so each LoRA module follows the device of the
+    layer it wraps.
+    """
+    from toolkit.network_mixins import ToolkitNetworkMixin
+
+    if getattr(ToolkitNetworkMixin, "_dual_gpu_patched", False):
+        return
+
+    def _per_layer_force_to(self_n, device, dtype):
+        try:
+            self_n.to(device, dtype)
+        except Exception:
+            pass
+        loras = []
+        if hasattr(self_n, "unet_loras"):
+            loras += self_n.unet_loras
+        if hasattr(self_n, "text_encoder_loras"):
+            loras += self_n.text_encoder_loras
+        for lora in loras:
+            tgt = device
+            try:
+                parent = lora.org_module[0]
+                p = next(parent.parameters(), None)
+                if p is not None:
+                    tgt = p.device
+            except Exception:
+                pass
+            lora.to(tgt, dtype)
+            for attr in ("lora_down", "lora_up", "lora_mid"):
+                m = getattr(lora, attr, None)
+                if m is not None:
+                    try:
+                        m.to(tgt, dtype)
+                    except Exception:
+                        pass
+
+    ToolkitNetworkMixin.force_to = _per_layer_force_to
+    ToolkitNetworkMixin._dual_gpu_patched = True
+
+
+def _patch_apply_to_with_lazy_forward() -> None:
+    """``LoRANetwork.apply_to`` creates wrapped LoRA modules and registers
+    them as submodules. After it runs, each LoRA's forward is wrapped to
+    lazily re-pin parameters to the input's device on every call.
+
+    The lazy-pin is the load-bearing safety net — any later ai-toolkit
+    hook that calls ``network.to(device)`` (e.g., from
+    ``accelerate.prepare``) is silently corrected on the next forward.
+    """
+    from toolkit.kohya_lora import LoRANetwork
+
+    if getattr(LoRANetwork, "_dual_gpu_apply_patched", False):
+        return
+
+    _orig_apply_to = LoRANetwork.apply_to
+
+    def _redistribute_apply_to(self_n, *args, **kwargs):
+        ret = _orig_apply_to(self_n, *args, **kwargs)
+        loras = []
+        if hasattr(self_n, "unet_loras"):
+            loras += self_n.unet_loras
+        if hasattr(self_n, "text_encoder_loras"):
+            loras += self_n.text_encoder_loras
+        for lora in loras:
+            if getattr(lora, "_dual_gpu_wrapped", False):
+                continue
+            lora.forward = _make_pinned_forward(lora, lora.forward)
+            try:
+                lora.org_module[0].forward = lora.forward
+            except Exception:
+                pass
+            lora._dual_gpu_wrapped = True
+        return ret
+
+    LoRANetwork.apply_to = _redistribute_apply_to
+    LoRANetwork._dual_gpu_apply_patched = True
+
+
+def _make_pinned_forward(lora, orig_forward):
+    """Wrap a LoRA module's forward to re-pin its parameters to the input
+    tensor's device on each call. Cheap no-op when devices already match.
+    """
+    def _pinned(*fargs, **fkwargs):
+        in_dev = None
+        for a in fargs:
+            if hasattr(a, "device") and getattr(a, "is_cuda", False):
+                in_dev = a.device
+                break
+        if in_dev is None:
+            return orig_forward(*fargs, **fkwargs)
+        p = next(lora.parameters(), None)
+        if p is not None and p.device != in_dev:
+            lora.to(in_dev)
+        return orig_forward(*fargs, **fkwargs)
+    return _pinned
+
+
+def _patch_broadcast_and_multiply() -> None:
+    """``network_mixins.broadcast_and_multiply(tensor, multiplier)`` fails
+    when ``tensor`` and ``multiplier`` live on different devices. Auto-move
+    the multiplier to match.
+    """
+    from toolkit import network_mixins as _nm
+
+    if getattr(_nm, "_dual_gpu_bm_patched", False):
+        return
+
+    _orig_bm = _nm.broadcast_and_multiply
+
+    def _device_aware_bm(tensor, multiplier):
+        try:
+            if hasattr(multiplier, "device") and multiplier.device != tensor.device:
+                multiplier = multiplier.to(tensor.device)
+        except Exception:
+            pass
+        return _orig_bm(tensor, multiplier)
+
+    _nm.broadcast_and_multiply = _device_aware_bm
+    _nm._dual_gpu_bm_patched = True

--- a/extensions_built_in/diffusion_models/z_image/z_image.py
+++ b/extensions_built_in/diffusion_models/z_image/z_image.py
@@ -359,14 +359,23 @@ class ZImageModel(ZImageDualGPUMixin, BaseModel):
         return noise_pred
 
     def get_prompt_embeds(self, prompt: str) -> PromptEmbeds:
-        if self.pipeline.text_encoder.device != self.device_torch:
-            self.pipeline.text_encoder.to(self.device_torch)
+        # Route tokenization + encoding through the TE device. Under
+        # Z_IMAGE_TE_DEVICE=cpu the Qwen3 encoder stays on CPU; without
+        # this guard the force-move to self.device_torch would pull it
+        # onto cuda:0 (defeating the offload) and a mismatched device
+        # would crash inside Qwen3's token_embedding.
+        if self.pipeline.text_encoder.device != self.te_device_torch:
+            self.pipeline.text_encoder.to(self.te_device_torch)
 
         prompt_embeds, _ = self.pipeline.encode_prompt(
             prompt,
             do_classifier_free_guidance=False,
-            device=self.device_torch,
+            device=self.te_device_torch,
         )
+        # Bring the output back to the trainer device so downstream
+        # pipeline ops (which run on device_torch) match.
+        if hasattr(prompt_embeds, "device") and prompt_embeds.device != self.device_torch:
+            prompt_embeds = prompt_embeds.to(self.device_torch)
         pe = PromptEmbeds([prompt_embeds, None])
         return pe
 

--- a/extensions_built_in/diffusion_models/z_image/z_image.py
+++ b/extensions_built_in/diffusion_models/z_image/z_image.py
@@ -29,6 +29,8 @@ except ImportError:
         "Diffusers is out of date. Update diffusers to the latest version by doing pip uninstall diffusers and then pip install -r requirements.txt"
     )
 
+from .z_image_dual_gpu import ZImageDualGPUMixin, is_dual_gpu_enabled
+
 
 scheduler_config = {
     "num_train_timesteps": 1000,
@@ -37,7 +39,7 @@ scheduler_config = {
 }
 
 
-class ZImageModel(BaseModel):
+class ZImageModel(ZImageDualGPUMixin, BaseModel):
     arch = "zimage"
 
     def __init__(
@@ -55,6 +57,7 @@ class ZImageModel(BaseModel):
         self.is_flow_matching = True
         self.is_transformer = True
         self.target_lora_modules = ["ZImageTransformer2DModel"]
+        self.init_te_device()
 
     # static method to get the noise scheduler
     @staticmethod
@@ -182,23 +185,32 @@ class ZImageModel(BaseModel):
             quantize_model(self, transformer)
             flush()
 
-        if (
-            self.model_config.layer_offloading
-            and self.model_config.layer_offloading_transformer_percent > 0
-        ):
-            MemoryManager.attach(
-                transformer,
-                self.device_torch,
-                offload_percent=self.model_config.layer_offloading_transformer_percent,
-                ignore_modules=[
-                    transformer.x_pad_token,
-                    transformer.cap_pad_token,
-                ]
-            )
+        if is_dual_gpu_enabled():
+            # Dual-GPU is mutually exclusive with layer_offloading + low_vram
+            # (both schemes manage transformer device residence). Distribute
+            # the transformer across cuda:0 / cuda:1 instead. After this
+            # call, transformer.to() is pinned to ignore device args so
+            # later pipe.transformer.to() / generate_single_image .to()
+            # sites become no-ops and the split layout survives.
+            self.setup_dual_gpu_distribution(transformer, dtype)
+        else:
+            if (
+                self.model_config.layer_offloading
+                and self.model_config.layer_offloading_transformer_percent > 0
+            ):
+                MemoryManager.attach(
+                    transformer,
+                    self.device_torch,
+                    offload_percent=self.model_config.layer_offloading_transformer_percent,
+                    ignore_modules=[
+                        transformer.x_pad_token,
+                        transformer.cap_pad_token,
+                    ]
+                )
 
-        if self.model_config.low_vram:
-            self.print_and_status_update("Moving transformer to CPU")
-            transformer.to("cpu")
+            if self.model_config.low_vram:
+                self.print_and_status_update("Moving transformer to CPU")
+                transformer.to("cpu")
 
         flush()
 
@@ -220,7 +232,7 @@ class ZImageModel(BaseModel):
                 offload_percent=self.model_config.layer_offloading_text_encoder_percent,
             )
 
-        text_encoder.to(self.device_torch, dtype=dtype)
+        text_encoder.to(self.te_device_torch, dtype=dtype)
         flush()
 
         if self.model_config.quantize_te:
@@ -263,7 +275,7 @@ class ZImageModel(BaseModel):
 
         flush()
         # just to make sure everything is on the right device and dtype
-        text_encoder[0].to(self.device_torch)
+        text_encoder[0].to(self.te_device_torch)
         text_encoder[0].requires_grad_(False)
         text_encoder[0].eval()
         flush()

--- a/extensions_built_in/diffusion_models/z_image/z_image_dual_gpu.py
+++ b/extensions_built_in/diffusion_models/z_image/z_image_dual_gpu.py
@@ -1,0 +1,571 @@
+"""Dual-GPU model-parallel path for Z-Image LoRA training.
+
+Activates when ``Z_IMAGE_DUAL_GPU=true``. Distributes the diffusers
+``ZImageTransformer2DModel`` (the Tongyi-MAI Z-Image transformer, novel
+architecture — not FLUX-shaped) across two CUDA devices with a single
+PCIe boundary mid-``layers``, keeps the Qwen3 text encoder on a
+configurable device, and reuses the same LoRA / multiplier patches the
+FLUX.2 / Wan 2.2 / LTX-2 / Qwen-Image / HiDream / Chroma / FLUX.1-Kontext
+dual-GPU paths install (those hook ai-toolkit-wide classes, not
+model-specific ones, so they apply unchanged here — the per-target patch
+flags make calling them all safe).
+
+Targets the ai-toolkit Z-Image trainer
+(``extensions_built_in/diffusion_models/z_image/z_image.py``).
+Integration:
+
+1. Make ``ZImageModel`` inherit from ``ZImageDualGPUMixin`` first
+   (MRO ordering: mixin before ``BaseModel``).
+2. In ``ZImageModel.__init__``, call ``self.init_te_device()`` after the
+   base ``__init__`` to resolve ``te_device_torch``.
+3. In ``ZImageModel.load_model``, after quantize, call
+   ``self.setup_dual_gpu_distribution(transformer, dtype)`` gated by
+   ``is_dual_gpu_enabled()``. Route the Qwen3 ``.to()`` sites to
+   ``self.te_device_torch``.
+
+Z-Image is shaped differently from FLUX-family transformers. It has:
+
+- ``all_x_embedder``: ``nn.ModuleDict`` keyed by ``"{patch_size}-{f_patch_size}"``
+- ``all_final_layer``: same key shape
+- ``noise_refiner``: ``nn.ModuleList`` (2 blocks, modulation=True)
+- ``context_refiner``: ``nn.ModuleList`` (2 blocks, modulation=False)
+- ``siglip_refiner``: optional ``nn.ModuleList`` (Omni variant)
+- ``t_embedder``, ``cap_embedder``, ``siglip_embedder`` (optional)
+- ``x_pad_token``, ``cap_pad_token``, ``siglip_pad_token`` (optional)
+  — module-level ``nn.Parameter`` attributes (don't follow ``.to(device)``
+  on the submodules; must be moved explicitly)
+- ``layers``: ``nn.ModuleList`` of 30 main blocks — the split target
+- ``rope_embedder``: plain Python class (NOT ``nn.Module``); its
+  ``freqs_cis`` cache follows the input tensor's device on each call, so
+  no special handling needed beyond keeping pre-main-loop inputs on cuda:0
+
+Layout: every pre-main-loop module (embedders, refiners, pad-token
+Parameters) + ``layers[:split_at]`` on cuda:0; ``layers[split_at:]`` +
+``all_final_layer`` on cuda:1. Default ``split_at = n_layers // 2 = 15``.
+
+Env vars:
+    Z_IMAGE_DUAL_GPU=true              enable the dual-GPU path
+    Z_IMAGE_TE_DEVICE=cpu              pin the Qwen3 text encoder
+    Z_IMAGE_DUAL_GPU_SPLIT_AT=15       override layers split index
+                                       (default: n_layers // 2)
+"""
+from __future__ import annotations
+
+import os
+import types
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from diffusers.utils import logging
+
+if TYPE_CHECKING:
+    from .z_image import ZImageModel  # noqa: F401
+
+logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
+
+
+def is_dual_gpu_enabled() -> bool:
+    return os.getenv("Z_IMAGE_DUAL_GPU", "false").lower() == "true"
+
+
+def get_te_device_override() -> torch.device | None:
+    val = os.getenv("Z_IMAGE_TE_DEVICE")
+    return torch.device(val) if val else None
+
+
+class ZImageDualGPUMixin:
+    """Mixin for :class:`ZImageModel` that adds the dual-GPU training path."""
+
+    te_device_torch: torch.device
+
+    # ---------------------------------------------------------------- init
+
+    def init_te_device(self) -> None:
+        override = get_te_device_override()
+        self.te_device_torch = override if override is not None else self.device_torch  # type: ignore[attr-defined]
+        if self.te_device_torch.type == "cpu":
+            self.print_and_status_update(  # type: ignore[attr-defined]
+                "Z_IMAGE_TE_DEVICE=cpu — the Qwen3 text encoder will run on "
+                "CPU. Set `cache_text_embeddings: true` in your config so it "
+                "runs once at startup; otherwise it runs on CPU every step."
+            )
+
+    # ----------------------------------------------------------- TE override
+
+    def text_encoder_to(self, *args: Any, **kwargs: Any) -> None:
+        target = self.te_device_torch
+        if isinstance(self.text_encoder, list):  # type: ignore[attr-defined]
+            for encoder in self.text_encoder:  # type: ignore[attr-defined]
+                encoder.to(target)
+        else:
+            self.text_encoder.to(target)  # type: ignore[attr-defined]
+
+    # ------------------------------------------------------------ load hook
+
+    def setup_dual_gpu_distribution(self, transformer: torch.nn.Module, dtype: torch.dtype) -> None:
+        """Distribute the Z-Image transformer across cuda:0 and cuda:1.
+
+        Layout:
+            cuda:0  — embedders (``t_embedder``, ``cap_embedder``,
+                      optional ``siglip_embedder``), ``all_x_embedder``,
+                      both refiners (``noise_refiner``, ``context_refiner``,
+                      optional ``siglip_refiner``), pad-token Parameters
+                      (``x_pad_token``, ``cap_pad_token``, optional
+                      ``siglip_pad_token``), ``layers[:split_at]``
+            cuda:1  — ``layers[split_at:]``, ``all_final_layer``
+
+        Module-level ``nn.Parameter`` attributes (``x_pad_token``,
+        ``cap_pad_token``, ``siglip_pad_token``) don't follow the
+        per-submodule ``.to()`` calls used elsewhere — they need explicit
+        ``.data = .data.to()`` moves. Without this they stay on whatever
+        device the loader landed them (typically the staging device),
+        breaking ``_prepare_sequence`` which uses them on cuda:0.
+
+        ``rope_embedder`` is a plain Python class (not ``nn.Module``); its
+        ``freqs_cis`` cache auto-follows the input tensor's device on each
+        call, so no explicit handling is needed.
+
+        Also installs the LoRA / multiplier patches that align downstream
+        ai-toolkit machinery with the split layout.
+        """
+        if not torch.cuda.is_available() or torch.cuda.device_count() < 2:
+            raise RuntimeError(
+                "Z_IMAGE_DUAL_GPU=true needs at least 2 CUDA devices "
+                f"(cuda:0 + cuda:1); found "
+                f"{torch.cuda.device_count() if torch.cuda.is_available() else 0}. "
+                "Unset Z_IMAGE_DUAL_GPU for single-GPU training."
+            )
+
+        d0 = torch.device("cuda:0")
+        d1 = torch.device("cuda:1")
+        n_layers = len(transformer.layers)
+        override = os.getenv("Z_IMAGE_DUAL_GPU_SPLIT_AT")
+        if override is not None:
+            try:
+                split_at = int(override)
+            except ValueError:
+                raise ValueError(
+                    "Z_IMAGE_DUAL_GPU_SPLIT_AT must be an integer; "
+                    f"got {override!r}."
+                )
+            if not (1 <= split_at < n_layers):
+                raise ValueError(
+                    f"Z_IMAGE_DUAL_GPU_SPLIT_AT={split_at} is out of range; "
+                    f"must be in [1, {n_layers - 1}] for a model with "
+                    f"{n_layers} main-block layers."
+                )
+        else:
+            split_at = n_layers // 2
+
+        self.print_and_status_update(  # type: ignore[attr-defined]
+            f"Distributing transformer across {d0} and {d1}"
+        )
+        self.print_and_status_update(  # type: ignore[attr-defined]
+            f"Main layers split: {split_at} on {d0}, "
+            f"{n_layers - split_at} on {d1}"
+        )
+
+        # --- cuda:0: embedders, refiners, pad-token Parameters,
+        #     first half of main layers
+        transformer.t_embedder.to(d0, dtype=dtype)
+        transformer.cap_embedder.to(d0, dtype=dtype)
+        transformer.all_x_embedder.to(d0, dtype=dtype)
+
+        for blk in transformer.noise_refiner:
+            blk.to(d0, dtype=dtype)
+        for blk in transformer.context_refiner:
+            blk.to(d0, dtype=dtype)
+
+        if getattr(transformer, "siglip_embedder", None) is not None:
+            transformer.siglip_embedder.to(d0, dtype=dtype)
+        if getattr(transformer, "siglip_refiner", None) is not None:
+            for blk in transformer.siglip_refiner:
+                blk.to(d0, dtype=dtype)
+
+        # Module-level nn.Parameter attrs — explicit .data move, since
+        # they're not reached by per-submodule .to() calls.
+        transformer.x_pad_token.data = transformer.x_pad_token.data.to(d0, dtype=dtype)
+        transformer.cap_pad_token.data = transformer.cap_pad_token.data.to(d0, dtype=dtype)
+        if getattr(transformer, "siglip_pad_token", None) is not None:
+            transformer.siglip_pad_token.data = transformer.siglip_pad_token.data.to(d0, dtype=dtype)
+
+        for i, blk in enumerate(transformer.layers):
+            blk.to(d0 if i < split_at else d1, dtype=dtype)
+
+        # --- cuda:1: final output (ModuleDict — every key goes to cuda:1)
+        transformer.all_final_layer.to(d1, dtype=dtype)
+
+        transformer.forward = types.MethodType(
+            _make_split_forward(split_at), transformer
+        )
+        _pin_transformer_to(transformer)
+
+        _install_external_patches()
+
+
+# ---------------------------------------------------------------- helpers
+
+
+def _make_split_forward(split_at: int):
+    """Create a ``ZImageTransformer2DModel.forward`` variant that inserts
+    a cuda:1 boundary at ``layers[split_at]``.
+
+    Recreates the diffusers ``ZImageTransformer2DModel.forward`` from the
+    *box's* installed diffusers (pulled at port time — the mac install
+    diverges, so we built against the box copy to track the actual
+    runtime — Qwen-Image lesson applied) with one addition:
+
+      At ``layers[split_at]`` — the single PCIe boundary — bridge to
+      cuda:1 every tensor the downstream main-block iterations +
+      ``all_final_layer`` + ``unpatchify`` consume: ``unified``,
+      ``unified_mask``, ``unified_freqs``, ``adaln_input`` (or
+      ``t_noisy``/``t_clean`` in Omni mode), and
+      ``unified_noise_tensor``. After ``unpatchify`` the output list is
+      moved back to cuda:0 element-wise so downstream loss ops work
+      without a device-mismatch error.
+
+    ``controlnet_block_samples`` is preserved verbatim — consumed inside
+    the per-layer step on whichever device the layer lives on. Caller
+    must provide samples on the right device; out of scope for the
+    LoRA-training path this port targets.
+    """
+    from diffusers.models.modeling_outputs import Transformer2DModelOutput
+
+    def forward(
+        self,
+        x: Any,  # list[Tensor] or list[list[Tensor]] in Omni mode
+        t: torch.Tensor,
+        cap_feats: Any,
+        return_dict: bool = True,
+        controlnet_block_samples: dict[int, torch.Tensor] | None = None,
+        siglip_feats: Any | None = None,
+        image_noise_mask: Any | None = None,
+        patch_size: int = 2,
+        f_patch_size: int = 1,
+    ):
+        assert patch_size in self.all_patch_size and f_patch_size in self.all_f_patch_size
+        omni_mode = isinstance(x[0], list)
+
+        # Devices on each side of the PCIe boundary.
+        d0_dev = next(self.layers[0].parameters()).device
+        d1_dev = next(self.layers[split_at].parameters()).device
+        device = d0_dev  # pre-main-loop work all happens on cuda:0
+
+        if omni_mode:
+            t_noisy = self.t_embedder(t.to(d0_dev) * self.t_scale).type_as(x[0][-1])
+            t_clean = self.t_embedder(torch.ones_like(t).to(d0_dev) * self.t_scale).type_as(x[0][-1])
+            adaln_input = None
+        else:
+            adaln_input = self.t_embedder(t.to(d0_dev) * self.t_scale).type_as(x[0])
+            t_noisy = t_clean = None
+
+        # Patchify
+        if omni_mode:
+            (
+                x,
+                cap_feats,
+                siglip_feats,
+                x_size,
+                x_pos_ids,
+                cap_pos_ids,
+                siglip_pos_ids,
+                x_pad_mask,
+                cap_pad_mask,
+                siglip_pad_mask,
+                x_pos_offsets,
+                x_noise_mask,
+                cap_noise_mask,
+                siglip_noise_mask,
+            ) = self.patchify_and_embed_omni(x, cap_feats, siglip_feats, patch_size, f_patch_size, image_noise_mask)
+        else:
+            (
+                x,
+                cap_feats,
+                x_size,
+                x_pos_ids,
+                cap_pos_ids,
+                x_pad_mask,
+                cap_pad_mask,
+            ) = self.patchify_and_embed(x, cap_feats, patch_size, f_patch_size)
+            x_pos_offsets = x_noise_mask = cap_noise_mask = siglip_noise_mask = None
+
+        # X embed & refine — cuda:0
+        x_seqlens = [len(xi) for xi in x]
+        x = self.all_x_embedder[f"{patch_size}-{f_patch_size}"](torch.cat(x, dim=0))
+        x, x_freqs, x_mask, _, x_noise_tensor = self._prepare_sequence(
+            list(x.split(x_seqlens, dim=0)), x_pos_ids, x_pad_mask, self.x_pad_token, x_noise_mask, device
+        )
+
+        for layer in self.noise_refiner:
+            x = (
+                self._gradient_checkpointing_func(
+                    layer, x, x_mask, x_freqs, adaln_input, x_noise_tensor, t_noisy, t_clean
+                )
+                if torch.is_grad_enabled() and self.gradient_checkpointing
+                else layer(x, x_mask, x_freqs, adaln_input, x_noise_tensor, t_noisy, t_clean)
+            )
+
+        # Cap embed & refine — cuda:0
+        cap_seqlens = [len(ci) for ci in cap_feats]
+        cap_feats = self.cap_embedder(torch.cat(cap_feats, dim=0))
+        cap_feats, cap_freqs, cap_mask, _, _ = self._prepare_sequence(
+            list(cap_feats.split(cap_seqlens, dim=0)), cap_pos_ids, cap_pad_mask, self.cap_pad_token, None, device
+        )
+
+        for layer in self.context_refiner:
+            cap_feats = (
+                self._gradient_checkpointing_func(layer, cap_feats, cap_mask, cap_freqs)
+                if torch.is_grad_enabled() and self.gradient_checkpointing
+                else layer(cap_feats, cap_mask, cap_freqs)
+            )
+
+        # Siglip embed & refine — cuda:0 (Omni only)
+        siglip_seqlens = siglip_freqs = None
+        if omni_mode and siglip_feats[0] is not None and self.siglip_embedder is not None:
+            siglip_seqlens = [len(si) for si in siglip_feats]
+            siglip_feats = self.siglip_embedder(torch.cat(siglip_feats, dim=0))
+            siglip_feats, siglip_freqs, siglip_mask, _, _ = self._prepare_sequence(
+                list(siglip_feats.split(siglip_seqlens, dim=0)),
+                siglip_pos_ids,
+                siglip_pad_mask,
+                self.siglip_pad_token,
+                None,
+                device,
+            )
+
+            for layer in self.siglip_refiner:
+                siglip_feats = (
+                    self._gradient_checkpointing_func(layer, siglip_feats, siglip_mask, siglip_freqs)
+                    if torch.is_grad_enabled() and self.gradient_checkpointing
+                    else layer(siglip_feats, siglip_mask, siglip_freqs)
+                )
+
+        # Unified sequence — cuda:0
+        unified, unified_freqs, unified_mask, unified_noise_tensor = self._build_unified_sequence(
+            x,
+            x_freqs,
+            x_seqlens,
+            x_noise_mask,
+            cap_feats,
+            cap_freqs,
+            cap_seqlens,
+            cap_noise_mask,
+            siglip_feats,
+            siglip_freqs,
+            siglip_seqlens,
+            siglip_noise_mask,
+            omni_mode,
+            device,
+        )
+
+        # Main transformer layers — PCIe boundary at split_at
+        for layer_idx, layer in enumerate(self.layers):
+            if layer_idx == split_at and d1_dev != d0_dev:
+                # Bridge every tensor the downstream main-blocks + final +
+                # unpatchify consume. ``unified_noise_tensor`` may be None
+                # in non-omni mode; guard. ``t_noisy`` / ``t_clean`` are
+                # used by final_layer in omni mode; bridge if present.
+                unified = unified.to(d1_dev)
+                if unified_mask is not None:
+                    unified_mask = unified_mask.to(d1_dev)
+                if unified_freqs is not None:
+                    if isinstance(unified_freqs, (list, tuple)):
+                        unified_freqs = type(unified_freqs)(
+                            f.to(d1_dev) if hasattr(f, "to") else f for f in unified_freqs
+                        )
+                    else:
+                        unified_freqs = unified_freqs.to(d1_dev)
+                if adaln_input is not None:
+                    adaln_input = adaln_input.to(d1_dev)
+                if unified_noise_tensor is not None:
+                    unified_noise_tensor = unified_noise_tensor.to(d1_dev)
+                if t_noisy is not None:
+                    t_noisy = t_noisy.to(d1_dev)
+                if t_clean is not None:
+                    t_clean = t_clean.to(d1_dev)
+
+            unified = (
+                self._gradient_checkpointing_func(
+                    layer, unified, unified_mask, unified_freqs, adaln_input, unified_noise_tensor, t_noisy, t_clean
+                )
+                if torch.is_grad_enabled() and self.gradient_checkpointing
+                else layer(unified, unified_mask, unified_freqs, adaln_input, unified_noise_tensor, t_noisy, t_clean)
+            )
+            if controlnet_block_samples is not None and layer_idx in controlnet_block_samples:
+                # Caller-supplied sample; bridge to the current unified
+                # device for safety. Out of scope for LoRA training, but
+                # keep parity with the vendored forward.
+                cb = controlnet_block_samples[layer_idx]
+                if hasattr(cb, "to") and cb.device != unified.device:
+                    cb = cb.to(unified.device)
+                unified = unified + cb
+
+        # Final layer on cuda:1; adaln_input + t_noisy/t_clean were
+        # bridged at the boundary already.
+        unified = (
+            self.all_final_layer[f"{patch_size}-{f_patch_size}"](
+                unified, noise_mask=unified_noise_tensor, c_noisy=t_noisy, c_clean=t_clean
+            )
+            if omni_mode
+            else self.all_final_layer[f"{patch_size}-{f_patch_size}"](unified, c=adaln_input)
+        )
+
+        # Unpatchify — operates on cuda:1 input, returns list[Tensor] on cuda:1.
+        x = self.unpatchify(list(unified.unbind(dim=0)), x_size, patch_size, f_patch_size, x_pos_offsets)
+
+        # Return on cuda:0 so downstream loss / scatter ops (which run on
+        # the model's nominal device) work without device-mismatch errors.
+        # x is a list[Tensor] — move each element.
+        if isinstance(x, list):
+            x = [t.to(d0_dev) if hasattr(t, "to") and t.device != d0_dev else t for t in x]
+        elif hasattr(x, "to") and x.device != d0_dev:
+            x = x.to(d0_dev)
+
+        return (x,) if not return_dict else Transformer2DModelOutput(sample=x)
+
+    return forward
+
+
+def _pin_transformer_to(transformer: torch.nn.Module) -> None:
+    """Wrap ``transformer.to()`` so device arguments are stripped (the model
+    is already distributed) while dtype changes still pass through.
+
+    Z-Image's ``z_image.py`` has more ``transformer.to(self.device_torch)``
+    call sites than most trainers (in ``load_model``, in
+    ``generate_single_image`` L303-304, and in ``get_noise_prediction``
+    L329). Pinning makes all of them no-ops.
+    """
+    _orig_to = transformer.to
+
+    def _split_preserving_to(*args: Any, **kwargs: Any):
+        filtered_args = [
+            a for a in args
+            if not isinstance(a, (str, torch.device, int))
+        ]
+        filtered_kwargs = {k: v for k, v in kwargs.items() if k != "device"}
+        if not filtered_args and not filtered_kwargs:
+            return transformer
+        return _orig_to(*filtered_args, **filtered_kwargs)
+
+    transformer.to = _split_preserving_to  # type: ignore[assignment]
+
+
+# Module-level idempotency flag — shared with FLUX.2 / Wan / LTX-2 /
+# Qwen-Image / HiDream / Chroma / FLUX.1-Kontext via per-target attribute
+# flags on the patched classes.
+_PATCHES_INSTALLED = False
+
+
+def _install_external_patches() -> None:
+    global _PATCHES_INSTALLED
+    if _PATCHES_INSTALLED:
+        return
+    _patch_force_to()
+    _patch_apply_to_with_lazy_forward()
+    _patch_broadcast_and_multiply()
+    _PATCHES_INSTALLED = True
+
+
+def _patch_force_to() -> None:
+    from toolkit.network_mixins import ToolkitNetworkMixin
+
+    if getattr(ToolkitNetworkMixin, "_dual_gpu_patched", False):
+        return
+
+    def _per_layer_force_to(self_n, device, dtype):
+        try:
+            self_n.to(device, dtype)
+        except Exception:
+            pass
+        loras = []
+        if hasattr(self_n, "unet_loras"):
+            loras += self_n.unet_loras
+        if hasattr(self_n, "text_encoder_loras"):
+            loras += self_n.text_encoder_loras
+        for lora in loras:
+            tgt = device
+            try:
+                parent = lora.org_module[0]
+                p = next(parent.parameters(), None)
+                if p is not None:
+                    tgt = p.device
+            except Exception:
+                pass
+            lora.to(tgt, dtype)
+            for attr in ("lora_down", "lora_up", "lora_mid"):
+                m = getattr(lora, attr, None)
+                if m is not None:
+                    try:
+                        m.to(tgt, dtype)
+                    except Exception:
+                        pass
+
+    ToolkitNetworkMixin.force_to = _per_layer_force_to
+    ToolkitNetworkMixin._dual_gpu_patched = True
+
+
+def _patch_apply_to_with_lazy_forward() -> None:
+    from toolkit.kohya_lora import LoRANetwork
+
+    if getattr(LoRANetwork, "_dual_gpu_apply_patched", False):
+        return
+
+    _orig_apply_to = LoRANetwork.apply_to
+
+    def _redistribute_apply_to(self_n, *args, **kwargs):
+        ret = _orig_apply_to(self_n, *args, **kwargs)
+        loras = []
+        if hasattr(self_n, "unet_loras"):
+            loras += self_n.unet_loras
+        if hasattr(self_n, "text_encoder_loras"):
+            loras += self_n.text_encoder_loras
+        for lora in loras:
+            if getattr(lora, "_dual_gpu_wrapped", False):
+                continue
+            lora.forward = _make_pinned_forward(lora, lora.forward)
+            try:
+                lora.org_module[0].forward = lora.forward
+            except Exception:
+                pass
+            lora._dual_gpu_wrapped = True
+        return ret
+
+    LoRANetwork.apply_to = _redistribute_apply_to
+    LoRANetwork._dual_gpu_apply_patched = True
+
+
+def _make_pinned_forward(lora, orig_forward):
+    def _pinned(*fargs, **fkwargs):
+        in_dev = None
+        for a in fargs:
+            if hasattr(a, "device") and getattr(a, "is_cuda", False):
+                in_dev = a.device
+                break
+        if in_dev is None:
+            return orig_forward(*fargs, **fkwargs)
+        p = next(lora.parameters(), None)
+        if p is not None and p.device != in_dev:
+            lora.to(in_dev)
+        return orig_forward(*fargs, **fkwargs)
+    return _pinned
+
+
+def _patch_broadcast_and_multiply() -> None:
+    from toolkit import network_mixins as _nm
+
+    if getattr(_nm, "_dual_gpu_bm_patched", False):
+        return
+
+    _orig_bm = _nm.broadcast_and_multiply
+
+    def _device_aware_bm(tensor, multiplier):
+        try:
+            if hasattr(multiplier, "device") and multiplier.device != tensor.device:
+                multiplier = multiplier.to(tensor.device)
+        except Exception:
+            pass
+        return _orig_bm(tensor, multiplier)
+
+    _nm.broadcast_and_multiply = _device_aware_bm
+    _nm._dual_gpu_bm_patched = True

--- a/toolkit/models/wan21/wan21.py
+++ b/toolkit/models/wan21/wan21.py
@@ -350,12 +350,20 @@ class Wan21(BaseModel):
             torch_dtype=dtype,
         ).to(dtype=dtype)
 
-        if self.model_config.split_model_over_gpus:
+        # Dual-GPU model-parallel path is supplied by a subclass mixin
+        # (Wan22DualGPUMixin on Wan225bModel). Activates when WAN_DUAL_GPU=true
+        # in the environment; keeps the transformer on CPU through quantize so
+        # the mixin can distribute modules across cuda:0/cuda:1 afterward.
+        use_dual_gpu = (
+            hasattr(self, 'setup_dual_gpu_distribution')
+            and os.getenv("WAN_DUAL_GPU", "false").lower() == "true"
+        )
+        if self.model_config.split_model_over_gpus and not use_dual_gpu:
             raise ValueError(
                 "Splitting model over gpus is not supported for Wan2.1 models")
 
-        if self.model_config.low_vram:
-            # quantize on the device
+        if self.model_config.low_vram or use_dual_gpu:
+            # quantize on CPU; for dual-GPU, distribution happens post-quant
             transformer.to('cpu', dtype=dtype)
             flush()
         else:
@@ -376,7 +384,11 @@ class Wan21(BaseModel):
             self.print_and_status_update("Quantizing Transformer")
             quantize_model(self, transformer)
             flush()
-        
+
+        if use_dual_gpu:
+            self.setup_dual_gpu_distribution(transformer, dtype)
+            flush()
+
         if self.model_config.layer_offloading and self.model_config.layer_offloading_transformer_percent > 0:
             MemoryManager.attach(
                 transformer,


### PR DESCRIPTION
Dual RTX 5090 is the best consumer GPU setup one can get. This PR
proposes a way past the per-card 32 GB VRAM limit for **FLUX.2**,
**Wan 2.2**, **LTX-2**, **Qwen-Image**, **Chroma1-HD**, **FLUX.1-Kontext**,
**HiDream-I1**, and **Z-Image** LoRA training.

Closes #531.

> **Scope note:** originally filed FLUX.2-only; the seven others are
> folded in because they share the same toolkit-wide infrastructure (the
> LoRA per-layer device routing patches, the CPU-quantize-before-move
> load path, the gradient-checkpoint dict/list aliasing handling). The
> dual-GPU machinery is genuinely shared; one PR per trainer is the
> honest unit of work. Happy to split if you'd prefer to review
> separately.

## Problem

On a single 32 GB consumer GPU, FLUX.2-dev at qfloat8 (~30 GB) plus
bf16 activations overshoots VRAM by ~1 GB per forward. Windows WDDM
pages the transient through unified memory every step. Throughput on
a single 5090 collapses from 14.4 s/it to 277 s/it within a few
hundred steps. On Linux the same configuration OOMs outright.

`torch.cuda.memory_summary()` confirms: at step 1 the peak allocation
already exceeds the card by ~1 GB (`cur=30.63 GB / peak=32.94 GB /
capacity=31.84 GB`). It's a per-step over-capacity transient, not
a leak.

The Wan 2.2 14B A14B variants have the same shape of problem — each of
the two expert transformers is ~14 GB at fp8, and the activation
footprint at video resolutions pushes a single 32 GB card over.
LTX-2 / Qwen-Image / Chroma1-HD / FLUX.1-Kontext / HiDream-I1 each hit
the same wall at fp8 + bf16 activations on a single 32 GB card.
Z-Image is the smallest of the eight (~30-block transformer) and would
fit single-card, but the same mixin runs it for symmetry + faster
training at higher batch sizes.

## Fix

Opt-in per arch via `FLUX2_DUAL_GPU=true` / `WAN_DUAL_GPU=true` /
`LTX2_DUAL_GPU=true` / `QWEN_IMAGE_DUAL_GPU=true` / `CHROMA_DUAL_GPU=true`
/ `FLUX_KONTEXT_DUAL_GPU=true` / `HIDREAM_DUAL_GPU=true` /
`Z_IMAGE_DUAL_GPU=true`.

- Transformer split across two CUDA devices at the block-list
  midpoint. One PCIe boundary per forward.
- Text encoder pinned to CPU (`<ARCH>_TE_DEVICE=cpu`). With the existing
  `cache_text_embeddings` + `unload_text_encoder` flags it runs once at
  training start, caches embeddings, then unloads. The inner loop never
  touches it.
- LoRA per-layer device routing. `ToolkitNetworkMixin.force_to` and
  `LoRANetwork.apply_to` patched to follow each LoRA's wrapped layer;
  lazy forward-pin as a safety net for LoRAs added post-install. These
  patches target ai-toolkit's own classes (not arch-specific), so every
  port reuses them via per-class idempotency flags.
- Fails fast on misconfiguration — fewer than 2 CUDA devices, a
  non-CUDA device, or an out-of-range split index each raise a clear
  error at load time rather than crashing mid-forward.

### FLUX.2

Packaged as `Flux2DualGPUMixin` in
`extensions_built_in/diffusion_models/flux2/flux2_dual_gpu.py`;
`Flux2Model` inherits it. Split at the `single_blocks` midpoint —
DoubleStreamBlocks + first half of SingleStreamBlocks on the primary
device, the remainder + `final_layer` on the next ordinal.

### Wan 2.2

Packaged as `Wan22DualGPUMixin` in
`extensions_built_in/diffusion_models/wan22/wan22_dual_gpu.py`, mirroring
the FLUX.2 mixin shape. `Wan225bModel` and `Wan2214bModel` inherit it
(the I2V variant transitively). Split places `rope` / `patch_embedding`
/ `condition_embedder` / first half of `blocks` on cuda:0, the remainder
+ `norm_out` / `proj_out` / `scale_shift_table` on cuda:1.
`Wan21.load_wan_transformer`'s existing
`raise ValueError("Splitting model over gpus is not supported")` is
softened to dispatch to the mixin when `WAN_DUAL_GPU=true`. For the 14B
A14B dual-DiT variants, each of the two expert transformers
(`transformer_1` high-noise + `transformer_2` low-noise) is distributed
individually after quantize; the `DualWanTransformer3DModel` wrapper's
timestep-routed forward is unchanged — whichever expert it picks now
runs through the split forward. Wan-specific handling: `rotary_emb` is a
`(cos, sin)` tuple, `scale_shift_table` is an `nn.Parameter`, and
Wan 2.2 ti2v's 2D-timestep path is preserved in the split forward.

### LTX-2

Packaged as `Ltx2DualGPUMixin` in
`extensions_built_in/diffusion_models/ltx2/ltx2_dual_gpu.py`. 48-block
transformer, split midpoint. LTX-2-specific handling: dual-modality
(video + audio) carries four RoPE tuples through the boundary; the
post-split forward bridges all four. The audio TE / connectors / vocoder
are kept on `te_device_torch` alongside the main TE.

### Qwen-Image

Packaged as `QwenImageDualGPUMixin` in
`extensions_built_in/diffusion_models/qwen_image/qwen_image_dual_gpu.py`.
60-block transformer, split 30/30. The split forward bridges
`hidden_states`, `encoder_hidden_states`, `temb`, the `(img_freqs,
txt_freqs)` RoPE tuple, the joint attention mask, and `modulate_index`
at the boundary. Two notable bugs surfaced + fixed:

  - The recreated split forward was originally written against the
    mac-side diffusers `QwenImageTransformer2DModel.forward`, which
    lacks the deprecated `txt_seq_lens` arg present on the box.
    Recreated against the box's copy so the signature + body match.
  - Gradient-checkpoint dict aliasing — `block_attention_kwargs` is a
    dict captured by reference per block; mutating its
    `"attention_mask"` entry at the boundary corrupted the cuda:0
    blocks' backward recompute. Fix: build a *separate* cuda:1 dict at
    the boundary; the cuda:0 dict is read-only post-distribute.

Four hardcoded `device_torch` text-encoder sites in `qwen_image.py` are
routed to `te_device_torch` so the Qwen2.5-VL TE lands on CPU under
dual-GPU.

### Chroma1-HD

Packaged as `ChromaDualGPUMixin` in
`extensions_built_in/diffusion_models/chroma/chroma_dual_gpu.py`. Chroma
is FLUX-shaped (19 double + 38 single blocks + final_layer) on the
*vendored* `Chroma` module under `chroma/src/model.py` — NOT a diffusers
class. The trainer imports the in-tree `src/model.py` via
`from .src.model import Chroma`, so that is the authoritative
split-forward source.

Chroma's `distilled_guidance_layer` runs under `no_grad` on cuda:0 once
before the block loops, producing `mod_vectors` distributed into a dict
keyed by block name (`single_blocks.{i}.modulation.lin`,
`double_blocks.{i}.img_mod.lin` / `.txt_mod.lin`,
`final_layer.adaLN_modulation.1`). At the PCIe boundary the forward
builds a *separate* cuda:1-resident dict of `ModulationOut` dataclasses
for the cuda:1 single blocks plus the final-layer modulation tensors —
the Qwen-Image gradient-checkpoint dict-aliasing lesson generalized to
this dict shape. The `mod_index` buffer (registered non-persistent on
the parent module) gets an explicit `.to(d0)` since per-submodule `.to()`
doesn't reach module-level buffers. Chroma's CLIP slot is a `FakeCLIP`
stub; only T5 is real and routes to `te_device_torch`.

### FLUX.1-Kontext

Packaged as `FluxKontextDualGPUMixin` in
`extensions_built_in/diffusion_models/flux_kontext/flux_kontext_dual_gpu.py`.
Targets the diffusers `FluxTransformer2DModel` (distinct from
ai-toolkit's vendored Flux2 transformer — different module attr names:
`transformer_blocks` / `single_transformer_blocks` / `proj_out` instead
of `double_blocks` / `single_blocks` / `final_layer`). Split places
`x_embedder` / `context_embedder` / `time_text_embed` / `pos_embed` +
all 19 `transformer_blocks` + `single_transformer_blocks[:19]` on
cuda:0; `single_transformer_blocks[19:]` + `norm_out` + `proj_out` on
cuda:1. Boundary bridges `hidden_states`, `encoder_hidden_states` (both
block loops return BOTH after the recent diffusers refactor), `temb`,
the `image_rotary_emb` (cos, sin) tuple, and any tensor entries in
`joint_attention_kwargs` (built as a NEW dict so the cuda:0 view stays
untouched). Controlnet residual branches preserved verbatim from the
upstream forward for parity.

Bug surfaced + fixed: `get_prompt_embeds` force-moved CLIP-L to
`self.device_torch` (cuda:0) while T5 stayed on cpu under
`FLUX_KONTEXT_TE_DEVICE=cpu`. The shared
`train_tools.encode_prompts_flux` helper then reads
`device = text_encoder[0].device` (CLIP-L → cuda:0) and piped cuda:0
`input_ids` to the cpu-resident T5 — token_embedding crashed
"index on cuda:0, weight on cpu". Fix: route both TEs through
`te_device_torch` in `get_prompt_embeds`, then move the resulting
`prompt_embeds + pooled_prompt_embeds` back to `device_torch` for
downstream pipeline consumption.

### HiDream-I1

Packaged as `HiDreamDualGPUMixin` in
`extensions_built_in/diffusion_models/hidream/hidream_dual_gpu.py`.
Targets the *vendored* `HiDreamImageTransformer2DModel` under
`hidream/src/models/transformers/transformer_hidream_image.py` — NOT
the diffusers-package class, which has a substantially different
forward (~1024 lines of divergence). The hidream extension imports from
the vendored copy via `from .src.models.transformers.transformer_hidream_image
import HiDreamImageTransformer2DModel`, so that is the authoritative
split-forward source.

Split places `x_embedder` / `t_embedder` / `p_embedder` / `pe_embedder` /
`caption_projection` + ALL `double_stream_blocks` (16) +
`single_stream_blocks[:16]` on cuda:0; `single_stream_blocks[16:]` +
`final_layer` on cuda:1. HiDream's `_no_split_modules` attribute governs
accelerate device-map sharding (it forbids splitting *within* a block),
and our split is between blocks, so it's informational only. MoE
(`MoEGate` / `MOEFeedForwardSwiGLU`) lives inside the blocks and
distributes with them transparently.

Bug surfaced + fixed: `get_prompt_embeds` passed `device=self.device_torch`
to the pipeline's `_encode_prompt`, which routed `input_ids` to cuda:0
while the four TEs lived on cpu under `HIDREAM_TE_DEVICE=cpu`. CLIP's
token_embedding crashed "index on cuda:0, weight on cpu". Fix: route
the encode through `te_device_torch`, then recursively move the
returned shapes (HiDream's `_encode_prompt` returns `prompt_embeds` as a
*list* of per-encoder tensors plus a single `pooled_prompt_embeds`
tensor) back to `device_torch` via a `_to_device` helper that handles
both list and scalar-tensor outputs. Te_device_torch is load-bearing
for the ~30 GB Llama-3.1-8B encoder — pinning it to CPU keeps cuda:0
free for the distributed transformer + activations.

### Z-Image

Packaged as `ZImageDualGPUMixin` in
`extensions_built_in/diffusion_models/z_image/z_image_dual_gpu.py`.
Targets the diffusers `ZImageTransformer2DModel`, a novel architecture
distinct from the FLUX-family shape every prior port used:

  - `all_x_embedder` / `all_final_layer`: `nn.ModuleDict` keyed by
    `"{patch_size}-{f_patch_size}"`
  - `noise_refiner` / `context_refiner` / optional `siglip_refiner`:
    `nn.ModuleList` (2 blocks each)
  - `x_pad_token` / `cap_pad_token` / optional `siglip_pad_token`:
    *module-level `nn.Parameter` attributes* — don't follow per-
    submodule `.to()` calls; require explicit `.data = .data.to(d0,
    dtype=dtype)` moves
  - `layers`: `nn.ModuleList` of 30 main blocks (the split target)
  - `rope_embedder`: a plain Python class (NOT `nn.Module` — auto-
    follows input device on each call)

Split places every pre-main-loop module (the four embedders, both
refiners, the pad-token Parameters) plus `layers[:15]` on cuda:0;
`layers[15:]` + `all_final_layer` on cuda:1.

Z-Image's forward takes list-style inputs (`x: list[Tensor]`,
`cap_feats: list[Tensor]`) rather than packed tensors. The split
forward runs through `patchify_and_embed` → x embed/refine → cap
embed/refine → optional siglip embed/refine → `_build_unified_sequence`
on cuda:0 before the main `self.layers` loop. At the PCIe boundary
inside the main loop it bridges `unified`, `unified_mask`,
`unified_freqs`, `adaln_input` (or `t_noisy` / `t_clean` in Omni mode),
and `unified_noise_tensor` to cuda:1. After `all_final_layer` +
`unpatchify` the `list[Tensor]` output is moved back to cuda:0
element-wise. `get_prompt_embeds` routes through `te_device_torch` so
the Qwen3 encoder stays on CPU through caching.

## Validation

All validated end-to-end on 2× RTX 5090.

**FLUX.2** — character LoRA, FLUX.2-dev + Turbo, rank 16, 512², batch 1,
gradient_checkpointing, adamw8bit, 1500 steps:

| Setup | Step rate | Wall clock (400 steps) |
|---|---|---|
| Single RTX 5090 (current default) | 14.4 → 277 s/it (WDDM-thrash) | 90 min → 30+ hours |
| Dual RTX 5090 (this PR) | 2.85 s/it sustained | ~19 min |

Per-GPU footprint: GPU 0 ~21 GB, GPU 1 ~12 GB. Both cards alternate at
99% SM, single-microbatch pipeline-parallel. Gradient-checkpointing
recompute crosses the device boundary cleanly (non-reentrant), and
`clip_grad_norm_` is compatible with the split.

**FLUX.2-klein** — the klein variants share the architecture and inherit
`Flux2DualGPUMixin` through `Flux2KleinModel`. Both validated, 100-step
smoke, sumi dataset, rank 16, fp8, 512²:

| Variant | Block split | Step rate |
|---|---|---|
| FLUX.2-klein-4B | 10/10 single-blocks | 2.33 it/s |
| FLUX.2-klein-9B | 12/12 single-blocks | 1.21 it/s |

**Wan 2.2** — sumi dataset, rank 16, fp8 weight-only, 512²:

| Variant | Detail | Step rate |
|---|---|---|
| Wan 2.2 TI2V-5B | 50 steps | 1.86 it/s |
| Wan 2.2 T2V-A14B | dual-DiT, `switch_boundary_every=10` (both experts exercised), both transformers distributed across cuda:0/cuda:1 | 1.09 s/it |

**LTX-2** — sumi dataset, rank 16, `--fp8_base`, 512²:

| Variant | Detail | Step rate |
|---|---|---|
| LTX-2 | 48 blocks split 24/24, Gemma3 12B TE on CPU, 20 steps | 2.78 s/it |

**Qwen-Image** — sumi dataset, rank 16, `--fp8_base`, 512²:

| Variant | Detail | Step rate |
|---|---|---|
| Qwen-Image | 60 blocks split 30/30, Qwen2.5-VL TE on CPU, 20 steps | 1.56 s/it |

**Chroma1-HD / FLUX.1-Kontext / HiDream-I1 / Z-Image** — sumi-512 dataset,
rank 16, fp8, 512², 20-step smoke, dual-GPU + TE on CPU:

| Variant | Detail | Step rate | Wall |
|---|---|---|---|
| Chroma1-HD | 19+38 blocks, split 19/19 single, T5 TE on CPU | 1.09 it/s | 4m49s |
| FLUX.1-Kontext | 19+38 blocks (diffusers `FluxTransformer2DModel`), split 19/19 single, CLIP+T5 on CPU | 1.05 s/it | 3m10s |
| HiDream-I1 | 16+32 blocks (vendored transformer), split 16/16 single, 4 TEs on CPU (incl. ~30 GB Llama-3.1-8B) | 2.1 s/it | 5m49s |
| Z-Image | 30 main `layers`, split 15/15, Qwen3 TE on CPU | (fast) | 0m59s |

## New environment variables

- `<ARCH>_DUAL_GPU=true` — enable the dual-GPU path (one per arch:
  FLUX2, WAN, LTX2, QWEN_IMAGE, CHROMA, FLUX_KONTEXT, HIDREAM, Z_IMAGE)
- `<ARCH>_TE_DEVICE=cpu` — pin text encoder to a device (independently
  useful)
- `<ARCH>_DUAL_GPU_SPLIT_AT` — override the block-list split index
  (default: midpoint of whichever block list is the split target)
- `FLUX2_MISTRAL_PATH=/local/path` — skip HF download for Mistral

## Limitations

fp8 weight-only training; pure-bf16 would need a third 32 GB card or
layer offloading. Single-microbatch pipeline-parallel; no gpipe / 1F1B
yet. EMA (`ema_config`) and `low_vram` transformer offloading do not
apply with the split active. Wan 2.2 A14B was validated with both
experts exercised via `switch_boundary_every`; the explicit
`--dit` + `--dit_high_noise` dual-checkpoint path is exercised through
the same `DualWanTransformer3DModel` wrapper. Z-Image's
`layer_offloading` config option is gated off when
`Z_IMAGE_DUAL_GPU=true` (both are competing memory schemes — picking
dual-GPU disables the alternative paths cleanly).

## Companion repo

Standalone version + writeup + diagnostic patches, plus the same
dual-GPU split ported to musubi-tuner, DiffSynth-Studio, and OneTrainer:
https://github.com/genno-whittlery/flux2-dual-gpu-lora
