### PR TITLE
fix(flux2-klein-base): clamp transformer residual stream to bf16-safe range

### DIFF
--- a/extensions_built_in/diffusion_models/flux2/src/model.py
+++ b/extensions_built_in/diffusion_models/flux2/src/model.py
@@ -334,7 +334,8 @@ class SingleStreamBlock(nn.Module):
 
         # compute activation in mlp stream, cat again and run second linear layer
         output = self.linear2(torch.cat((attn, self.mlp_act(mlp)), 2))
-        return x + mod_gate * output
+        # FLUX.2-klein-base fix: clamp residual stream (see DoubleStreamBlock)
+        return (x + mod_gate * output).clamp(-30000.0, 30000.0)
 
 
 class DoubleStreamBlock(nn.Module):
@@ -429,17 +430,18 @@ class DoubleStreamBlock(nn.Module):
         attn = attention(q, k, v, pe)
         txt_attn, img_attn = attn[:, : txt_q.shape[2]], attn[:, txt_q.shape[2] :]
 
-        # calculate the img blocks
-        img = img + img_mod1_gate * self.img_attn.proj(img_attn)
-        img = img + img_mod2_gate * self.img_mlp(
+        # FLUX.2-klein-base fix: clamp residual stream to bf16-safe range.
+        # Without this, txt overflows to +Inf around the 8th block.
+        _CLAMP = 30000.0
+        img = (img + img_mod1_gate * self.img_attn.proj(img_attn)).clamp(-_CLAMP, _CLAMP)
+        img = (img + img_mod2_gate * self.img_mlp(
             (1 + img_mod2_scale) * (self.img_norm2(img)) + img_mod2_shift
-        )
+        )).clamp(-_CLAMP, _CLAMP)
 
-        # calculate the txt blocks
-        txt = txt + txt_mod1_gate * self.txt_attn.proj(txt_attn)
-        txt = txt + txt_mod2_gate * self.txt_mlp(
+        txt = (txt + txt_mod1_gate * self.txt_attn.proj(txt_attn)).clamp(-_CLAMP, _CLAMP)
+        txt = (txt + txt_mod2_gate * self.txt_mlp(
             (1 + txt_mod2_scale) * (self.txt_norm2(txt)) + txt_mod2_shift
-        )
+        )).clamp(-_CLAMP, _CLAMP)
         return img, txt
 
 


### PR DESCRIPTION
## Summary

When training or sampling a LoRA against **FLUX.2-klein-base-9B** (`arch: flux2_klein_9b`, `is_guidance_distilled: False`) with `dtype: bf16` and the proper trained weights from BFL, the txt residual stream overflows to `+Inf` around the 8th `DoubleStreamBlock`. The rest of the forward (24 `SingleStreamBlock`s + `final_layer`) then produces `NaN`. Sampling outputs solid-black images (with `RuntimeWarning: invalid value encountered in cast` from `diffusers.image_processor`) and LoRA training silently learns a degenerate gradient — the loss looks healthy (≈1.5) only because near-zero predictions against unit-variance targets coincidentally land in that range.

This PR adds a minimal residual-stream clamp inside the FLUX.2 transformer so the model stays usable in bf16 on a single 4090.

## Reproduction

- Model: `black-forest-labs/FLUX.2-klein-base-9B` (BFL single-file safetensors, 18 GB bf16)
- Hardware: RTX 4090 (48 GB), driver 595.58, CUDA 12.8, PyTorch 2.10.0+cu128
- ai-toolkit: current `main` (e03c6e4)
- Job: `arch: flux2_klein_9b`, `quantize: false`, `quantize_te: false`, `low_vram: false`, `batch_size: 1`, `dtype: bf16`
- Sample: `sampler: flowmatch`, `width=height=1024`, `sample_steps: 30`, `guidance_scale: 4` (also reproduced via the `to_folder` GenerateProcess job, no LoRA)

Result without the fix: solid black image; instrumentation shows `txt inf=1` after `double_block[7]`, then all subsequent `pred` and `latents` are `NaN`.

## Instrumentation (per-block stats, BFL official weights)

```
[in] img std=0.514 max=1.32e+01 | txt std=1.929 max=3.78e+02 | vec std=0.304
[db0] img std=3.20 max=326    nan=0 inf=0 | txt nan=0 inf=0
[db1] img std=3.74 max=304    nan=0 inf=0 | txt nan=0 inf=0
[db2] img std=3.80 max=661    nan=0 inf=0 | txt nan=0 inf=0
[db3] img std=3.50 max=1290   nan=0 inf=0 | txt nan=0 inf=0
[db4] img std=5.08 max=3400   nan=0 inf=0 | txt nan=0 inf=0
[db5] img std=7.43 max=4800   nan=0 inf=0 | txt nan=0 inf=0
[db6] img std=8.20 max=5170   nan=0 inf=0 | txt nan=0 inf=0
[db7] img std=15.98 max=4340  nan=0 inf=0 | txt nan=0 inf=1    <-- +Inf appears
[sb0..sb23, final]: all NaN
```

The model architecture itself is fine: BFL's reference `diffusers.Flux2KleinPipeline` (which the model card recommends for bf16 inference) runs cleanly with the same weights on the same hardware. The issue is specific to a handful of outlier positions in the residual stream that grow past bf16's max (~65504) over the depth of the network in this re-implementation.

## Fix

Clamp the residual stream to a conservative bf16-safe range (±30000) after each gated residual add:
- `DoubleStreamBlock`: 4 sites (img attn, img mlp, txt attn, txt mlp)
- `SingleStreamBlock`: 1 site (gated mlp+attn output)

This eliminates the `+Inf` cascade without materially changing the result for in-range values. **30000** leaves enough headroom for the following `(1 + scale)` modulation in the next block.

After the fix, a `to_folder` / training-time sample produces a clean, prompt-aligned image visually comparable to ComfyUI's official klein workflow on the same prompt+seed.

## What this PR does NOT do

- Does not touch `pipeline.py`, `flux2_model.py`, `flux2_klein_model.py`, `sampling.py`, or the autoencoder.
- Does not introduce any new dtype conversions, autocast wrappers, or optional flags.
- Does not change the model's mathematical behavior for in-range activations; it's purely a safety clamp on outliers that would otherwise corrupt the rest of the forward pass.

## Notes

- Tested with `arch: flux2_klein_9b` (non-distilled). The clamp is also applied to `flux2_klein_4b` and `flux2_dev` since they share `Flux2.forward` / `DoubleStreamBlock` / `SingleStreamBlock`; I did not test those configs and a maintainer who can run them might want to confirm the clamp doesn't degrade quality there. For klein-9b base it's a clear quality improvement (clean image vs all-black NaN).
- Related closed issue with the same symptom but no fix: #700 ("flux.2 klein model training effect is poor").
- Happy to add an env-controlled opt-out (e.g. `FLUX2_RESIDUAL_CLAMP`) if a maintainer prefers to keep the original behavior available; the current patch hardcodes the clamp on.
