### PR TITLE
fix(flux2-klein): support community Qwen3 text encoders with missing chat_template

### DIFF
--- a/extensions_built_in/diffusion_models/flux2/flux2_klein_model.py
+++ b/extensions_built_in/diffusion_models/flux2/flux2_klein_model.py
@@ -1,4 +1,4 @@
-from .flux2_model import Flux2Model
+from .flux2_model import Flux2Model, HF_TOKEN
 from transformers import Qwen3ForCausalLM, Qwen2Tokenizer
 from optimum.quanto import freeze
 from toolkit.util.quantize import quantize, get_qtype
@@ -33,16 +33,22 @@ class Flux2KleinModel(Flux2Model):
         )
         # use the new format on this new model by default
         self.use_old_lokr_format = False
+        # Allow overriding the default Qwen3 checkpoint via model config (e.g. for
+        # community fine-tunes or gated HF repos). te_name_or_path is the canonical
+        # ModelConfig field; if set it takes precedence over the class-level default.
+        if model_config.te_name_or_path:
+            self.flux2_klein_te_path = model_config.te_name_or_path
 
     def load_te(self):
         if self.flux2_klein_te_path is None:
             raise ValueError("flux2_klein_te_path must be set for Flux2KleinModel")
         dtype = self.torch_dtype
-        self.print_and_status_update("Loading Qwen3")
+        self.print_and_status_update(f"Loading Qwen3 ({self.flux2_klein_te_path})")
 
         text_encoder: Qwen3ForCausalLM = Qwen3ForCausalLM.from_pretrained(
             self.flux2_klein_te_path,
             torch_dtype=dtype,
+            token=HF_TOKEN,
         )
         if self.model_config.quantize_te:
             self.print_and_status_update("Quantizing Qwen3")
@@ -63,8 +69,30 @@ class Flux2KleinModel(Flux2Model):
                 offload_percent=self.model_config.layer_offloading_text_encoder_percent,
             )
 
-        tokenizer = Qwen2Tokenizer.from_pretrained(self.flux2_klein_te_path)
+        # Some community fine-tunes (abliterated, merged, etc.) strip chat_template
+        # from tokenizer_config.json. The transformers Jinja renderer then falls back
+        # to a generic template that calls .startswith() on a bool and crashes at
+        # inference time. Detect the missing template early and fall back to loading
+        # the tokenizer from the canonical Qwen3 class default, which is always complete.
+        # The model weights loaded above are unaffected.
+        tokenizer = Qwen2Tokenizer.from_pretrained(
+            self.flux2_klein_te_path, token=HF_TOKEN
+        )
+        if not getattr(tokenizer, "chat_template", None):
+            fallback_path = self.__class__.flux2_klein_te_path
+            self.print_and_status_update(
+                f"Tokenizer at '{self.flux2_klein_te_path}' has no chat_template; "
+                f"falling back to '{fallback_path}' for tokenizer"
+            )
+            tokenizer = Qwen2Tokenizer.from_pretrained(fallback_path, token=HF_TOKEN)
         return text_encoder, tokenizer
+
+    def get_prompt_embeds(self, prompt, **kwargs):
+        # Guard against None or non-string values (e.g. an empty negative prompt
+        # passed as False) that cause the Qwen3 chat template to crash.
+        if not isinstance(prompt, str):
+            prompt = "" if not prompt else str(prompt)
+        return super().get_prompt_embeds(prompt, **kwargs)
 
 
 class Flux2Klein4BModel(Flux2KleinModel):


### PR DESCRIPTION
## Problem

When using community fine-tuned or abliterated Qwen3 checkpoints (e.g. `huihui-ai/Huihui-Qwen3-8B-abliterated-v2`) as the text encoder for Flux 2 Klein training, two crashes occur:

1. **Missing `chat_template`** - Many community Qwen3 forks strip `chat_template` from `tokenizer_config.json`. The `transformers` Jinja renderer falls back to a generic template that calls `.startswith()` on a `bool`, raising `AttributeError` at inference time.
2. **Non-string prompt** - Passing `neg: false` (or any falsy non-string value) as a negative prompt crashes the Qwen3 chat template renderer.

Additionally, the model and tokenizer loads had no `token=` argument, so gated HF repos requiring `HF_TOKEN` would fail with an auth error. There was also no way to specify a custom TE checkpoint via job config without subclassing.

## Changes

**`extensions_built_in/diffusion_models/flux2/flux2_klein_model.py`**

- **`te_name_or_path` support** - `__init__` now reads the existing `ModelConfig.te_name_or_path` field and applies it as `flux2_klein_te_path`, so users can specify any Qwen3-compatible checkpoint in their training config without subclassing.
- **`HF_TOKEN` passthrough** - both `from_pretrained` calls (model and tokenizer) now pass `token=HF_TOKEN`, consistent with the rest of the Flux 2 loader.
- **`chat_template` fallback** - after loading the tokenizer from the requested path, checks for a missing `chat_template` and falls back to the canonical class-default checkpoint (e.g. `Qwen/Qwen3-8B`) for the tokenizer only. Model weights from the custom path are unaffected.
- **`get_prompt_embeds` None guard** - coerces `None`/falsy/non-string prompts to `""` before they reach the chat template renderer, fixing the `neg: false` crash.

## Usage

To use a community Qwen3 TE, add `te_name_or_path` to the `model` block in your training config:

```yaml
model:
  name_or_path: "path/to/flux-2-klein-base-9b.safetensors"
  arch: flux2_klein_9b
  te_name_or_path: "huihui-ai/Huihui-Qwen3-8B-abliterated-v2"
```

No code changes required - the existing `ModelConfig.te_name_or_path` field is used directly.

## Notes

- All changes are backward-compatible. If `te_name_or_path` is not set, behaviour is identical to before.
- The tokenizer fallback correctly uses the class-level default (e.g. `Qwen/Qwen3-8B`) even when `te_name_or_path` points to a custom repo.