### PR TITLE
Revise SECURITY.md for clarity on support and reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest stable version of ai-toolkit receives security updates. Make sure you are running the most recent release.
+
+## Reporting a Vulnerability
+
+Please do not open public issues for security problems. Instead, use GitHub's "Report a vulnerability" feature in the Security tab of this repository. We will review and respond as soon as possible.
+
+## Security Updates
+
+If we fix a vulnerability, we will announce it in the release notes. Keep your installation up to date to receive the latest fixes.


### PR DESCRIPTION
## Description
Update SECURITY.md to clarify supported versions, vulnerability reporting expectations, and the preferred private disclosure process.

This also asks maintainers to enable GitHub’s “Private vulnerability reporting” / “Report a vulnerability” option in the repository settings, so researchers can submit security reports privately through GitHub Security Advisories instead of opening public issues.
