### PR TITLE
Fixed macstats loading on Mac OS in the UI

### DIFF
--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -10,10 +10,10 @@ const nextConfig: NextConfig = {
   env: {
     NEXT_PUBLIC_APP_VERSION: appVersion,
   },
-  serverExternalPackages: ['macstats', 'osx-temperature-sensor'],
+  serverExternalPackages: ['osx-temperature-sensor'],
   webpack: (config, { isServer }) => {
     if (isServer) {
-      config.externals.push('osx-temperature-sensor', 'macstats');
+      config.externals.push('osx-temperature-sensor');
     }
     return config;
   },

--- a/ui/src/app/api/cpu/route.ts
+++ b/ui/src/app/api/cpu/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import si from 'systeminformation';
-import { createRequire } from 'module';
 import os from 'os';
 import { CpuInfo } from '@/types';
+import { getMacstats } from '@/server/macstats';
 
 const isMac = os.platform() === 'darwin';
 
@@ -13,10 +13,17 @@ export async function GET() {
 
     if (isMac) {
       try {
-        const nativeRequire = createRequire(import.meta.url);
-        const ms = nativeRequire('macstats') as any;
-        const ramData = ms.getRAMUsageSync();
-        const cpuData = ms.getCpuDataSync();
+        const ms = await getMacstats();
+        if (!ms) {
+          throw new Error('macstats unavailable');
+        }
+
+        const ramData = ms.getRAMUsageSync?.();
+        const cpuData = ms.getCpuDataSync?.();
+
+        if (!ramData || !cpuData) {
+          throw new Error('macstats missing CPU or RAM readers');
+        }
 
         cpuInfo = {
           name: `${cpuInfoRaw.manufacturer} ${cpuInfoRaw.brand}`,

--- a/ui/src/app/api/gpu/route.ts
+++ b/ui/src/app/api/gpu/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import { exec, execSync } from 'child_process';
 import { promisify } from 'util';
-import { createRequire } from 'module';
 import os from 'os';
+import { getMacstats } from '@/server/macstats';
 
 const execAsync = promisify(exec);
 
@@ -47,41 +47,42 @@ async function getMacGpuInfo(): Promise<MacGpuResult | null> {
     let memTotal = memoryTotal;
 
     try {
-      // Use createRequire to hide from webpack static analysis so it doesn't fail on non-mac platforms
-      const nativeRequire = createRequire(import.meta.url);
-      const ms = nativeRequire('macstats') as any;
-
-      try {
-        const gpuData = ms.getGpuDataSync();
-        temperature = gpuData.temperature || 0;
-        gpuLoad = gpuData.usage || 0;
-      } catch {
-        // ignore
-      }
-
-      try {
-        const fanData = ms.getFanDataSync();
-        const fanKeys = Object.keys(fanData);
-        if (fanKeys.length > 0) {
-          fanSpeed = fanData[fanKeys[0]].rpm || 0;
+      const ms = await getMacstats();
+      if (ms) {
+        try {
+          const gpuData = ms.getGpuDataSync?.();
+          temperature = gpuData?.temperature || 0;
+          gpuLoad = gpuData?.usage || 0;
+        } catch {
+          // ignore
         }
-      } catch {
-        // ignore
-      }
 
-      try {
-        const powerData = ms.getPowerDataSync();
-        powerDraw = powerData.gpu || 0;
-      } catch {
-        // ignore
-      }
+        try {
+          const fanData = ms.getFanDataSync?.();
+          const fanKeys = fanData ? Object.keys(fanData) : [];
+          if (fanData && fanKeys.length > 0) {
+            fanSpeed = fanData[fanKeys[0]].rpm || 0;
+          }
+        } catch {
+          // ignore
+        }
 
-      try {
-        const ramData = ms.getRAMUsageSync();
-        memUsed = ramData.used / (1024 * 1024);
-        memTotal = ramData.total / (1024 * 1024);
-      } catch {
-        // ignore
+        try {
+          const powerData = ms.getPowerDataSync?.();
+          powerDraw = powerData?.gpu || 0;
+        } catch {
+          // ignore
+        }
+
+        try {
+          const ramData = ms.getRAMUsageSync?.();
+          if (ramData) {
+            memUsed = ramData.used / (1024 * 1024);
+            memTotal = ramData.total / (1024 * 1024);
+          }
+        } catch {
+          // ignore
+        }
       }
     } catch (error) {
       console.warn('macstats not available:', error);
@@ -248,4 +249,3 @@ async function getGpuStats(isWindows: boolean) {
 
   return gpus;
 }
-

--- a/ui/src/server/macstats.ts
+++ b/ui/src/server/macstats.ts
@@ -1,0 +1,28 @@
+type MacstatsModule = {
+  getGpuDataSync?: () => { temperature?: number; usage?: number };
+  getFanDataSync?: () => Record<string, { rpm?: number }>;
+  getPowerDataSync?: () => { gpu?: number };
+  getRAMUsageSync?: () => { used: number; total: number; free: number };
+  getCpuDataSync?: () => { temperature?: number };
+};
+
+let macstatsPromise: Promise<MacstatsModule | null> | undefined;
+
+export async function getMacstats(): Promise<MacstatsModule | null> {
+  if (!macstatsPromise) {
+    macstatsPromise = (async () => {
+      try {
+        const mod = await import('macstats');
+        return (mod.default ?? mod) as MacstatsModule;
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code === 'MODULE_NOT_FOUND' || code === 'ERR_MODULE_NOT_FOUND') {
+          return null;
+        }
+        throw error;
+      }
+    })();
+  }
+
+  return macstatsPromise;
+}


### PR DESCRIPTION
## Description

Fixes an issue on Mac OS where the `macstats` module could fail to load, causing the GPU monitor panel to show all zero values.

The issue was caused by loading `macstats` through `createRequire()` in the Next.js server routes. During the Next.js build, this created a broken runtime module resolution path for the ESM module, so the built route could still throw `Cannot find module 'macstats'` even when `macstats` was installed correctly.

This changes the Mac CPU and GPU API routes to load `macstats` through a shared dynamic import helper instead.

Closes #790.