### PR TITLE
fix learning rate metric rounding to zero on graph legend

### DIFF
--- a/ui/src/components/JobLossGraph.tsx
+++ b/ui/src/components/JobLossGraph.tsx
@@ -312,6 +312,7 @@ export default function JobLossGraph({ job }: Props) {
         width: 2,
         spanGaps: false,
         points: { show: false },
+        value: (_u, value) => formatNum(value),
       });
       colArrays.push(smooth);
 
@@ -324,6 +325,7 @@ export default function JobLossGraph({ job }: Props) {
           width: 2.5,
           spanGaps: false,
           points: { show: false },
+          value: (_u, value) => formatNum(value),
         });
         colArrays.push(fullSmooth);
       }


### PR DESCRIPTION
The default uPlot legend formatter rounds small values to zero. This makes it use our `formatNum` func to format them.