### PR TITLE
Make the final checkpoint follow the step numbering convention

### DIFF
--- a/jobs/process/BaseSDTrainProcess.py
+++ b/jobs/process/BaseSDTrainProcess.py
@@ -2592,7 +2592,7 @@ class BaseSDTrainProcess(BaseTrainProcess):
             self.logger.commit(step=self.step_num)
         print_acc("")
         if self.accelerator.is_main_process:
-            self.save()
+            self.save(self.step_num)
             self.logger.finish()
         self.accelerator.end_training()
 


### PR DESCRIPTION
Many people have requested this in Discord here https://discord.com/channels/1144033039786188891/1490993758496620564/1490993758496620564 . This makes the checkpoints consistent when resuming from a finished run after increasing max steps.
