### PR TITLE
Fix macstats native addon load in GPU API route (Apple Silicon)

### DIFF
--- a/ui/src/app/api/gpu/route.ts
+++ b/ui/src/app/api/gpu/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server';
 import { exec, execSync } from 'child_process';
 import { promisify } from 'util';
-import { createRequire } from 'module';
 import os from 'os';
 
 const execAsync = promisify(exec);
@@ -47,8 +46,12 @@ async function getMacGpuInfo(): Promise<MacGpuResult | null> {
     let memTotal = memoryTotal;
 
     try {
-      // Use createRequire to hide from webpack static analysis so it doesn't fail on non-mac platforms
-      const nativeRequire = createRequire(import.meta.url);
+      // Load the native macstats addon at runtime. We must reach createRequire via
+      // process.getBuiltinModule('module') rather than a static `import { createRequire } from 'module'`:
+      // the Next server bundler strips that import (replacing it with `(void 0)`), and import.meta.url
+      // resolves to an internal bundle path. getBuiltinModule is a runtime call the bundler can't touch,
+      // and resolving from process.cwd() (the ui/ folder) finds node_modules/macstats reliably.
+      const nativeRequire = process.getBuiltinModule('module').createRequire(process.cwd() + '/package.json');
       const ms = nativeRequire('macstats') as any;
 
       try {


### PR DESCRIPTION
## Problem

On Apple Silicon, the GPU monitor in the UI always shows **0** for temperature, utilization, power, and fan speed.

The `/api/gpu` route loads the native `macstats` addon with:

```ts
import { createRequire } from 'module';
...
const nativeRequire = createRequire(import.meta.url);
const ms = nativeRequire('macstats');
```

When `next build` bundles the server route, it **strips the `createRequire` import** (the minified output becomes `let a=(void 0)("macstats")`) and rewrites `import.meta.url` to an internal bundle path. So the require throws (`TypeError: (void 0) is not a function`, or `MODULE_NOT_FOUND`), the `catch` swallows it with `console.warn('macstats not available', ...)`, and every stat falls back to 0.

The addon itself is installed and working — `require('macstats')` succeeds outside the bundle.

## Fix

Reach `createRequire` through `process.getBuiltinModule('module')` — a runtime call the bundler cannot strip (Node ≥ 22.3; the UI ships Node 23) — and resolve from `process.cwd()` (the `ui/` folder, which is the server's working directory) so `node_modules/macstats` is found reliably:

```ts
const nativeRequire = process.getBuiltinModule('module').createRequire(process.cwd() + '/package.json');
const ms = nativeRequire('macstats');
```

## Verification

On an M3 Max, `/api/gpu` before the fix returned `temperature: 0, utilization.gpu: 0, power.draw: 0` plus a `macstats not available` warning on every request. After the fix it returns live values during a training run:

```json
{"temperature":72,"utilization":{"gpu":100,"memory":79},"power":{"draw":20.49}}
```

with zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)