### PR TITLE
Support transformers >=5.6 (flattened CLIPTextModel) and unpin

### DIFF
--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -2,7 +2,7 @@ torchao==0.10.0
 safetensors
 git+https://github.com/huggingface/diffusers.git@dc8d9032171c83741fd37ed2b12bc9d8274464f3
 #pip install git+https://github.com/huggingface/diffusers.git@refs/pull/13432/head
-transformers==5.5.3
+transformers>=5.6,<6
 lycoris-lora==1.8.3
 flatten_json
 pyyaml

--- a/toolkit/models/te_aug_adapter.py
+++ b/toolkit/models/te_aug_adapter.py
@@ -195,7 +195,9 @@ class TEAugAdapter(torch.nn.Module):
         text_encoder: CLIPTextModel = sd.text_encoder
         dim = text_encoder.config.hidden_size
 
-        clip_encoder: CLIPEncoder = text_encoder.text_model.encoder
+        # transformers >=5.6 flattened CLIPTextModel (no .text_model wrapper);
+        # CLIPTextModelWithProjection still nests it. getattr handles both.
+        clip_encoder: CLIPEncoder = getattr(text_encoder, "text_model", text_encoder).encoder
         # dim = clip_encoder.layers[-1].self_attn
 
         if hasattr(adapter.vision_encoder.config, 'hidden_sizes'):

--- a/toolkit/stable_diffusion_model.py
+++ b/toolkit/stable_diffusion_model.py
@@ -2921,7 +2921,9 @@ class StableDiffusion:
                     te_has_grad = encoder.layers[0].mlp.gate_proj.weight.requires_grad
                 else:
                     try:
-                        te_has_grad = encoder.text_model.final_layer_norm.weight.requires_grad
+                        # transformers >=5.6 flattened CLIPTextModel (no .text_model wrapper);
+                        # CLIPTextModelWithProjection still nests it. getattr handles both.
+                        te_has_grad = getattr(encoder, "text_model", encoder).final_layer_norm.weight.requires_grad
                     except:
                         te_has_grad = False
                 self.device_state['text_encoder'].append({
@@ -2940,7 +2942,9 @@ class StableDiffusion:
             elif isinstance(self.text_encoder, LlamaModel):
                 te_has_grad = self.text_encoder.layers[0].mlp.gate_proj.weight.requires_grad
             else:
-                te_has_grad = self.text_encoder.text_model.final_layer_norm.weight.requires_grad
+                # transformers >=5.6 flattened CLIPTextModel (no .text_model wrapper).
+                te = self.text_encoder
+                te_has_grad = getattr(te, "text_model", te).final_layer_norm.weight.requires_grad
 
             self.device_state['text_encoder'] = {
                 'training': self.text_encoder.training,


### PR DESCRIPTION
Unpins `transformers==5.5.3` → `>=5.6,<6`.

transformers 5.6 (huggingface/transformers#44431) flattened `CLIPTextModel`, removing the `.text_model` wrapper. Loading is unaffected (already via `from_pretrained`), but three sites reached into `.text_model.*` and break on a flat `CLIPTextModel`:
- `toolkit/stable_diffusion_model.py` (two `final_layer_norm` accesses)
- `toolkit/models/te_aug_adapter.py` (`.encoder` access)

Fix uses `getattr(te, "text_model", te)`, correct on old (nested), new (flat), and `CLIPTextModelWithProjection` (still nested).

Verified: files compile; shim returns the right inner module for all three shapes.

**Residual checks before un-drafting** (not CLIP-related): LTX2 Gemma3 `strict=True` manual `load_state_dict` (ltx2.py) and the `huggingface_hub`/diffusers transitive pins under 5.6. Draft — AI-assisted, pending human validation.