### PR TITLE
Show dataset item counts in training config

### DIFF
--- a/ui/src/app/api/datasets/countItems/route.ts
+++ b/ui/src/app/api/datasets/countItems/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+import { countDatasetItemsRecursively, isPathInRoot } from '@/server/datasets';
+import { getDatasetsRoot } from '@/server/settings';
+
+type DatasetItemCounts = Record<string, number | null>;
+
+export async function POST(request: Request) {
+  try {
+    const { datasetPaths } = await request.json();
+
+    if (!Array.isArray(datasetPaths)) {
+      return NextResponse.json({ error: 'datasetPaths must be an array' }, { status: 400 });
+    }
+
+    const datasetsRoot = await getDatasetsRoot();
+    const counts: DatasetItemCounts = {};
+
+    for (const rawDatasetPath of datasetPaths) {
+      if (typeof rawDatasetPath !== 'string' || rawDatasetPath.trim() === '') continue;
+
+      const datasetPath = path.resolve(rawDatasetPath);
+
+      if (!isPathInRoot(datasetPath, datasetsRoot)) {
+        counts[rawDatasetPath] = null;
+        continue;
+      }
+
+      if (!fs.existsSync(datasetPath) || !fs.statSync(datasetPath).isDirectory()) {
+        counts[rawDatasetPath] = null;
+        continue;
+      }
+
+      counts[rawDatasetPath] = countDatasetItemsRecursively(datasetPath);
+    }
+
+    return NextResponse.json({ counts });
+  } catch (error) {
+    console.error('Error counting dataset items:', error);
+    return NextResponse.json({ error: 'Failed to count dataset items' }, { status: 500 });
+  }
+}

--- a/ui/src/app/api/datasets/listImages/route.ts
+++ b/ui/src/app/api/datasets/listImages/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
 import { getDatasetsRoot } from '@/server/settings';
+import { findDatasetItemsRecursively } from '@/server/datasets';
 
 export async function POST(request: Request) {
   const datasetsPath = await getDatasetsRoot();
@@ -15,14 +16,13 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: `Folder '${datasetName}' not found` }, { status: 404 });
     }
 
-    // Find all images recursively
-    const imageFiles = findImagesRecursively(datasetFolder);
+    const datasetItems = findDatasetItemsRecursively(datasetFolder);
 
     // Sort server-side so the client doesn't have to sort large lists
-    imageFiles.sort((a, b) => a.localeCompare(b));
+    datasetItems.sort((a, b) => a.localeCompare(b));
 
-    // Format response
-    const result = imageFiles.map(imgPath => ({
+    // Keep the existing response shape for current dataset browser consumers.
+    const result = datasetItems.map(imgPath => ({
       img_path: imgPath,
     }));
 
@@ -31,35 +31,4 @@ export async function POST(request: Request) {
     console.error('Error finding images:', error);
     return NextResponse.json({ error: 'Failed to process request' }, { status: 500 });
   }
-}
-
-/**
- * Recursively finds all image files in a directory and its subdirectories
- * @param dir Directory to search
- * @returns Array of absolute paths to image files
- */
-function findImagesRecursively(dir: string): string[] {
-  const imageExtensions = ['.png', '.jpg', '.jpeg', '.webp', '.mp4', '.avi', '.mov', '.mkv', '.wmv', '.m4v', '.flv', '.mp3', '.wav', '.flac', '.ogg'];
-  let results: string[] = [];
-
-  // withFileTypes avoids a separate statSync per entry — a big win on large datasets
-  const entries = fs.readdirSync(dir, { withFileTypes: true });
-
-  for (const entry of entries) {
-    const name = entry.name;
-    if (name.startsWith('.')) continue;
-    const itemPath = path.join(dir, name);
-
-    if (entry.isDirectory()) {
-      if (name === '_controls') continue;
-      results = results.concat(findImagesRecursively(itemPath));
-    } else if (entry.isFile()) {
-      const ext = path.extname(name).toLowerCase();
-      if (imageExtensions.includes(ext)) {
-        results.push(itemPath);
-      }
-    }
-  }
-
-  return results;
 }

--- a/ui/src/app/jobs/new/SimpleJob.tsx
+++ b/ui/src/app/jobs/new/SimpleJob.tsx
@@ -32,6 +32,7 @@ import { FlipHorizontal2, FlipVertical2 } from 'lucide-react';
 import { handleModelArchChange } from './utils';
 import { IoFlaskSharp } from 'react-icons/io5';
 import { isMac } from '@/helpers/basic';
+import useDatasetItemCounts from '@/hooks/useDatasetItemCounts';
 
 type Props = {
   jobConfig: JobConfig;
@@ -81,6 +82,10 @@ export default function SimpleJob({
 
   const isVideoModel = !!(modelArch?.group === 'video');
   const isAudioModel = !!(modelArch?.group === 'audio');
+  const datasetPaths = useMemo(() => {
+    return jobConfig.config.process[0].datasets.map(dataset => dataset.folder_path || '');
+  }, [jobConfig.config.process[0].datasets]);
+  const datasetItemCounts = useDatasetItemCounts(datasetPaths);
 
   const taggedSampleArr: Record<string, any>[] | null = useMemo(() => {
     if (!modelArch) return null;
@@ -883,7 +888,13 @@ export default function SimpleJob({
                       <X className="w-4 h-4" />
                     </button>
                   </div>
-                  <h2 className="text-lg font-bold mb-4">Dataset {i + 1}</h2>
+                  <h2 className="text-lg font-bold mb-4">
+                    Dataset {i + 1}
+                    {datasetItemCounts[dataset.folder_path] === undefined ||
+                    datasetItemCounts[dataset.folder_path] === null
+                      ? ''
+                      : ` - ${datasetItemCounts[dataset.folder_path]} items`}
+                  </h2>
                   <div className={datasetStyleClass}>
                     <div>
                       <SelectInput

--- a/ui/src/hooks/useDatasetItemCounts.tsx
+++ b/ui/src/hooks/useDatasetItemCounts.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { apiClient } from '@/utils/api';
+
+type DatasetItemCounts = Record<string, number | null>;
+
+export default function useDatasetItemCounts(datasetPaths: string[]) {
+  const [counts, setCounts] = useState<DatasetItemCounts>({});
+
+  const datasetPathKey = useMemo(() => {
+    return Array.from(new Set(datasetPaths.filter(datasetPath => datasetPath.trim() !== ''))).join('\0');
+  }, [datasetPaths]);
+
+  useEffect(() => {
+    const uniqueDatasetPaths = datasetPathKey === '' ? [] : datasetPathKey.split('\0');
+
+    if (uniqueDatasetPaths.length === 0) {
+      setCounts({});
+      return;
+    }
+
+    let isMounted = true;
+
+    apiClient
+      .post('/api/datasets/countItems', { datasetPaths: uniqueDatasetPaths })
+      .then(res => {
+        if (isMounted) {
+          setCounts(res.data.counts ?? {});
+        }
+      })
+      .catch(error => {
+        if (isMounted) {
+          console.error('Error counting dataset items:', error);
+          setCounts({});
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [datasetPathKey]);
+
+  return counts;
+}

--- a/ui/src/server/datasets.ts
+++ b/ui/src/server/datasets.ts
@@ -1,0 +1,79 @@
+import fs from 'fs';
+import path from 'path';
+
+const datasetItemExtensions = new Set([
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.webp',
+  '.mp4',
+  '.avi',
+  '.mov',
+  '.mkv',
+  '.wmv',
+  '.m4v',
+  '.flv',
+  '.mp3',
+  '.wav',
+  '.flac',
+  '.ogg',
+]);
+
+export function isDatasetItem(filename: string) {
+  return datasetItemExtensions.has(path.extname(filename).toLowerCase());
+}
+
+export function findDatasetItemsRecursively(dir: string): string[] {
+  let results: string[] = [];
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const name = entry.name;
+    if (name.startsWith('.')) continue;
+
+    const itemPath = path.join(dir, name);
+
+    if (entry.isDirectory()) {
+      if (name === '_controls') continue;
+      results = results.concat(findDatasetItemsRecursively(itemPath));
+    } else if (entry.isFile() && isDatasetItem(name)) {
+      results.push(itemPath);
+    }
+  }
+
+  return results;
+}
+
+export function countDatasetItemsRecursively(dir: string): number {
+  let count = 0;
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const name = entry.name;
+    if (name.startsWith('.')) continue;
+
+    const itemPath = path.join(dir, name);
+
+    if (entry.isDirectory()) {
+      if (name === '_controls') continue;
+      count += countDatasetItemsRecursively(itemPath);
+    } else if (entry.isFile() && isDatasetItem(name)) {
+      count += 1;
+    }
+  }
+
+  return count;
+}
+
+export function isPathInRoot(filePath: string, rootPath: string) {
+  const resolvedPath = path.resolve(filePath);
+  const resolvedRoot = path.resolve(rootPath);
+
+  if (process.platform === 'win32') {
+    const lowerPath = resolvedPath.toLowerCase();
+    const lowerRoot = resolvedRoot.toLowerCase();
+    return lowerPath === lowerRoot || lowerPath.startsWith(lowerRoot + path.sep);
+  }
+
+  return resolvedPath === resolvedRoot || resolvedPath.startsWith(resolvedRoot + path.sep);
+}


### PR DESCRIPTION
## Description

Adds dataset item counts to each dataset card in the training configuration page for easier dataset balancing.  Dataset heads now show counts like:

Dataset 1 - 150 items

The count includes the media types already used (images, videos, audio).

## Implementation
The existing recursive dataset item scanning logic was separated out so it wouldn't need to be duplicated.
Updated the dataset browser 'listImages' to reuse that shared helper.
Added /api/datasets/countItems that returns counts for selected dataset paths.
Added the client hook to fetch counts

Note: I didn't use the already existing /api/datasets/listImages because that returns every item path, and we only needed a count.  I tried to keep this lightweight.

## Testing
Build and ran successfully
