### PR TITLE
Fix jobactionbar spacing web and mobile

### DIFF
--- a/ui/src/components/JobActionBar.tsx
+++ b/ui/src/components/JobActionBar.tsx
@@ -31,6 +31,7 @@ export default function JobActionBar({
   if (!afterDelete) afterDelete = onRefresh;
 
   const iconSizeClass = 'w-5 h-5 sm:w-6 sm:h-6';
+  const actionClass = "ml-2 p-2 sm:ml-4 sm:p-1";
   return (
     <div className={`flex items-center flex-shrink-0 ${className ?? ''}`}>
       {canStart && (
@@ -44,7 +45,7 @@ export default function JobActionBar({
             }
             if (onRefresh) onRefresh();
           }}
-          className={`ml-1 sm:ml-2 opacity-100`}
+          className={`${actionClass} opacity-100`}
         >
           <Play className={iconSizeClass} />
         </Button>
@@ -56,7 +57,7 @@ export default function JobActionBar({
             await markJobAsStopped(job.id);
             if (onRefresh) onRefresh();
           }}
-          className={`ml-1 sm:ml-2 opacity-100`}
+          className={`${actionClass} opacity-100`}
         >
           <X className={iconSizeClass} />
         </Button>
@@ -76,7 +77,7 @@ export default function JobActionBar({
               },
             });
           }}
-          className={`ml-1 sm:ml-2 opacity-100`}
+          className={`${actionClass} opacity-100`}
         >
           <Pause className={iconSizeClass} />
         </Button>
@@ -131,7 +132,7 @@ export default function JobActionBar({
             },
           });
         }}
-        className={`ml-1 sm:ml-2 opacity-100`}
+        className={`${actionClass} opacity-100`}
       >
         <Trash2 className={iconSizeClass} />
       </Button>


### PR DESCRIPTION
Alignment spacing for the jobactionbar buttons on the web ui were incorrect and off balanced. (More space between cogwheel and other buttons)
I've fixed that as well as slightly padding those buttons correctly for mobile users so they can comfortably be clicked without accidentally hitting the wrong button.

There is now a single modifiable class name since the buttons already shared the same layout.

<img width="768" height="432" alt="20260618_211131" src="https://github.com/user-attachments/assets/8f033e31-79a1-4438-950d-3feb00371516" />


