### PR TITLE
Fix training startup when output directory is on an SMB mount

### DIFF
--- a/toolkit/logging_aitk.py
+++ b/toolkit/logging_aitk.py
@@ -121,7 +121,10 @@ class UILogger:
             os.makedirs(parent, exist_ok=True)
 
         self._con = sqlite3.connect(self.log_file, timeout=30.0, isolation_level=None)
-        self._con.execute("PRAGMA journal_mode=WAL;")
+        try:
+            self._con.execute("PRAGMA journal_mode=WAL;")
+        except sqlite3.OperationalError:
+            self._con.execute("PRAGMA journal_mode=DELETE;")
         self._con.execute("PRAGMA synchronous=NORMAL;")
         self._con.execute("PRAGMA temp_store=MEMORY;")
         self._con.execute("PRAGMA foreign_keys=ON;")


### PR DESCRIPTION
This change falls back to SQLite `DELETE` journal mode when enabling WAL fails.

When the output directory is mounted on an SMB share, initializing the UI logger database with `PRAGMA journal_mode=WAL;` can fail with:

```text
sqlite3.OperationalError: database is locked
```

This prevents training jobs from starting even though the database can still be used with the default/delete journal mode.

This PR should fix https://github.com/ostris/ai-toolkit/issues/621 .