### PR TITLE
Fix Krea2/Qwen-Image flat samples: use a VAE with non-zero quant convs

### DIFF
--- a/extensions_built_in/diffusion_models/krea2/krea2.py
+++ b/extensions_built_in/diffusion_models/krea2/krea2.py
@@ -87,7 +87,13 @@ scheduler_config = {
 
 # Defaults; both overridable via model.model_kwargs.
 QWEN3_VL_PATH = "Qwen/Qwen3-VL-4B-Instruct"
-QWEN_IMAGE_VAE_PATH = "Qwen/Qwen-Image"
+# NOTE: the base "Qwen/Qwen-Image" VAE checkpoint ships with all-zero
+# quant_conv / post_quant_conv weights, which AutoencoderKLQwenImage applies on
+# encode AND decode -- that zeros the latent path, so encode returns pure noise
+# and decode returns a constant flat field (every sample comes out the same
+# muddy-brown image). "Qwen/Qwen-Image-2512" is the same VAE with those convs
+# populated correctly, so we use it here.
+QWEN_IMAGE_VAE_PATH = "Qwen/Qwen-Image-2512"
 
 HF_TOKEN = os.getenv("HF_TOKEN", None)
 
@@ -229,6 +235,19 @@ class Krea2Model(BaseModel):
         vae = AutoencoderKLQwenImage.from_pretrained(
             vae_path, subfolder="vae", torch_dtype=self.vae_torch_dtype, token=HF_TOKEN
         )
+        # Guard against the known-bad Qwen-Image VAE checkpoint whose quant_conv /
+        # post_quant_conv weights are all zero: applying them zeros the latent path
+        # so encode -> noise and decode -> flat field, silently ruining training and
+        # samples. Fail loudly instead of wasting hours on muddy-brown output.
+        for cname in ("quant_conv", "post_quant_conv"):
+            conv = getattr(vae, cname, None)
+            if conv is not None and not torch.any(conv.weight != 0):
+                raise RuntimeError(
+                    f"The VAE at {vae_path!r} has an all-zero {cname}; its latent path "
+                    "is dead (samples would be a flat field and training would learn "
+                    "noise). Use 'Qwen/Qwen-Image-2512' (set model.model_kwargs.vae_path) "
+                    "or re-download a VAE with populated quant convs."
+                )
         vae.eval()
         vae.requires_grad_(False)
         return vae


### PR DESCRIPTION
I've never submitted something like this before and i want to be upfront: Claude Code came up with the solution, but i was getting these brown sample images. Claude Code says it's the VAE.


## Problem
Training Krea2 (raw or turbo) produces sample previews that are a uniform
muddy-brown field — identical for every prompt, step, and run (the output JPEGs
are byte-for-byte identical). FLUX / z-image are unaffected.

## Root cause
Krea2 defaults its VAE to `Qwen/Qwen-Image`, loaded via `AutoencoderKLQwenImage`.
In the current `main` revision of that repo, the VAE's `quant_conv` and
`post_quant_conv` weights are **all zero**. The pinned diffusers commit applies
these convs on both encode and decode, which zeros the latent path:

- **decode** → constant output regardless of latent → flat brown image
- **encode** → returns N(0,1) noise instead of the image → so training also
  silently learns against noise targets, not just broken previews.

`Qwen/Qwen-Image-2512` is the same VAE (byte-identical encoder/decoder weights)
with the quant convs populated. `extensions_built_in/diffusion_models/qwen_image/
qwen_image.py` loads the same `Qwen/Qwen-Image` VAE, so that arch is likely
affected too.

## Fix
- Default Krea2 to `Qwen/Qwen-Image-2512`.
- Guard `_load_vae` to raise on an all-zero `quant_conv` so this fails loudly
  instead of silently wasting training hours.

## Minimal repro (no DiT needed)
```python
import torch
from diffusers import AutoencoderKLQwenImage

for repo in ["Qwen/Qwen-Image", "Qwen/Qwen-Image-2512"]:
    vae = AutoencoderKLQwenImage.from_pretrained(
        repo, subfolder="vae", torch_dtype=torch.float32).to("cuda").eval()
    a, b = torch.randn(1,16,1,64,64,device="cuda"), torch.randn(1,16,1,64,64,device="cuda")
    with torch.no_grad():
        da, db = vae.decode(a).sample, vae.decode(b).sample
    print(repo,
          "| post_quant_conv std:", round(vae.post_quant_conv.weight.std().item(), 4),
          "| decode response to latent:", round(((da-db).norm()/da.norm()).item(), 4))
# Qwen/Qwen-Image      -> post_quant_conv std: 0.0    | decode response: 0.0   (dead)
# Qwen/Qwen-Image-2512 -> post_quant_conv std: 0.104  | decode response: ~1.0  (works)

Verification

With the fix, the VAE round-trip reconstructs the input (recon pixel std matches
the source image) and Krea2 generation produces correct, prompt-distinct images
(verified end-to-end on Krea-2-Raw: "a red sports car on a city street" and
"an oil painting of snowy mountains at sunset" both render correctly).

Alternative the maintainer may prefer: pin a Qwen/Qwen-Image revision whose VAE
has populated quant convs. The same fix likely applies to qwen_image.py.

🤖 Generated with Claude Code (https://claude.com/claude-code)
