### PR TITLE
Clear stale return-to-queue flag when starting jobs, fixes crash loop

### DIFF
--- a/ui/cron/actions/startJob.ts
+++ b/ui/cron/actions/startJob.ts
@@ -165,6 +165,7 @@ export default async function startJob(jobID: string) {
     data: {
       status: 'running',
       stop: false,
+      return_to_queue: false,
       info: 'Starting job...',
     },
   });


### PR DESCRIPTION
Fixes a notorious crash loop some people have been resorting to editing the sqlite database manually to fix.