### PR TITLE
Fix CUDA OOM during Krea2 block-by-block quantization

### DIFF
--- a/extensions_built_in/diffusion_models/krea2/krea2.py
+++ b/extensions_built_in/diffusion_models/krea2/krea2.py
@@ -330,6 +330,10 @@ class Krea2Model(BaseModel):
 
         if self.model_config.quantize:
             self.print_and_status_update("Quantizing transformer")
+            transformer.to("cpu")
+            if self.assistant_lora is not None:
+                self.assistant_lora.force_to("cpu", dtype=self.torch_dtype)
+            flush()
             quantize_model(self, transformer)
             flush()
 

--- a/toolkit/util/quantize.py
+++ b/toolkit/util/quantize.py
@@ -16,6 +16,7 @@ from safetensors.torch import load_file
 from huggingface_hub import hf_hub_download
 
 from toolkit.print import print_acc
+from toolkit.basic import flush
 import os
 
 if TYPE_CHECKING:
@@ -342,11 +343,16 @@ def quantize_model(
         base_model.print_and_status_update(
             f" - quantizing {len(all_blocks)} transformer blocks"
         )
+        model_to_quantize.to("cpu")
+        flush()
         for block in tqdm(all_blocks):
             block.to(base_model.device_torch, dtype=base_model.torch_dtype, non_blocking=True)
             quantize(block, weights=quantization_type)
             freeze(block)
-            block.to("cpu", non_blocking=True)
+            block.to("cpu")
+            if torch.cuda.is_available():
+                torch.cuda.synchronize()
+            flush()
 
         # todo, on extras find a universal way to quantize them on device and move them back to their original
         # device without having to move the transformer blocks to the device first


### PR DESCRIPTION
## Summary
- Fix CUDA OOM during Krea2 transformer quantization by synchronizing and flushing GPU memory after each block is offloaded to CPU.
- Ensure Krea2 starts quantization from a clean CPU baseline, including assistant LoRA weights when present.

## Test plan
- [x] Reproduced original failure path (OOM around block 25/28 during `quantize_model`)
- [x] Verified all 28 blocks quantize successfully on a 24GB RTX 3090
- [x] Confirmed Krea2 Raw training job completes model load and starts training