### PR TITLE
Expose pretrained LoRA path in simple UI

### DIFF
--- a/ui/src/app/jobs/new/SimpleJob.tsx
+++ b/ui/src/app/jobs/new/SimpleJob.tsx
@@ -487,6 +487,17 @@ export default function SimpleJob({
             )}
             {jobConfig.config.process[0].network?.type == 'lora' && (
               <>
+                <TextInput
+                  label="Pretrained LoRA Path"
+                  value={jobConfig.config.process[0].network.pretrained_lora_path ?? ''}
+                  onChange={value =>
+                    setJobConfig(
+                      value.trim() === '' ? undefined : value.trim(),
+                      'config.process[0].network.pretrained_lora_path'
+                    )
+                  }
+                  placeholder="eg. /path/to/previous_lora.safetensors"
+                />
                 <NumberInput
                   label="Linear Rank"
                   value={jobConfig.config.process[0].network.linear}

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -62,6 +62,7 @@ export interface GPUApiResponse {
 
 export interface NetworkConfig {
   type: string;
+  pretrained_lora_path?: string;
   linear: number;
   linear_alpha: number;
   conv: number;


### PR DESCRIPTION
Expose the existing `network.pretrained_lora_path` option in the simple LoRA training UI.
This lets users initialize a new LoRA training run from an existing LoRA checkpoint without switching to advanced config editing.