### PR TITLE
Send T5 tokens to the T5 encoder's own device when caching text embeddings

### DIFF
--- a/toolkit/train_tools.py
+++ b/toolkit/train_tools.py
@@ -561,7 +561,7 @@ def encode_prompts_flux(
     )
     text_input_ids = text_inputs.input_ids
 
-    prompt_embeds = text_encoder[1](text_input_ids.to(device), output_hidden_states=False)[0]
+    prompt_embeds = text_encoder[1](text_input_ids.to(text_encoder[1].device), output_hidden_states=False)[0]
 
     dtype = text_encoder[1].dtype
     prompt_embeds = prompt_embeds.to(dtype=dtype, device=device)


### PR DESCRIPTION
## What

`encode_prompts_flux` in `toolkit/train_tools.py` computes a single `device` from the first text encoder (CLIP) and reuses it for the second encoder (T5). When caching text embeddings, it sends the T5 input ids to `device` (CLIP's device) instead of to T5's own device.

## Why it breaks

On setups that place the large T5 encoder on a different device than CLIP (e.g. CPU offload / `device_map` on low-VRAM or unified-memory systems), the tokens land on CLIP's GPU while T5's weights are elsewhere, so the T5 forward raises:

```
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu
```

This surfaces during "Caching text embeddings to disk" — the model, VAE, network, and CLIP all load fine first, then it dies when T5 is invoked.

## Fix

Send the tokens to `text_encoder[1].device` (T5's own device).

## Regression safety

When both encoders are co-located (the default single-GPU case), `text_encoder[1].device == device`, so this is a **no-op** — no behavior change for existing setups. It only corrects the split-device path.

## Validation

- **Before:** a CLIP+T5 LoRA training run with the T5 encoder offloaded crashes at the caching step with the device mismatch above.
- **After:** caching completes and training proceeds; a full LoRA training run finished end-to-end and saved weights.

Refs #374 (the `cache_text_embeddings` device-mismatch report).
