### PR TITLE
Use the generate config sampler instead of the undefined train_config in GenerateProcess

### DIFF
--- a/jobs/process/GenerateProcess.py
+++ b/jobs/process/GenerateProcess.py
@@ -102,7 +102,7 @@ class GenerateProcess(BaseProcess):
             if self.model_config.is_lumina2:
                 arch = 'lumina2'
             sampler = get_sampler(
-                self.train_config.noise_scheduler,
+                self.generate_config.sampler,
                 {
                     "prediction_type": "v_prediction" if self.model_config.is_v_pred else "epsilon",
                 },


### PR DESCRIPTION
## What

In `GenerateProcess.__init__` (`jobs/process/GenerateProcess.py`), the sampler-building branch references `self.train_config.noise_scheduler`, but `GenerateProcess` never sets `self.train_config` (only training processes do).

## Why it breaks

Running a `generate` job that reaches this branch crashes at construction:

```
AttributeError: 'GenerateProcess' object has no attribute 'train_config'
```

## Fix

Use `self.generate_config.sampler`, which is already built earlier in the same `__init__`. `GenerateConfig` defines `sampler` (default `'ddpm'`), which is exactly what `get_sampler(...)` expects.

## Note on the previous attempt (#498)

This revives the fix reported in #416 and attempted in #498 (closed for inactivity). It intentionally uses `generate_config.sampler` rather than `generate_config.noise_scheduler` (as in #498): `GenerateConfig` has a `sampler` attribute but **no** `noise_scheduler` attribute, so `.sampler` actually resolves the crash instead of moving it to a different `AttributeError`.

## Regression safety

This branch currently always crashes, so no working path is affected.

## Validation

- **Before:** a FLUX `generate` job crashes at init with the `AttributeError` above.
- **After:** the generate job constructs, loads the model, and produces images (validated with a FLUX generate run that produced a full batch).

Refs #416. Supersedes the approach in #498.
