### PR TITLE
캡션 혼합 처리와 학습 캡션 디버그 로그 추가

### DIFF
--- a/config/examples/modal/modal_train_lora_flux_24gb.yaml
+++ b/config/examples/modal/modal_train_lora_flux_24gb.yaml
@@ -31,7 +31,7 @@ config:
         - folder_path: "/root/ai-toolkit/your-dataset"
           caption_ext: "txt"
           caption_dropout_rate: 0.05  # will drop out the caption 5% of time
-          shuffle_tokens: false  # shuffle caption order, split by commas
+          shuffle_caption: false  # shuffle caption order, split by commas
           cache_latents_to_disk: true  # leave this true unless you know what you're doing
           resolution: [ 512, 768, 1024 ]  # flux enjoys multiple resolutions
       train:

--- a/config/examples/modal/modal_train_lora_flux_schnell_24gb.yaml
+++ b/config/examples/modal/modal_train_lora_flux_schnell_24gb.yaml
@@ -31,7 +31,7 @@ config:
         - folder_path: "/root/ai-toolkit/your-dataset"
           caption_ext: "txt"
           caption_dropout_rate: 0.05  # will drop out the caption 5% of time
-          shuffle_tokens: false  # shuffle caption order, split by commas
+          shuffle_caption: false  # shuffle caption order, split by commas
           cache_latents_to_disk: true  # leave this true unless you know what you're doing
           resolution: [ 512, 768, 1024 ]  # flux enjoys multiple resolutions
       train:

--- a/config/examples/train_full_fine_tune_flex.yaml
+++ b/config/examples/train_full_fine_tune_flex.yaml
@@ -28,7 +28,7 @@ config:
         - folder_path: "/path/to/images/folder"
           caption_ext: "txt"
           caption_dropout_rate: 0.05  # will drop out the caption 5% of time
-          shuffle_tokens: false  # shuffle caption order, split by commas
+          shuffle_caption: false  # shuffle caption order, split by commas
           # cache_latents_to_disk: true  # leave this true unless you know what you're doing
           resolution: [ 512, 768, 1024 ]  # flex enjoys multiple resolutions
       train:

--- a/config/examples/train_full_fine_tune_lumina.yaml
+++ b/config/examples/train_full_fine_tune_lumina.yaml
@@ -28,7 +28,7 @@ config:
         - folder_path: "/path/to/images/folder"
           caption_ext: "txt"
           caption_dropout_rate: 0.05  # will drop out the caption 5% of time
-          shuffle_tokens: false  # shuffle caption order, split by commas
+          shuffle_caption: false  # shuffle caption order, split by commas
           # cache_latents_to_disk: true  # leave this true unless you know what you're doing
           resolution: [ 512, 768, 1024 ]  # lumina2 enjoys multiple resolutions
       train:

--- a/config/examples/train_lora_chroma_24gb.yaml
+++ b/config/examples/train_lora_chroma_24gb.yaml
@@ -34,7 +34,7 @@ config:
         - folder_path: "/path/to/images/folder"
           caption_ext: "txt"
           caption_dropout_rate: 0.05  # will drop out the caption 5% of time
-          shuffle_tokens: false  # shuffle caption order, split by commas
+          shuffle_caption: false  # shuffle caption order, split by commas
           cache_latents_to_disk: true  # leave this true unless you know what you're doing
           resolution: [ 512, 768, 1024 ]  # chroma enjoys multiple resolutions
       train:

--- a/config/examples/train_lora_flex_24gb.yaml
+++ b/config/examples/train_lora_flex_24gb.yaml
@@ -34,7 +34,7 @@ config:
         - folder_path: "/path/to/images/folder"
           caption_ext: "txt"
           caption_dropout_rate: 0.05  # will drop out the caption 5% of time
-          shuffle_tokens: false  # shuffle caption order, split by commas
+          shuffle_caption: false  # shuffle caption order, split by commas
           cache_latents_to_disk: true  # leave this true unless you know what you're doing
           resolution: [ 512, 768, 1024 ]  # flex enjoys multiple resolutions
       train:

--- a/config/examples/train_lora_flux_24gb.yaml
+++ b/config/examples/train_lora_flux_24gb.yaml
@@ -34,7 +34,7 @@ config:
         - folder_path: "/path/to/images/folder"
           caption_ext: "txt"
           caption_dropout_rate: 0.05  # will drop out the caption 5% of time
-          shuffle_tokens: false  # shuffle caption order, split by commas
+          shuffle_caption: false  # shuffle caption order, split by commas
           cache_latents_to_disk: true  # leave this true unless you know what you're doing
           resolution: [ 512, 768, 1024 ]  # flux enjoys multiple resolutions
       train:

--- a/config/examples/train_lora_flux_kontext_24gb.yaml
+++ b/config/examples/train_lora_flux_kontext_24gb.yaml
@@ -39,7 +39,7 @@ config:
           control_path: "/path/to/control/folder"
           caption_ext: "txt"
           caption_dropout_rate: 0.05  # will drop out the caption 5% of time
-          shuffle_tokens: false  # shuffle caption order, split by commas
+          shuffle_caption: false  # shuffle caption order, split by commas
           cache_latents_to_disk: true  # leave this true unless you know what you're doing
           # Kontext runs images in at 2x the latent size. It may OOM at 1024 resolution with 24GB vram.
           resolution: [ 512, 768 ]  # flux enjoys multiple resolutions

--- a/config/examples/train_lora_flux_schnell_24gb.yaml
+++ b/config/examples/train_lora_flux_schnell_24gb.yaml
@@ -34,7 +34,7 @@ config:
         - folder_path: "/path/to/images/folder"
           caption_ext: "txt"
           caption_dropout_rate: 0.05  # will drop out the caption 5% of time
-          shuffle_tokens: false  # shuffle caption order, split by commas
+          shuffle_caption: false  # shuffle caption order, split by commas
           cache_latents_to_disk: true  # leave this true unless you know what you're doing
           resolution: [ 512, 768, 1024 ]  # flux enjoys multiple resolutions
       train:

--- a/config/examples/train_lora_lumina.yaml
+++ b/config/examples/train_lora_lumina.yaml
@@ -32,7 +32,7 @@ config:
         - folder_path: "/path/to/images/folder"
           caption_ext: "txt"
           caption_dropout_rate: 0.05  # will drop out the caption 5% of time
-          shuffle_tokens: false  # shuffle caption order, split by commas
+          shuffle_caption: false  # shuffle caption order, split by commas
           # cache_latents_to_disk: true  # leave this true unless you know what you're doing
           resolution: [ 512, 768, 1024 ]  # lumina2 enjoys multiple resolutions
       train:

--- a/config/examples/train_lora_omnigen2_24gb.yaml
+++ b/config/examples/train_lora_omnigen2_24gb.yaml
@@ -34,7 +34,7 @@ config:
         - folder_path: "/path/to/images/folder"
           caption_ext: "txt"
           caption_dropout_rate: 0.05  # will drop out the caption 5% of time
-          shuffle_tokens: false  # shuffle caption order, split by commas
+          shuffle_caption: false  # shuffle caption order, split by commas
           cache_latents_to_disk: true  # leave this true unless you know what you're doing
           resolution: [ 512, 768, 1024 ]  # omnigen2 should work with multiple resolutions
       train:

--- a/config/examples/train_lora_qwen_image_24gb.yaml
+++ b/config/examples/train_lora_qwen_image_24gb.yaml
@@ -32,7 +32,7 @@ config:
           caption_ext: "txt"
           # default_caption: "a person" # if caching text embeddings, if you dont have captions, this will get cached
           caption_dropout_rate: 0.05  # will drop out the caption 5% of time
-          shuffle_tokens: false  # shuffle caption order, split by commas
+          shuffle_caption: false  # shuffle caption order, split by commas
           cache_latents_to_disk: true  # leave this true unless you have a large dataset
           # if you OOM, 1024 may be too much, but should work
           resolution: [ 512, 768, 1024 ]  # qwen image enjoys multiple resolutions

--- a/config/examples/train_lora_sd35_large_24gb.yaml
+++ b/config/examples/train_lora_sd35_large_24gb.yaml
@@ -35,7 +35,7 @@ config:
         - folder_path: "/path/to/images/folder"
           caption_ext: "txt"
           caption_dropout_rate: 0.05  # will drop out the caption 5% of time
-          shuffle_tokens: false  # shuffle caption order, split by commas
+          shuffle_caption: false  # shuffle caption order, split by commas
           cache_latents_to_disk: true  # leave this true unless you know what you're doing
           resolution: [ 1024 ] 
       train:

--- a/config/examples/train_lora_wan21_14b_24gb.yaml
+++ b/config/examples/train_lora_wan21_14b_24gb.yaml
@@ -41,7 +41,7 @@ config:
         - folder_path: "/path/to/images/folder"
           caption_ext: "txt"
           caption_dropout_rate: 0.05  # will drop out the caption 5% of time
-          shuffle_tokens: false  # shuffle caption order, split by commas
+          shuffle_caption: false  # shuffle caption order, split by commas
           cache_latents_to_disk: true  # leave this true unless you know what you're doing
           resolution: [ 632 ]  # will be around 480p
       train:

--- a/config/examples/train_lora_wan21_1b_24gb.yaml
+++ b/config/examples/train_lora_wan21_1b_24gb.yaml
@@ -36,7 +36,7 @@ config:
         - folder_path: "/path/to/images/folder"
           caption_ext: "txt"
           caption_dropout_rate: 0.05  # will drop out the caption 5% of time
-          shuffle_tokens: false  # shuffle caption order, split by commas
+          shuffle_caption: false  # shuffle caption order, split by commas
           cache_latents_to_disk: true  # leave this true unless you know what you're doing
           resolution: [ 632 ]  # will be around 480p
       train:

--- a/flux_train_ui.py
+++ b/flux_train_ui.py
@@ -2,6 +2,7 @@ import os
 from huggingface_hub import whoami    
 os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
 import sys
+import math
 
 # Add the current working directory to the Python path
 sys.path.insert(0, os.getcwd())
@@ -13,18 +14,36 @@ import uuid
 import os
 import shutil
 import json
+from collections import deque
+from queue import Empty, Full, Queue
+from threading import Event, Thread
 import yaml
 from slugify import slugify
 from transformers import AutoProcessor, AutoModelForCausalLM
 
 sys.path.insert(0, "ai-toolkit")
+from toolkit.caption_logging import reset_caption_log_listener, set_caption_log_listener
 from toolkit.job import get_job
 
 MAX_IMAGES = 150
+CAPTION_LOG_HISTORY_LINES = 500
+CAPTION_LOG_QUEUE_EVENTS = 100
+CAPTION_LOG_POLL_SECONDS = 0.25
+
+def _is_text_file(file_path):
+    return os.path.splitext(os.fspath(file_path))[1].lower() == '.txt'
+
+
+def _is_image_file(file_path):
+    # The Gradio input accepts only images and .txt files. Treat every
+    # non-caption upload as an image so formats such as BMP, GIF, and TIFF keep
+    # working instead of narrowing the UI to the training loader's core list.
+    return not _is_text_file(file_path)
+
 
 def load_captioning(uploaded_files, concept_sentence):
-    uploaded_images = [file for file in uploaded_files if not file.endswith('.txt')]
-    txt_files = [file for file in uploaded_files if file.endswith('.txt')]
+    uploaded_images = [file for file in uploaded_files if _is_image_file(file)]
+    txt_files = [file for file in uploaded_files if _is_text_file(file)]
     txt_files_dict = {os.path.splitext(os.path.basename(txt_file))[0]: txt_file for txt_file in txt_files}
     updates = []
     if len(uploaded_images) <= 1:
@@ -55,7 +74,7 @@ def load_captioning(uploaded_files, concept_sentence):
             print(image_value)
             if base_name in txt_files_dict:
                 print("entrou")
-                with open(txt_files_dict[base_name], 'r') as file:
+                with open(txt_files_dict[base_name], 'r', encoding='utf-8') as file:
                     corresponding_caption = file.read()
                     
         # Update value of captioning area
@@ -76,22 +95,33 @@ def hide_captioning():
 
 def create_dataset(*inputs):
     print("Creating dataset")
-    images = inputs[0]
-    destination_folder = str(f"datasets/{uuid.uuid4()}")
-    if not os.path.exists(destination_folder):
-        os.makedirs(destination_folder)
+    uploaded_files = inputs[0] or []
+    captions = inputs[1:]
+    uploaded_images = [file for file in uploaded_files if _is_image_file(file)]
+    uploaded_text_files = [file for file in uploaded_files if _is_text_file(file)]
+    destination_folder = os.path.join("datasets", str(uuid.uuid4()))
+    os.makedirs(destination_folder, exist_ok=True)
+
+    # Preserve explicitly uploaded captions, including mixed-caption *_nl.txt
+    # files. Textbox captions are written afterwards so user edits win over an
+    # uploaded same-stem base caption.
+    for text_file in uploaded_text_files:
+        shutil.copy(text_file, destination_folder)
 
     jsonl_file_path = os.path.join(destination_folder, "metadata.jsonl")
-    with open(jsonl_file_path, "a") as jsonl_file:
-        for index, image in enumerate(images):
+    with open(jsonl_file_path, "w", encoding="utf-8") as jsonl_file:
+        for index, image in enumerate(uploaded_images):
             new_image_path = shutil.copy(image, destination_folder)
-
-            original_caption = inputs[index + 1]
+            original_caption = captions[index] if index < len(captions) else None
             file_name = os.path.basename(new_image_path)
 
-            data = {"file_name": file_name, "prompt": original_caption}
+            if original_caption is not None:
+                caption_path = os.path.splitext(new_image_path)[0] + ".txt"
+                with open(caption_path, "w", encoding="utf-8") as caption_file:
+                    caption_file.write(str(original_caption))
 
-            jsonl_file.write(json.dumps(data) + "\n")
+            data = {"file_name": file_name, "prompt": original_caption}
+            jsonl_file.write(json.dumps(data, ensure_ascii=False) + "\n")
 
     return destination_folder
 
@@ -106,7 +136,8 @@ def run_captioning(images, concept_sentence, *captions):
     processor = AutoProcessor.from_pretrained("multimodalart/Florence-2-large-no-flash-attn", trust_remote_code=True)
 
     captions = list(captions)
-    for i, image_path in enumerate(images):
+    uploaded_images = [image for image in (images or []) if _is_image_file(image)]
+    for i, image_path in enumerate(uploaded_images):
         print(captions[i])
         if isinstance(image_path, str):  # If image is a file path
             image = Image.open(image_path).convert("RGB")
@@ -148,6 +179,17 @@ def start_training(
     rank,
     model_to_train,
     low_vram,
+    caption_mode,
+    mixed_weight_tags,
+    mixed_weight_nl,
+    mixed_weight_tags_nl,
+    mixed_weight_nl_tags,
+    shuffle_caption,
+    token_dropout_rate,
+    keep_tokens,
+    keep_tokens_separator,
+    secondary_separator,
+    log_captions_every_n_steps,
     dataset_folder,
     sample_1,
     sample_2,
@@ -158,6 +200,22 @@ def start_training(
     push_to_hub = True
     if not lora_name:
         raise gr.Error("You forgot to insert your LoRA name! This name has to be unique.")
+    try:
+        mixed_weights = {
+            "tags": float(mixed_weight_tags),
+            "nl": float(mixed_weight_nl),
+            "tags_nl": float(mixed_weight_tags_nl),
+            "nl_tags": float(mixed_weight_nl_tags),
+        }
+    except (TypeError, ValueError) as exc:
+        raise gr.Error("Mixed caption weights must be finite numbers greater than or equal to 0.") from exc
+    mixed_weight_total = sum(mixed_weights.values())
+    if any(not math.isfinite(weight) or weight < 0 for weight in mixed_weights.values()) or not math.isfinite(
+        mixed_weight_total
+    ):
+        raise gr.Error("Mixed caption weights must be finite numbers greater than or equal to 0.")
+    if caption_mode == "mixed" and mixed_weight_total <= 0:
+        raise gr.Error("Mixed caption mode requires at least one positive caption weight.")
     try:
         if whoami()["auth"]["accessToken"]["role"] == "write" or "repo.write" in whoami()["auth"]["accessToken"]["fineGrained"]["scoped"][0]["permissions"]:
             gr.Info(f"Starting training locally {whoami()['name']}. Your LoRA will be available locally and in Hugging Face after it finishes.")
@@ -184,6 +242,15 @@ def start_training(
     config["config"]["process"][0]["network"]["linear"] = int(rank)
     config["config"]["process"][0]["network"]["linear_alpha"] = int(rank)
     config["config"]["process"][0]["datasets"][0]["folder_path"] = dataset_folder
+    config["config"]["process"][0]["datasets"][0]["caption_mode"] = caption_mode
+    config["config"]["process"][0]["datasets"][0]["mixed_weights"] = mixed_weights
+    config["config"]["process"][0]["datasets"][0]["shuffle_caption"] = shuffle_caption
+    config["config"]["process"][0]["datasets"][0]["token_dropout_rate"] = float(token_dropout_rate)
+    config["config"]["process"][0]["datasets"][0]["keep_tokens"] = int(keep_tokens)
+    config["config"]["process"][0]["datasets"][0]["keep_tokens_separator"] = keep_tokens_separator or None
+    config["config"]["process"][0]["datasets"][0]["secondary_separator"] = secondary_separator or None
+    logging_config = config["config"]["process"][0].setdefault("logging", {})
+    logging_config["log_captions_every_n_steps"] = int(log_captions_every_n_steps or 0)
     config["config"]["process"][0]["save"]["push_to_hub"] = push_to_hub
     if(push_to_hub):
         try:
@@ -225,12 +292,85 @@ def start_training(
     with open(config_path, "w") as f:
         yaml.dump(config, f)
     
-    # run the job locally
-    job = get_job(config_path)
-    job.run()
-    job.cleanup()
+    # Run training outside the Gradio event generator so caption events can be
+    # streamed back to the page while the job is still running. The listener is
+    # installed inside the worker because ContextVars do not automatically
+    # propagate into newly created threads.
+    caption_events = Queue(maxsize=CAPTION_LOG_QUEUE_EVENTS)
+    worker_done = Event()
+    worker_errors = []
 
-    return f"Training completed successfully. Model saved as {slugged_lora_name}"
+    def on_caption_log(message):
+        # Logging must never block or fail training if the browser disconnects
+        # or cannot consume events quickly enough. Keep the newest events.
+        try:
+            caption_events.put_nowait(str(message))
+        except Full:
+            try:
+                caption_events.get_nowait()
+            except Empty:
+                pass
+            try:
+                caption_events.put_nowait(str(message))
+            except Full:
+                pass
+
+    def run_training_job():
+        listener_token = None
+        job = None
+        try:
+            listener_token = set_caption_log_listener(on_caption_log)
+            job = get_job(config_path)
+            job.run()
+        except BaseException as exc:
+            worker_errors.append(exc)
+        finally:
+            if job is not None:
+                try:
+                    job.cleanup()
+                except BaseException as exc:
+                    if not worker_errors:
+                        worker_errors.append(exc)
+                    else:
+                        print(f"Error cleaning up failed training job: {exc}", flush=True)
+            if listener_token is not None:
+                try:
+                    reset_caption_log_listener(listener_token)
+                except BaseException as exc:
+                    if not worker_errors:
+                        worker_errors.append(exc)
+                    else:
+                        print(f"Error resetting caption log listener: {exc}", flush=True)
+            worker_done.set()
+
+    worker = Thread(target=run_training_job, name=f"train-{slugged_lora_name}", daemon=True)
+    worker.start()
+
+    caption_history = deque(maxlen=CAPTION_LOG_HISTORY_LINES)
+
+    def render_training_log(status):
+        if caption_history:
+            return f"{status}\n\n" + "\n".join(caption_history)
+        return status
+
+    yield render_training_log("Training started. Waiting for caption debug events...")
+
+    while not worker_done.is_set() or not caption_events.empty():
+        try:
+            message = caption_events.get(timeout=CAPTION_LOG_POLL_SECONDS)
+        except Empty:
+            continue
+        message_lines = message.rstrip().splitlines()
+        caption_history.extend(message_lines if message_lines else [message])
+        yield render_training_log("Training in progress...")
+
+    worker.join()
+    if worker_errors:
+        error = worker_errors[0]
+        yield render_training_log(f"Training failed: {error}")
+        raise gr.Error(f"Training failed: {error}")
+
+    yield render_training_log(f"Training completed successfully. Model saved as {slugged_lora_name}")
 
 config_yaml = '''
 device: cuda:0
@@ -349,6 +489,56 @@ with gr.Blocks(theme=theme, css=css) as demo:
             rank = gr.Number(label="LoRA Rank", value=16, minimum=4, maximum=128, step=4)
             model_to_train = gr.Radio(["dev", "schnell"], value="dev", label="Model to train")
             low_vram = gr.Checkbox(label="Low VRAM", value=True)
+            caption_mode = gr.Radio(
+                ["single", "mixed"],
+                value="single",
+                label="Caption mode",
+                info="Mixed mode samples from image.txt and image_nl.txt",
+            )
+            mixed_weight_tags = gr.Number(label="Tags caption weight", value=40, minimum=0)
+            mixed_weight_nl = gr.Number(label="Natural language caption weight", value=30, minimum=0)
+            mixed_weight_tags_nl = gr.Number(label="Tags + natural language weight", value=20, minimum=0)
+            mixed_weight_nl_tags = gr.Number(label="Natural language + tags weight", value=10, minimum=0)
+            shuffle_caption = gr.Checkbox(
+                label="Shuffle caption tags",
+                info="Randomize comma-separated tag order each time an image is used for training",
+                value=False,
+            )
+            token_dropout_rate = gr.Number(
+                label="Caption tag dropout rate",
+                info="Chance to remove each comma-separated tag during training (0 to 1)",
+                value=0,
+                minimum=0,
+                maximum=1,
+                step=0.01,
+            )
+            keep_tokens = gr.Number(
+                label="Keep first tags",
+                info="Number of leading tags protected from caption tag dropout",
+                value=0,
+                minimum=0,
+                step=1,
+            )
+            keep_tokens_separator = gr.Textbox(
+                label="Keep tokens separator",
+                info="Text before this separator is protected from tag dropout and shuffling",
+                placeholder="|||",
+                value="",
+            )
+            secondary_separator = gr.Textbox(
+                label="Secondary separator",
+                info="Join tags into groups that are dropped or shuffled as a single unit",
+                placeholder=";;;",
+                value="",
+            )
+            log_captions_every_n_steps = gr.Number(
+                label="Log captions every N steps",
+                info="Show the processed captions used for training at this interval; 0 disables logging",
+                value=0,
+                minimum=0,
+                step=1,
+                precision=0,
+            )
             with gr.Accordion("Even more advanced options", open=False):
                 use_more_advanced_options = gr.Checkbox(label="Use more advanced options", value=False)
                 more_advanced_options = gr.Code(config_yaml, language="yaml")
@@ -367,7 +557,12 @@ with gr.Blocks(theme=theme, css=css) as demo:
         output_components.append(sample_3)
         start = gr.Button("Start training", visible=False)
         output_components.append(start)
-        progress_area = gr.Markdown("")
+        progress_area = gr.Textbox(
+            label="Caption debug log",
+            value="",
+            lines=12,
+            interactive=False,
+        )
 
     dataset_folder = gr.State()
 
@@ -398,6 +593,17 @@ with gr.Blocks(theme=theme, css=css) as demo:
             rank,
             model_to_train,
             low_vram,
+            caption_mode,
+            mixed_weight_tags,
+            mixed_weight_nl,
+            mixed_weight_tags_nl,
+            mixed_weight_nl_tags,
+            shuffle_caption,
+            token_dropout_rate,
+            keep_tokens,
+            keep_tokens_separator,
+            secondary_separator,
+            log_captions_every_n_steps,
             dataset_folder,
             sample_1,
             sample_2,
@@ -411,4 +617,5 @@ with gr.Blocks(theme=theme, css=css) as demo:
     do_captioning.click(fn=run_captioning, inputs=[images, concept_sentence] + caption_list, outputs=caption_list)
 
 if __name__ == "__main__":
+    demo.queue()
     demo.launch(share=True, show_error=True)

--- a/jobs/process/BaseSDTrainProcess.py
+++ b/jobs/process/BaseSDTrainProcess.py
@@ -23,6 +23,11 @@ from huggingface_hub import HfApi, interpreter_login
 from toolkit.memory_management import MemoryManager
 
 from toolkit.basic import value_map
+from toolkit.caption_logging import (
+    emit_caption_log,
+    format_caption_debug_log,
+    should_log_captions,
+)
 from toolkit.clip_vision_adapter import ClipVisionAdapter
 from toolkit.custom_adapter import CustomAdapter
 from toolkit.data_loader import get_dataloader_from_datasets, trigger_dataloader_setup_epoch
@@ -2501,6 +2506,22 @@ class BaseSDTrainProcess(BaseTrainProcess):
 
                     if self.progress_bar is not None:
                         self.progress_bar.set_postfix_str(prog_bar_string)
+
+                completed_step = self.step_num + 1
+                caption_log_interval = getattr(
+                    self.logging_config,
+                    'log_captions_every_n_steps',
+                    0,
+                )
+                if (
+                    not did_oom
+                    and self.accelerator.is_main_process
+                    and should_log_captions(completed_step, caption_log_interval)
+                ):
+                    caption_debug_log = format_caption_debug_log(completed_step, batch_list)
+                    if caption_debug_log is not None:
+                        print(caption_debug_log, flush=True)
+                        emit_caption_log(caption_debug_log)
 
                 # if the batch is a DataLoaderBatchDTO, then we need to clean it up
                 if isinstance(batch, DataLoaderBatchDTO):

--- a/testing/test_caption_logging.py
+++ b/testing/test_caption_logging.py
@@ -1,0 +1,462 @@
+import ast
+import json
+import math
+from pathlib import Path
+from types import SimpleNamespace
+import unittest
+
+from toolkit.caption_logging import (
+    emit_caption_log,
+    format_caption_debug_log,
+    reset_caption_log_listener,
+    set_caption_log_listener,
+    should_log_captions,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _make_file_item(
+    path,
+    caption,
+    *,
+    caption_short=None,
+    is_reg=False,
+):
+    return SimpleNamespace(
+        path=path,
+        caption=caption,
+        caption_short=caption_short,
+        is_reg=is_reg,
+    )
+
+
+def _make_batch(file_items, *, cached_embedding=False):
+    return SimpleNamespace(
+        file_items=list(file_items),
+        prompt_embeds=object() if cached_embedding else None,
+    )
+
+
+def _load_logging_config_class():
+    """Load LoggingConfig without importing the training dependency stack."""
+    source_path = ROOT / 'toolkit' / 'config_modules.py'
+    tree = ast.parse(source_path.read_text(encoding='utf-8'), filename=str(source_path))
+    class_node = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == 'LoggingConfig'
+    )
+    namespace = {'math': math}
+    module = ast.Module(body=[class_node], type_ignores=[])
+    exec(compile(module, str(source_path), 'exec'), namespace)
+    return namespace['LoggingConfig']
+
+
+class CaptionLoggingCadenceTest(unittest.TestCase):
+    def test_disabled_interval_never_logs(self):
+        for completed_step in (0, 1, 100, 200):
+            with self.subTest(completed_step=completed_step):
+                self.assertFalse(should_log_captions(completed_step, 0))
+
+    def test_interval_100_logs_only_on_completed_steps_100_and_200(self):
+        expected = {
+            0: False,
+            1: False,
+            99: False,
+            100: True,
+            101: False,
+            199: False,
+            200: True,
+            201: False,
+        }
+        for completed_step, should_log in expected.items():
+            with self.subTest(completed_step=completed_step):
+                self.assertEqual(
+                    should_log_captions(completed_step, 100),
+                    should_log,
+                )
+
+    def test_first_completed_step_is_step_one(self):
+        self.assertFalse(should_log_captions(0, 1))
+        self.assertTrue(should_log_captions(1, 1))
+
+
+class CaptionDebugFormattingTest(unittest.TestCase):
+    def test_formats_two_microbatches_and_all_items(self):
+        batches = [
+            _make_batch(
+                [
+                    _make_file_item(
+                        'dataset/a.png',
+                        'long A',
+                        caption_short='short A',
+                    ),
+                    _make_file_item(
+                        'dataset/b.png',
+                        'same B',
+                        caption_short='same B',
+                        is_reg=True,
+                    ),
+                ],
+            ),
+            _make_batch(
+                [
+                    _make_file_item('dataset/c.png', 'long C'),
+                    _make_file_item('dataset/d.png', 'long D'),
+                ],
+                cached_embedding=True,
+            ),
+        ]
+
+        message = format_caption_debug_log(100, batches)
+
+        self.assertIsNotNone(message)
+        lines = message.splitlines()
+        self.assertEqual(len(lines), 4)
+
+        self.assertIn('[caption-debug] step=100', lines[0])
+        self.assertIn('microbatch=1/2', lines[0])
+        self.assertIn('item=1/2', lines[0])
+        self.assertIn('reg=false', lines[0])
+        self.assertIn('cached_embedding=false', lines[0])
+        self.assertIn(f'file={json.dumps("a.png")}', lines[0])
+        self.assertIn(f'caption={json.dumps("long A")}', lines[0])
+        self.assertIn(f'caption_short={json.dumps("short A")}', lines[0])
+
+        self.assertIn('microbatch=1/2', lines[1])
+        self.assertIn('item=2/2', lines[1])
+        self.assertIn('reg=true', lines[1])
+        self.assertNotIn('caption_short=', lines[1])
+
+        self.assertIn('microbatch=2/2', lines[2])
+        self.assertIn('item=1/2', lines[2])
+        self.assertIn('cached_embedding=true', lines[2])
+        self.assertIn(f'caption={json.dumps("long C")}', lines[2])
+
+        self.assertIn('microbatch=2/2', lines[3])
+        self.assertIn('item=2/2', lines[3])
+        self.assertIn(f'file={json.dumps("d.png")}', lines[3])
+
+    def test_json_escapes_path_caption_and_short_caption(self):
+        path = 'dataset/a "quoted".png'
+        basename = 'a "quoted".png'
+        caption = 'first line\nsecond "line" \\ tail'
+        caption_short = 'short\n"caption"'
+        batch = _make_batch(
+            [
+                _make_file_item(
+                    path,
+                    caption,
+                    caption_short=caption_short,
+                )
+            ]
+        )
+
+        message = format_caption_debug_log(1, [batch])
+
+        self.assertEqual(len(message.splitlines()), 1)
+        self.assertIn(
+            f'file={json.dumps(basename, ensure_ascii=False)}',
+            message,
+        )
+        self.assertIn(f'caption={json.dumps(caption, ensure_ascii=False)}', message)
+        self.assertIn(
+            f'caption_short={json.dumps(caption_short, ensure_ascii=False)}',
+            message,
+        )
+        self.assertNotIn('first line\nsecond', message)
+
+    def test_returns_none_when_there_are_no_file_items(self):
+        self.assertIsNone(format_caption_debug_log(100, []))
+        self.assertIsNone(format_caption_debug_log(100, [_make_batch([])]))
+
+
+class CaptionLogListenerTest(unittest.TestCase):
+    def test_context_listener_is_restored_when_token_is_reset(self):
+        outer_messages = []
+        inner_messages = []
+        outer_token = set_caption_log_listener(outer_messages.append)
+        try:
+            emit_caption_log('outer before')
+            inner_token = set_caption_log_listener(inner_messages.append)
+            try:
+                emit_caption_log('inner')
+            finally:
+                reset_caption_log_listener(inner_token)
+            emit_caption_log('outer after')
+        finally:
+            reset_caption_log_listener(outer_token)
+
+        self.assertEqual(outer_messages, ['outer before', 'outer after'])
+        self.assertEqual(inner_messages, ['inner'])
+
+    def test_listener_failure_is_non_fatal(self):
+        def failing_listener(_message):
+            raise RuntimeError('listener failed')
+
+        token = set_caption_log_listener(failing_listener)
+        try:
+            emitted = emit_caption_log('caption debug message')
+        finally:
+            reset_caption_log_listener(token)
+
+        self.assertFalse(emitted)
+
+
+class TrainingLoopCaptionLoggingWiringTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.source_path = ROOT / 'jobs' / 'process' / 'BaseSDTrainProcess.py'
+        tree = ast.parse(cls.source_path.read_text(encoding='utf-8'), filename=str(cls.source_path))
+        class_node = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == 'BaseSDTrainProcess'
+        )
+        cls.run_method = next(
+            node
+            for node in class_node.body
+            if isinstance(node, ast.FunctionDef) and node.name == 'run'
+        )
+
+    def test_uses_completed_step_and_all_accumulated_batches_once(self):
+        completed_step_assignments = [
+            node
+            for node in ast.walk(self.run_method)
+            if isinstance(node, ast.Assign)
+            and any(
+                isinstance(target, ast.Name) and target.id == 'completed_step'
+                for target in node.targets
+            )
+        ]
+        self.assertEqual(len(completed_step_assignments), 1)
+        self.assertEqual(
+            ast.unparse(completed_step_assignments[0].value),
+            'self.step_num + 1',
+        )
+
+        format_calls = [
+            node
+            for node in ast.walk(self.run_method)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == 'format_caption_debug_log'
+        ]
+        emit_calls = [
+            node
+            for node in ast.walk(self.run_method)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == 'emit_caption_log'
+        ]
+        self.assertEqual(len(format_calls), 1)
+        self.assertEqual(len(emit_calls), 1)
+        self.assertEqual(
+            [ast.unparse(argument) for argument in format_calls[0].args],
+            ['completed_step', 'batch_list'],
+        )
+
+    def test_skips_oom_and_non_main_process_before_cleanup(self):
+        guard = next(
+            node
+            for node in ast.walk(self.run_method)
+            if isinstance(node, ast.If)
+            and 'should_log_captions' in ast.unparse(node.test)
+        )
+        guard_source = ast.unparse(guard.test)
+        self.assertIn('not did_oom', guard_source)
+        self.assertIn('self.accelerator.is_main_process', guard_source)
+        self.assertIn(
+            'should_log_captions(completed_step, caption_log_interval)',
+            guard_source,
+        )
+
+        train_call = next(
+            node
+            for node in ast.walk(self.run_method)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == 'hook_train_loop'
+        )
+        cleanup_call = next(
+            node
+            for node in ast.walk(self.run_method)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == 'cleanup'
+        )
+        self.assertLess(train_call.lineno, guard.lineno)
+        self.assertLess(guard.lineno, cleanup_call.lineno)
+
+
+class LoggingConfigCaptionIntervalTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.LoggingConfig = _load_logging_config_class()
+
+    def test_defaults_to_disabled_and_accepts_none(self):
+        self.assertEqual(self.LoggingConfig().log_captions_every_n_steps, 0)
+        self.assertEqual(
+            self.LoggingConfig(log_captions_every_n_steps=None).log_captions_every_n_steps,
+            0,
+        )
+
+    def test_accepts_integer_strings_and_integer_valued_floats(self):
+        for raw_value in ('100', '100.0', 100, 100.0):
+            with self.subTest(raw_value=raw_value):
+                config = self.LoggingConfig(log_captions_every_n_steps=raw_value)
+                self.assertEqual(config.log_captions_every_n_steps, 100)
+                self.assertIsInstance(config.log_captions_every_n_steps, int)
+
+    def test_rejects_bool_fraction_negative_and_non_finite_values(self):
+        invalid_values = (
+            True,
+            False,
+            1.5,
+            '1.5',
+            -1,
+            '-1',
+            float('nan'),
+            float('inf'),
+            float('-inf'),
+            'nan',
+            'inf',
+        )
+        for raw_value in invalid_values:
+            with self.subTest(raw_value=raw_value):
+                with self.assertRaises(ValueError):
+                    self.LoggingConfig(log_captions_every_n_steps=raw_value)
+
+
+class FluxTrainUiCaptionLoggingWiringTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.source_path = ROOT / 'flux_train_ui.py'
+        cls.source = cls.source_path.read_text(encoding='utf-8')
+        cls.tree = ast.parse(cls.source, filename=str(cls.source_path))
+        cls.start_training = next(
+            node
+            for node in cls.tree.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == 'start_training'
+        )
+
+    def test_start_training_signature_and_config_assignment(self):
+        argument_names = [argument.arg for argument in self.start_training.args.args]
+        separator_index = argument_names.index('secondary_separator')
+        logging_index = argument_names.index('log_captions_every_n_steps')
+        dataset_index = argument_names.index('dataset_folder')
+        self.assertEqual(logging_index, separator_index + 1)
+        self.assertEqual(dataset_index, logging_index + 1)
+
+        config_assignments = [
+            node
+            for node in ast.walk(self.start_training)
+            if isinstance(node, (ast.Assign, ast.AnnAssign))
+            and any(
+                isinstance(part, ast.Constant)
+                and part.value == 'log_captions_every_n_steps'
+                for part in ast.walk(node)
+            )
+        ]
+        self.assertTrue(config_assignments)
+        assignment_source = '\n'.join(
+            ast.unparse(assignment) for assignment in config_assignments
+        )
+        self.assertIn('int(log_captions_every_n_steps', assignment_source)
+
+    def test_number_control_and_click_input_order(self):
+        number_assignment = next(
+            node
+            for node in ast.walk(self.tree)
+            if isinstance(node, ast.Assign)
+            and any(
+                isinstance(target, ast.Name)
+                and target.id == 'log_captions_every_n_steps'
+                for target in node.targets
+            )
+            and isinstance(node.value, ast.Call)
+        )
+        keyword_values = {
+            keyword.arg: ast.literal_eval(keyword.value)
+            for keyword in number_assignment.value.keywords
+            if keyword.arg in {'value', 'minimum', 'step'}
+        }
+        self.assertEqual(
+            keyword_values,
+            {'value': 0, 'minimum': 0, 'step': 1},
+        )
+
+        then_call = next(
+            node
+            for node in ast.walk(self.tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == 'then'
+            and any(
+                keyword.arg == 'fn'
+                and isinstance(keyword.value, ast.Name)
+                and keyword.value.id == 'start_training'
+                for keyword in node.keywords
+            )
+        )
+        inputs_node = next(
+            keyword.value for keyword in then_call.keywords if keyword.arg == 'inputs'
+        )
+        input_names = [
+            element.id for element in inputs_node.elts if isinstance(element, ast.Name)
+        ]
+        separator_index = input_names.index('secondary_separator')
+        logging_index = input_names.index('log_captions_every_n_steps')
+        dataset_index = input_names.index('dataset_folder')
+        self.assertEqual(logging_index, separator_index + 1)
+        self.assertEqual(dataset_index, logging_index + 1)
+
+    def test_training_is_a_live_generator_with_scoped_listener(self):
+        self.assertTrue(
+            any(isinstance(node, (ast.Yield, ast.YieldFrom)) for node in ast.walk(self.start_training))
+        )
+        called_names = {
+            node.func.id
+            for node in ast.walk(self.start_training)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+        self.assertIn('set_caption_log_listener', called_names)
+        self.assertIn('reset_caption_log_listener', called_names)
+
+    def test_gradio_rejects_invalid_mixed_weights_before_writing_config(self):
+        function_source = ast.unparse(self.start_training)
+        self.assertIn('math.isfinite', function_source)
+        self.assertIn("caption_mode == 'mixed' and mixed_weight_total <= 0", function_source)
+        validation_line = next(
+            node.lineno
+            for node in ast.walk(self.start_training)
+            if isinstance(node, ast.If)
+            and "caption_mode == 'mixed'" in ast.unparse(node.test)
+        )
+        config_line = next(
+            node.lineno
+            for node in ast.walk(self.start_training)
+            if isinstance(node, ast.Assign)
+            and any(
+                isinstance(part, ast.Constant) and part.value == 'mixed_weights'
+                for part in ast.walk(node)
+            )
+        )
+        self.assertLess(validation_line, config_line)
+
+    def test_ai_captioning_filters_uploaded_text_sidecars(self):
+        run_captioning = next(
+            node
+            for node in self.tree.body
+            if isinstance(node, ast.FunctionDef) and node.name == 'run_captioning'
+        )
+        function_source = ast.unparse(run_captioning)
+        self.assertIn('_is_image_file(image)', function_source)
+        self.assertIn('enumerate(uploaded_images)', function_source)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/testing/test_flux_train_ui_dataset.py
+++ b/testing/test_flux_train_ui_dataset.py
@@ -1,0 +1,117 @@
+import ast
+import json
+import os
+from pathlib import Path
+import shutil
+import tempfile
+from types import SimpleNamespace
+import unittest
+
+
+def load_dataset_helpers():
+    """Load only the lightweight dataset helpers, without importing Gradio."""
+    source_path = Path(__file__).resolve().parents[1] / 'flux_train_ui.py'
+    tree = ast.parse(source_path.read_text(encoding='utf-8'), filename=str(source_path))
+    helper_names = {'_is_text_file', '_is_image_file', 'create_dataset'}
+    helper_nodes = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in helper_names
+    ]
+    namespace = {
+        'json': json,
+        'os': os,
+        'shutil': shutil,
+        'uuid': SimpleNamespace(uuid4=lambda: 'test-dataset'),
+    }
+    module = ast.Module(body=helper_nodes, type_ignores=[])
+    exec(compile(module, str(source_path), 'exec'), namespace)
+    return namespace['create_dataset']
+
+
+class FluxTrainUiDatasetTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+        self.uploads = self.root / 'uploads'
+        self.workdir = self.root / 'workdir'
+        self.uploads.mkdir()
+        self.workdir.mkdir()
+        self.create_dataset = load_dataset_helpers()
+
+    def create_from_workdir(self, files, *captions):
+        previous_cwd = os.getcwd()
+        try:
+            os.chdir(self.workdir)
+            relative_destination = self.create_dataset(files, *captions)
+        finally:
+            os.chdir(previous_cwd)
+        return self.workdir / relative_destination
+
+    def test_writes_edited_sidecars_and_preserves_uploaded_mixed_caption(self):
+        first_image = self.uploads / 'first.bmp'
+        second_image = self.uploads / 'second.gif'
+        uploaded_base = self.uploads / 'first.txt'
+        uploaded_nl = self.uploads / 'first_nl.txt'
+        first_image.write_bytes(b'first image')
+        second_image.write_bytes(b'second image')
+        uploaded_base.write_text('uploaded base caption', encoding='utf-8')
+        uploaded_nl.write_text('업로드된 자연어 캡션', encoding='utf-8')
+
+        destination = self.create_from_workdir(
+            [first_image, uploaded_base, uploaded_nl, second_image],
+            '편집된 태그 ||| red hair;;;blue eyes',
+            'AI generated caption',
+        )
+
+        self.assertEqual(
+            (destination / 'first.txt').read_text(encoding='utf-8'),
+            '편집된 태그 ||| red hair;;;blue eyes',
+        )
+        self.assertEqual(
+            (destination / 'first_nl.txt').read_text(encoding='utf-8'),
+            '업로드된 자연어 캡션',
+        )
+        self.assertEqual(
+            (destination / 'second.txt').read_text(encoding='utf-8'),
+            'AI generated caption',
+        )
+
+        metadata = [
+            json.loads(line)
+            for line in (destination / 'metadata.jsonl').read_text(encoding='utf-8').splitlines()
+        ]
+        self.assertEqual(
+            metadata,
+            [
+                {
+                    'file_name': 'first.bmp',
+                    'prompt': '편집된 태그 ||| red hair;;;blue eyes',
+                },
+                {'file_name': 'second.gif', 'prompt': 'AI generated caption'},
+            ],
+        )
+
+    def test_empty_textbox_overwrites_base_caption_but_not_nl_caption(self):
+        image = self.uploads / 'image.tiff'
+        uploaded_base = self.uploads / 'image.txt'
+        uploaded_nl = self.uploads / 'image_nl.txt'
+        image.write_bytes(b'image')
+        uploaded_base.write_text('base caption', encoding='utf-8')
+        uploaded_nl.write_text('natural language caption', encoding='utf-8')
+
+        destination = self.create_from_workdir(
+            [image, uploaded_base, uploaded_nl],
+            '',
+        )
+
+        self.assertEqual((destination / 'image.txt').read_text(encoding='utf-8'), '')
+        self.assertEqual(
+            (destination / 'image_nl.txt').read_text(encoding='utf-8'),
+            'natural language caption',
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/testing/test_mixed_caption_processing.py
+++ b/testing/test_mixed_caption_processing.py
@@ -1,0 +1,311 @@
+import ast
+import math
+import os
+from pathlib import Path
+import random
+from types import SimpleNamespace
+from typing import Dict, List, Union
+import unittest
+from unittest.mock import patch
+
+from toolkit.caption_utils import (
+    drop_caption_tags,
+    expand_secondary_separator,
+    join_caption_sections,
+    select_mixed_caption_selection,
+    shuffle_caption_tags,
+)
+
+
+def _inject_trigger_into_prompt(
+    prompt,
+    trigger=None,
+    to_replace_list=None,
+    add_if_not_present=True,
+):
+    """Lightweight equivalent for source-loading the caption-only method."""
+    trigger = trigger or ''
+    replacements = list(to_replace_list or []) + ['[name]', '[trigger]']
+    output = prompt
+    for replacement in set(replacements):
+        output = output.replace(replacement, trigger)
+    if trigger and add_if_not_present and trigger not in output:
+        output = trigger + ' ' + output
+    return output
+
+
+def _load_mixed_caption_processor():
+    """Load the pure caption method without importing the heavy dataloader stack."""
+    source_path = Path(__file__).resolve().parents[1] / 'toolkit' / 'dataloader_mixins.py'
+    tree = ast.parse(source_path.read_text(encoding='utf-8'), filename=str(source_path))
+    class_node = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == 'CaptionProcessingDTOMixin'
+    )
+    method_node = next(
+        node
+        for node in class_node.body
+        if isinstance(node, ast.FunctionDef) and node.name == '_get_mixed_caption'
+    )
+    namespace = {
+        'drop_caption_tags': drop_caption_tags,
+        'expand_secondary_separator': expand_secondary_separator,
+        'inject_trigger_into_prompt': _inject_trigger_into_prompt,
+        'join_caption_sections': join_caption_sections,
+        'random': random,
+        'shuffle_caption_tags': shuffle_caption_tags,
+    }
+    module = ast.Module(body=[method_node], type_ignores=[])
+    exec(compile(module, str(source_path), 'exec'), namespace)
+    return namespace['_get_mixed_caption']
+
+
+def _load_caption_loader():
+    """Load the sidecar caption loader without importing the heavy dataloader stack."""
+    source_path = Path(__file__).resolve().parents[1] / 'toolkit' / 'dataloader_mixins.py'
+    tree = ast.parse(source_path.read_text(encoding='utf-8'), filename=str(source_path))
+    class_node = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == 'CaptionProcessingDTOMixin'
+    )
+    method_node = next(
+        node
+        for node in class_node.body
+        if isinstance(node, ast.FunctionDef) and node.name == 'load_caption'
+    )
+    namespace = {
+        'Union': Union,
+        'clean_caption': lambda caption: caption.strip(),
+        'os': os,
+        'select_mixed_caption_selection': select_mixed_caption_selection,
+    }
+    module = ast.Module(body=[method_node], type_ignores=[])
+    exec(compile(module, str(source_path), 'exec'), namespace)
+    return namespace['load_caption']
+
+
+PROCESS_MIXED_CAPTION = _load_mixed_caption_processor()
+LOAD_CAPTION = _load_caption_loader()
+
+
+def _load_dataset_config_class():
+    """Load DatasetConfig without importing the training dependency stack."""
+    source_path = Path(__file__).resolve().parents[1] / 'toolkit' / 'config_modules.py'
+    tree = ast.parse(source_path.read_text(encoding='utf-8'), filename=str(source_path))
+    class_node = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == 'DatasetConfig'
+    )
+    namespace = {
+        'ControlTypes': str,
+        'Dict': Dict,
+        'GuidanceType': str,
+        'List': List,
+        'Union': Union,
+        'math': math,
+        'os': os,
+    }
+    module = ast.Module(body=[class_node], type_ignores=[])
+    exec(compile(module, str(source_path), 'exec'), namespace)
+    return namespace['DatasetConfig']
+
+
+DATASET_CONFIG = _load_dataset_config_class()
+
+
+class MixedCaptionProcessingTest(unittest.TestCase):
+    def _make_item(self, variant):
+        weights = {'tags': 40, 'nl': 30, 'tags_nl': 20, 'nl_tags': 10}
+        with patch('toolkit.caption_utils.random.choices', return_value=[variant]):
+            selection = select_mixed_caption_selection(
+                'fixed ||| a, b;;;c, d',
+                'A woman, standing outdoors.',
+                weights,
+                '|||',
+            )
+        config = SimpleNamespace(
+            token_dropout_rate=0.5,
+            cache_text_embeddings=False,
+            keep_tokens=0,
+            secondary_separator=';;;',
+            random_triggers=[],
+            random_triggers_max=1,
+            shuffle_caption=True,
+        )
+        return SimpleNamespace(
+            mixed_caption_selection=selection,
+            dataset_config=config,
+        )
+
+    def test_shuffle_and_dropout_only_transform_tags_in_every_mixed_variant(self):
+        expected = {
+            'tags': 'fixed, b, c, a',
+            'nl': 'fixed, A woman, standing outdoors.',
+            'tags_nl': 'fixed, b, c, a, A woman, standing outdoors.',
+            'nl_tags': 'fixed, A woman, standing outdoors., b, c, a',
+        }
+
+        for variant, expected_caption in expected.items():
+            with self.subTest(variant=variant):
+                item = self._make_item(variant)
+                with patch(
+                    'toolkit.caption_utils.random.random',
+                    side_effect=[0.9, 0.9, 0.1],
+                ), patch(
+                    'toolkit.caption_utils.random.shuffle',
+                    side_effect=lambda groups: groups.reverse(),
+                ):
+                    caption = PROCESS_MIXED_CAPTION(item)
+
+                self.assertEqual(caption, expected_caption)
+
+    def test_trigger_placeholder_in_nl_is_replaced_without_moving_nl(self):
+        item = self._make_item('nl')
+        item.dataset_config.token_dropout_rate = 1.0
+
+        with patch('toolkit.caption_utils.random.shuffle', side_effect=lambda groups: groups.reverse()):
+            caption = PROCESS_MIXED_CAPTION(
+                item,
+                trigger='subject',
+                to_replace_list=['A woman'],
+                add_if_not_present=True,
+            )
+
+        self.assertEqual(caption, 'fixed, subject, standing outdoors.')
+
+    def test_missing_mixed_caption_still_receives_required_trigger(self):
+        weights = {'tags': 40, 'nl': 30, 'tags_nl': 20, 'nl_tags': 10}
+        selection = select_mixed_caption_selection('', '', weights, '|||')
+        item = SimpleNamespace(
+            mixed_caption_selection=selection,
+            dataset_config=SimpleNamespace(
+                token_dropout_rate=1.0,
+                cache_text_embeddings=False,
+                keep_tokens=0,
+                secondary_separator=';;;',
+                random_triggers=[],
+                random_triggers_max=1,
+                shuffle_caption=True,
+            ),
+        )
+
+        caption = PROCESS_MIXED_CAPTION(
+            item,
+            trigger='subject',
+            add_if_not_present=True,
+        )
+
+        self.assertEqual(caption, 'subject')
+
+    def test_tags_nl_trigger_stays_before_random_tags_after_full_dropout(self):
+        weights = {'tags': 0, 'nl': 0, 'tags_nl': 1, 'nl_tags': 0}
+        with patch('toolkit.caption_utils.random.choices', return_value=['tags_nl']):
+            selection = select_mixed_caption_selection(
+                'tag one',
+                'Natural language caption.',
+                weights,
+            )
+        item = SimpleNamespace(
+            mixed_caption_selection=selection,
+            dataset_config=SimpleNamespace(
+                token_dropout_rate=1.0,
+                cache_text_embeddings=False,
+                keep_tokens=0,
+                secondary_separator=None,
+                random_triggers=['random tag'],
+                random_triggers_max=1,
+                shuffle_caption=False,
+            ),
+        )
+
+        caption = PROCESS_MIXED_CAPTION(
+            item,
+            trigger='subject',
+            add_if_not_present=True,
+        )
+
+        self.assertEqual(caption, 'subject, random tag, Natural language caption.')
+
+    def test_separator_only_tags_caption_is_semantically_empty(self):
+        weights = {'tags': 40, 'nl': 30, 'tags_nl': 20, 'nl_tags': 10}
+
+        selection = select_mixed_caption_selection('|||', '', weights, '|||')
+
+        self.assertEqual(selection.render(), '')
+        self.assertIsNone(selection.keep_tokens_separator)
+
+    def test_mixed_weights_reject_non_finite_and_non_numeric_values(self):
+        invalid_weights = (
+            {'tags': float('nan')},
+            {'tags': float('inf')},
+            {'tags': float('-inf')},
+            {'tags': 'not-a-number'},
+            {
+                'tags': 1e308,
+                'nl': 1e308,
+                'tags_nl': 1e308,
+                'nl_tags': 1e308,
+            },
+        )
+
+        for mixed_weights in invalid_weights:
+            with self.subTest(mixed_weights=mixed_weights):
+                with self.assertRaisesRegex(ValueError, 'finite numeric values'):
+                    DATASET_CONFIG(caption_mode='mixed', mixed_weights=mixed_weights)
+
+    def test_mixed_variant_is_reselected_each_time_item_is_loaded(self):
+        with self.subTest('sidecar sources are reused without pinning the variant'):
+            from tempfile import TemporaryDirectory
+
+            with TemporaryDirectory() as temp_dir:
+                image_path = Path(temp_dir) / 'image.png'
+                image_path.write_bytes(b'not needed by caption loader')
+                image_path.with_suffix('.txt').write_text('tag one, tag two', encoding='utf-8')
+                (Path(temp_dir) / 'image_nl.txt').write_text(
+                    'A natural language caption.',
+                    encoding='utf-8',
+                )
+
+                item = SimpleNamespace(
+                    path=str(image_path),
+                    raw_caption=None,
+                    raw_caption_short=None,
+                    caption=None,
+                    caption_short=None,
+                    mixed_caption_selection=None,
+                    mixed_caption_sources=None,
+                    dataset_config=SimpleNamespace(
+                        caption_ext='.txt',
+                        caption_mode='mixed',
+                        mixed_weights={
+                            'tags': 40,
+                            'nl': 30,
+                            'tags_nl': 20,
+                            'nl_tags': 10,
+                        },
+                        keep_tokens_separator=None,
+                        default_caption=None,
+                        use_short_captions=False,
+                    ),
+                )
+                item.get_caption = lambda short_caption=False: item.raw_caption
+
+                with patch(
+                    'toolkit.caption_utils.random.choices',
+                    side_effect=[['tags'], ['nl']],
+                ) as choices_mock:
+                    LOAD_CAPTION(item)
+                    first_caption = item.caption
+                    LOAD_CAPTION(item)
+                    second_caption = item.caption
+
+                self.assertEqual(first_caption, 'tag one, tag two')
+                self.assertEqual(second_caption, 'A natural language caption.')
+                self.assertEqual(choices_mock.call_count, 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/testing/test_shuffle_caption.py
+++ b/testing/test_shuffle_caption.py
@@ -1,0 +1,196 @@
+import unittest
+from unittest.mock import patch
+
+from toolkit.caption_utils import (
+    drop_caption_tags,
+    expand_secondary_separator,
+    join_caption_sections,
+    select_mixed_caption,
+    shuffle_caption_tags,
+    split_caption_at_separator,
+)
+
+
+class ShuffleCaptionTest(unittest.TestCase):
+    def test_shuffle_caption_reorders_comma_separated_tags(self):
+        with patch('toolkit.caption_utils.random.shuffle', side_effect=lambda tags: tags.reverse()):
+            caption = shuffle_caption_tags('a, b, c, d, e')
+
+        self.assertEqual(caption, 'e, d, c, b, a')
+
+    def test_shuffle_caption_is_randomized_for_each_caption_load(self):
+        orders = [
+            ['b', 'd', 'a', 'e', 'c'],
+            ['b', 'c', 'a', 'd', 'e'],
+        ]
+
+        def use_next_order(tags):
+            tags[:] = orders.pop(0)
+
+        with patch('toolkit.caption_utils.random.shuffle', side_effect=use_next_order):
+            first = shuffle_caption_tags('a, b, c, d, e')
+            second = shuffle_caption_tags('a, b, c, d, e')
+
+        self.assertEqual(first, 'b, d, a, e, c')
+        self.assertEqual(second, 'b, c, a, d, e')
+
+    def test_separator_protects_prefix_from_tag_dropout(self):
+        protected, processable, has_separator = split_caption_at_separator(
+            'character name, portrait ||| red hair, blue eyes', '|||'
+        )
+
+        processable = drop_caption_tags(processable, dropout_rate=1.0)
+        caption = join_caption_sections(protected, processable)
+
+        self.assertTrue(has_separator)
+        self.assertEqual(caption, 'character name, portrait')
+        self.assertNotIn('|||', caption)
+
+    def test_separator_protects_prefix_from_shuffle(self):
+        protected, processable, _ = split_caption_at_separator(
+            'character name, portrait ||| red hair, blue eyes', '|||'
+        )
+
+        with patch('toolkit.caption_utils.random.shuffle', side_effect=lambda tags: tags.reverse()):
+            processable = shuffle_caption_tags(processable)
+        caption = join_caption_sections(protected, processable)
+
+        self.assertEqual(caption, 'character name, portrait, blue eyes, red hair')
+
+    def test_separator_splits_only_at_first_occurrence(self):
+        protected, processable, has_separator = split_caption_at_separator(
+            'fixed ||| tag one ||| tag two', '|||'
+        )
+
+        self.assertTrue(has_separator)
+        self.assertEqual(protected.strip(), 'fixed')
+        self.assertEqual(processable.strip(), 'tag one ||| tag two')
+
+    def test_secondary_separator_shuffles_group_as_one_unit(self):
+        def use_group_order(groups):
+            a, b, cde, f = groups
+            groups[:] = [f, b, cde, a]
+
+        with patch('toolkit.caption_utils.random.shuffle', side_effect=use_group_order):
+            caption = shuffle_caption_tags('a, b, c;;;d;;;e, f', ';;;')
+        caption = expand_secondary_separator(caption, ';;;')
+
+        self.assertEqual(caption, 'f, b, c, d, e, a')
+
+    def test_secondary_separator_uses_one_dropout_decision_per_group(self):
+        with patch(
+            'toolkit.caption_utils.random.random',
+            side_effect=[0.5, 0.5, 0.05, 0.5],
+        ) as random_mock:
+            caption = drop_caption_tags(
+                'a, b, c;;;d;;;e, f',
+                dropout_rate=0.1,
+                secondary_separator=';;;',
+            )
+        caption = expand_secondary_separator(caption, ';;;')
+
+        self.assertEqual(random_mock.call_count, 4)
+        self.assertEqual(caption, 'a, b, f')
+
+    def test_keep_and_secondary_separators_work_together(self):
+        protected, processable, _ = split_caption_at_separator(
+            'fixed one, fixed two ||| a, b, c;;;d;;;e, f', '|||'
+        )
+
+        with patch('toolkit.caption_utils.random.shuffle', side_effect=lambda groups: groups.reverse()):
+            processable = shuffle_caption_tags(processable, ';;;')
+        processable = expand_secondary_separator(processable, ';;;')
+        caption = join_caption_sections(protected, processable)
+
+        self.assertEqual(caption, 'fixed one, fixed two, f, c, d, e, b, a')
+
+    def test_mixed_caption_variants_use_configured_weights(self):
+        weights = {
+            'tags': 40,
+            'nl': 30,
+            'tags_nl': 20,
+            'nl_tags': 10,
+        }
+        expected = {
+            'tags': 'tag1, tag2, tag3',
+            'nl': 'A person standing outside.',
+            'tags_nl': 'tag1, tag2, tag3, A person standing outside.',
+            'nl_tags': 'A person standing outside., tag1, tag2, tag3',
+        }
+
+        for variant, expected_caption in expected.items():
+            with self.subTest(variant=variant):
+                with patch(
+                    'toolkit.caption_utils.random.choices',
+                    return_value=[variant],
+                ) as choices_mock:
+                    caption = select_mixed_caption(
+                        'tag1, tag2, tag3',
+                        'A person standing outside.',
+                        weights,
+                    )
+
+                self.assertEqual(caption, expected_caption)
+                choices_mock.assert_called_once_with(
+                    ['tags', 'nl', 'tags_nl', 'nl_tags'],
+                    weights=[40, 30, 20, 10],
+                    k=1,
+                )
+
+    def test_mixed_caption_falls_back_to_available_file(self):
+        weights = {'tags': 0, 'nl': 100, 'tags_nl': 0, 'nl_tags': 0}
+
+        with patch('toolkit.caption_utils.random.choices') as choices_mock:
+            tags_only = select_mixed_caption('tag1, tag2', '', weights)
+            nl_only = select_mixed_caption('', 'A person standing outside.', weights)
+
+        self.assertEqual(tags_only, 'tag1, tag2')
+        self.assertEqual(nl_only, 'A person standing outside.')
+        choices_mock.assert_not_called()
+
+    def test_mixed_caption_keeps_protected_tags_first_in_every_variant(self):
+        tags = 'tag1, tag2, tag3 ||| tag4, tag5'
+        nl = 'A person standing outside.'
+        weights = {'tags': 40, 'nl': 30, 'tags_nl': 20, 'nl_tags': 10}
+        expected = {
+            'tags': 'tag1, tag2, tag3, tag4, tag5',
+            'nl': 'tag1, tag2, tag3, A person standing outside.',
+            'tags_nl': 'tag1, tag2, tag3, tag4, tag5, A person standing outside.',
+            'nl_tags': 'tag1, tag2, tag3, A person standing outside., tag4, tag5',
+        }
+
+        for variant, expected_caption in expected.items():
+            with self.subTest(variant=variant):
+                with patch('toolkit.caption_utils.random.choices', return_value=[variant]):
+                    selected = select_mixed_caption(tags, nl, weights, '|||')
+                protected, processable, has_separator = split_caption_at_separator(selected, '|||')
+                caption = join_caption_sections(protected, processable)
+
+                self.assertTrue(has_separator)
+                self.assertEqual(caption, expected_caption)
+
+    def test_mixed_caption_protected_tags_survive_suffix_processing(self):
+        weights = {'tags': 0, 'nl': 0, 'tags_nl': 0, 'nl_tags': 1}
+        with patch('toolkit.caption_utils.random.choices', return_value=['nl_tags']):
+            selected = select_mixed_caption(
+                'tag1, tag2, tag3 ||| tag4, tag5',
+                'A person standing outside.',
+                weights,
+                '|||',
+            )
+        protected, processable, _ = split_caption_at_separator(selected, '|||')
+
+        dropped = drop_caption_tags(processable, dropout_rate=1.0)
+        dropout_caption = join_caption_sections(protected, dropped)
+        with patch('toolkit.caption_utils.random.shuffle', side_effect=lambda tags: tags.reverse()):
+            shuffled = shuffle_caption_tags(processable)
+        shuffle_caption = join_caption_sections(protected, shuffled)
+
+        self.assertEqual(dropout_caption, 'tag1, tag2, tag3')
+        self.assertEqual(
+            shuffle_caption,
+            'tag1, tag2, tag3, tag5, tag4, A person standing outside.',
+        )
+
+if __name__ == '__main__':
+    unittest.main()

--- a/toolkit/caption_logging.py
+++ b/toolkit/caption_logging.py
@@ -1,0 +1,96 @@
+"""Helpers for reporting the captions used by training batches."""
+
+from __future__ import annotations
+
+import json
+import os
+from contextvars import ContextVar, Token
+from typing import Callable, Iterable, Optional
+
+
+CaptionLogListener = Callable[[str], None]
+
+_caption_log_listener: ContextVar[Optional[CaptionLogListener]] = ContextVar(
+    "caption_log_listener",
+    default=None,
+)
+
+
+def should_log_captions(completed_step: int, interval: int) -> bool:
+    """Return whether a positive, completed step matches the log interval."""
+    return completed_step > 0 and interval > 0 and completed_step % interval == 0
+
+
+def _json_string(value: object) -> str:
+    """Render a value as a compact JSON string suitable for a one-line log."""
+    if value is not None and not isinstance(value, str):
+        value = str(value)
+    return json.dumps(value, ensure_ascii=False)
+
+
+def format_caption_debug_log(
+    completed_step: int,
+    batches: Iterable[object],
+) -> Optional[str]:
+    """Format every final caption in the supplied training microbatches."""
+    batch_list = list(batches)
+    total_microbatches = len(batch_list)
+    lines = []
+
+    for microbatch_index, batch in enumerate(batch_list, start=1):
+        file_items = getattr(batch, "file_items", None)
+        if not file_items:
+            continue
+
+        cached_embedding = getattr(batch, "prompt_embeds", None) is not None
+        total_items = len(file_items)
+        for item_index, item in enumerate(file_items, start=1):
+            path = getattr(item, "path", "")
+            try:
+                basename = os.path.basename(os.fspath(path))
+            except TypeError:
+                basename = os.path.basename(str(path))
+
+            caption = getattr(item, "caption", None)
+            caption_short = getattr(item, "caption_short", None)
+            is_reg = bool(getattr(item, "is_reg", False))
+
+            line = (
+                f"[caption-debug] step={completed_step} "
+                f"microbatch={microbatch_index}/{total_microbatches} "
+                f"item={item_index}/{total_items} "
+                f"reg={json.dumps(is_reg)} "
+                f"cached_embedding={json.dumps(cached_embedding)} "
+                f"file={_json_string(basename)} "
+                f"caption={_json_string(caption)}"
+            )
+            if caption_short is not None and caption_short != caption:
+                line += f" caption_short={_json_string(caption_short)}"
+            lines.append(line)
+
+    return "\n".join(lines) if lines else None
+
+
+def set_caption_log_listener(listener: Optional[CaptionLogListener]) -> Token:
+    """Install a listener in the current context and return its reset token."""
+    if listener is not None and not callable(listener):
+        raise TypeError("caption log listener must be callable or None")
+    return _caption_log_listener.set(listener)
+
+
+def reset_caption_log_listener(token: Token) -> None:
+    """Restore the listener value represented by a previous set token."""
+    _caption_log_listener.reset(token)
+
+
+def emit_caption_log(message: str) -> bool:
+    """Send a formatted caption log block to the current context listener."""
+    listener = _caption_log_listener.get()
+    if listener is None:
+        return False
+    try:
+        listener(message)
+    except Exception:
+        # A disconnected or faulty debug UI must never interrupt training.
+        return False
+    return True

--- a/toolkit/caption_utils.py
+++ b/toolkit/caption_utils.py
@@ -1,0 +1,192 @@
+import random
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+
+MIXED_CAPTION_VARIANTS = ('tags', 'nl', 'tags_nl', 'nl_tags')
+
+
+def _join_with_keep_separator(protected: str, processable: str, separator: str) -> str:
+    """Keep a protected prefix marked until later caption processing."""
+    return f'{protected.strip()} {separator} {processable.strip()}'.strip()
+
+
+def _join_caption_parts(*parts: str) -> str:
+    """Join ordered caption sections while normalizing their comma boundaries."""
+    caption = ''
+    for part in parts:
+        caption = join_caption_sections(caption, part)
+    return caption
+
+
+@dataclass(frozen=True)
+class MixedCaptionSelection:
+    """A mixed-caption choice whose tag and natural-language sections stay distinct."""
+
+    variant: str
+    protected_tags: str
+    processable_tags: str
+    nl_caption: str
+    keep_tokens_separator: Optional[str] = None
+
+    @property
+    def includes_tags(self) -> bool:
+        return self.variant in ('tags', 'tags_nl', 'nl_tags')
+
+    @property
+    def includes_nl(self) -> bool:
+        return self.variant in ('nl', 'tags_nl', 'nl_tags')
+
+    def render(self) -> str:
+        """Render the selected raw caption, retaining its keep-token boundary."""
+        tags = self.processable_tags if self.includes_tags else ''
+        nl_caption = self.nl_caption if self.includes_nl else ''
+        if self.variant == 'tags':
+            processable = tags
+        elif self.variant == 'nl':
+            processable = nl_caption
+        elif self.variant == 'tags_nl':
+            processable = _join_caption_parts(tags, nl_caption)
+        else:
+            processable = _join_caption_parts(nl_caption, tags)
+
+        if self.keep_tokens_separator is not None:
+            return _join_with_keep_separator(
+                self.protected_tags,
+                processable,
+                self.keep_tokens_separator,
+            )
+        return processable
+
+    def render_processed(
+        self,
+        protected_tags: str,
+        processable_tags: str,
+        nl_caption: str,
+        extra_tags: str = '',
+    ) -> str:
+        """Render processed tags around an untouched natural-language section."""
+        if self.variant == 'tags':
+            parts = (protected_tags, processable_tags, extra_tags)
+        elif self.variant == 'nl':
+            parts = (protected_tags, nl_caption, extra_tags)
+        elif self.variant == 'tags_nl':
+            parts = (protected_tags, processable_tags, extra_tags, nl_caption)
+        else:
+            parts = (protected_tags, nl_caption, processable_tags, extra_tags)
+        return _join_caption_parts(*parts)
+
+
+def select_mixed_caption_selection(
+    tags_caption: str,
+    nl_caption: str,
+    weights: Dict[str, float],
+    keep_tokens_separator: Optional[str] = None,
+) -> MixedCaptionSelection:
+    """Select a weighted variant without flattening its tags and natural language."""
+    tags_caption = tags_caption.strip()
+    nl_caption = nl_caption.strip()
+    protected, processable_tags, has_keep_separator = split_caption_at_separator(
+        tags_caption, keep_tokens_separator
+    )
+    has_tags = bool(protected.strip() or processable_tags.strip())
+
+    if not has_tags:
+        selected = 'nl'
+    elif not nl_caption:
+        selected = 'tags'
+    else:
+        variant_names = list(MIXED_CAPTION_VARIANTS)
+        selected = random.choices(
+            variant_names,
+            weights=[weights[name] for name in variant_names],
+            k=1,
+        )[0]
+
+    return MixedCaptionSelection(
+        variant=selected,
+        protected_tags=protected.strip(),
+        processable_tags=processable_tags.strip(),
+        nl_caption=nl_caption,
+        keep_tokens_separator=(
+            keep_tokens_separator if has_keep_separator and has_tags else None
+        ),
+    )
+
+
+def select_mixed_caption(
+    tags_caption: str,
+    nl_caption: str,
+    weights: Dict[str, float],
+    keep_tokens_separator: Optional[str] = None,
+) -> str:
+    """Select one weighted caption variant, falling back when one side is absent."""
+    return select_mixed_caption_selection(
+        tags_caption,
+        nl_caption,
+        weights,
+        keep_tokens_separator,
+    ).render()
+
+
+def _get_caption_tag_groups(caption: str, secondary_separator: Optional[str] = None):
+    """Return comma-separated units while retaining secondary tag groups."""
+    groups = [group.strip() for group in caption.split(',') if group.strip()]
+    if secondary_separator:
+        normalized_groups = []
+        for group in groups:
+            tags = [tag.strip() for tag in group.split(secondary_separator) if tag.strip()]
+            if tags:
+                normalized_groups.append(secondary_separator.join(tags))
+        groups = normalized_groups
+    return groups
+
+
+def shuffle_caption_tags(caption: str, secondary_separator: Optional[str] = None) -> str:
+    """Shuffle comma-separated tags or secondary-separated tag groups."""
+    groups = _get_caption_tag_groups(caption, secondary_separator)
+    random.shuffle(groups)
+    return ', '.join(groups)
+
+
+def drop_caption_tags(
+    caption: str,
+    dropout_rate: float,
+    keep_tokens: int = 0,
+    secondary_separator: Optional[str] = None,
+) -> str:
+    """Randomly drop tags or secondary-separated tag groups."""
+    groups = _get_caption_tag_groups(caption, secondary_separator)
+    kept_groups = []
+    for index, group in enumerate(groups):
+        if index < keep_tokens:
+            kept_groups.append(group)
+        elif dropout_rate < 1.0 and random.random() > dropout_rate:
+            kept_groups.append(group)
+    return ', '.join(kept_groups)
+
+
+def expand_secondary_separator(caption: str, secondary_separator: Optional[str]) -> str:
+    """Expand grouped tags into a normal comma-separated training caption."""
+    if not secondary_separator:
+        return caption
+    groups = _get_caption_tag_groups(caption, secondary_separator)
+    tags = []
+    for group in groups:
+        tags.extend(tag.strip() for tag in group.split(secondary_separator) if tag.strip())
+    return ', '.join(tags)
+
+
+def split_caption_at_separator(caption: str, separator: Optional[str]) -> Tuple[str, str, bool]:
+    """Split a caption into protected and processable sections."""
+    if separator and separator in caption:
+        protected, processable = caption.split(separator, 1)
+        return protected, processable, True
+    return '', caption, False
+
+
+def join_caption_sections(protected: str, processable: str) -> str:
+    """Join caption sections after removing their separator boundary."""
+    protected = protected.strip().rstrip(',').rstrip()
+    processable = processable.strip().lstrip(',').lstrip()
+    return ', '.join(part for part in (protected, processable) if part)

--- a/toolkit/config_modules.py
+++ b/toolkit/config_modules.py
@@ -1,3 +1,4 @@
+import math
 import os
 import time
 from typing import List, Optional, Literal, Tuple, Union, TYPE_CHECKING, Dict
@@ -35,6 +36,28 @@ class SaveConfig:
 class LoggingConfig:
     def __init__(self, **kwargs):
         self.log_every: int = kwargs.get('log_every', 100)
+        raw_caption_log_interval = kwargs.get('log_captions_every_n_steps', 0)
+        if raw_caption_log_interval is None:
+            raw_caption_log_interval = 0
+        if isinstance(raw_caption_log_interval, bool):
+            raise ValueError(
+                'log_captions_every_n_steps must be a finite whole number greater than or equal to 0'
+            )
+        try:
+            caption_log_interval = float(raw_caption_log_interval)
+        except (OverflowError, TypeError, ValueError) as exc:
+            raise ValueError(
+                'log_captions_every_n_steps must be a finite whole number greater than or equal to 0'
+            ) from exc
+        if (
+            not math.isfinite(caption_log_interval)
+            or caption_log_interval < 0
+            or not caption_log_interval.is_integer()
+        ):
+            raise ValueError(
+                'log_captions_every_n_steps must be a finite whole number greater than or equal to 0'
+            )
+        self.log_captions_every_n_steps: int = int(caption_log_interval)
         self.verbose: bool = kwargs.get('verbose', False)
         self.use_wandb: bool = kwargs.get('use_wandb', False)
         self.use_ui_logger: bool = kwargs.get('use_ui_logger', False)
@@ -906,6 +929,39 @@ class DatasetConfig:
         # if caption_ext doesnt start with a dot, add it
         if self.caption_ext and not self.caption_ext.startswith('.'):
             self.caption_ext = '.' + self.caption_ext
+        self.caption_mode: str = str(kwargs.get('caption_mode', 'single')).lower()
+        if self.caption_mode not in ['single', 'mixed']:
+            raise ValueError(
+                f"caption_mode must be 'single' or 'mixed', got {self.caption_mode}"
+            )
+        default_mixed_weights = {
+            'tags': 40.0,
+            'nl': 30.0,
+            'tags_nl': 20.0,
+            'nl_tags': 10.0,
+        }
+        raw_mixed_weights = kwargs.get('mixed_weights', None)
+        if raw_mixed_weights is None:
+            raw_mixed_weights = default_mixed_weights
+        if not isinstance(raw_mixed_weights, dict):
+            raise ValueError('mixed_weights must be a mapping')
+        try:
+            self.mixed_weights: Dict[str, float] = {
+                key: float(raw_mixed_weights.get(key, 0.0))
+                for key in default_mixed_weights
+            }
+        except (OverflowError, TypeError, ValueError) as exc:
+            raise ValueError('mixed_weights must contain finite numeric values') from exc
+        mixed_weight_total = sum(self.mixed_weights.values())
+        if (
+            any(not math.isfinite(weight) for weight in self.mixed_weights.values())
+            or not math.isfinite(mixed_weight_total)
+        ):
+            raise ValueError('mixed_weights must contain finite numeric values')
+        if any(weight < 0 for weight in self.mixed_weights.values()):
+            raise ValueError('mixed_weights cannot contain negative values')
+        if self.caption_mode == 'mixed' and mixed_weight_total <= 0:
+            raise ValueError('mixed_weights must contain at least one positive value')
         self.random_scale: bool = kwargs.get('random_scale', False)
         self.random_crop: bool = kwargs.get('random_crop', False)
         self.resolution: int = kwargs.get('resolution', 512)
@@ -916,9 +972,21 @@ class DatasetConfig:
         self.prior_reg: bool = kwargs.get('prior_reg', False)
         self.network_weight: float = float(kwargs.get('network_weight', 1.0))
         self.token_dropout_rate: float = float(kwargs.get('token_dropout_rate', 0.0))
-        self.shuffle_tokens: bool = kwargs.get('shuffle_tokens', False)
+        # ``shuffle_tokens`` is the legacy name for caption tag shuffling.
+        # Keep accepting it so existing configs continue to work, while using
+        # the clearer ``shuffle_caption`` name for new configs and the UI.
+        self.shuffle_caption: bool = kwargs.get(
+            'shuffle_caption', kwargs.get('shuffle_tokens', False)
+        )
+        self.shuffle_tokens: bool = self.shuffle_caption
         self.caption_dropout_rate: float = float(kwargs.get('caption_dropout_rate', 0.0))
         self.keep_tokens: int = kwargs.get('keep_tokens', 0)  # #of first tokens to always keep unless caption dropped
+        self.keep_tokens_separator: str = kwargs.get('keep_tokens_separator', None)
+        if self.keep_tokens_separator == '':
+            self.keep_tokens_separator = None
+        self.secondary_separator: str = kwargs.get('secondary_separator', None)
+        if self.secondary_separator == '':
+            self.secondary_separator = None
         self.flip_x: bool = kwargs.get('flip_x', False)
         self.flip_y: bool = kwargs.get('flip_y', False)
         self.augments: List[str] = kwargs.get('augments', [])

--- a/toolkit/dataloader_mixins.py
+++ b/toolkit/dataloader_mixins.py
@@ -19,6 +19,15 @@ from transformers import CLIPImageProcessor, CLIPVisionModelWithProjection, Sigl
 from toolkit.audio.preserve_pitch import time_stretch_preserve_pitch
 from toolkit.basic import flush, value_map
 from toolkit.buckets import get_bucket_for_image_size, get_resolution
+from toolkit.caption_utils import (
+    MixedCaptionSelection,
+    drop_caption_tags,
+    expand_secondary_separator,
+    join_caption_sections,
+    select_mixed_caption_selection,
+    shuffle_caption_tags,
+    split_caption_at_separator,
+)
 from toolkit.config_modules import ControlTypes
 from toolkit.control_generator import ControlGenerator
 from toolkit.metadata import get_meta_for_safetensors
@@ -316,6 +325,8 @@ class CaptionProcessingDTOMixin:
             self.raw_caption_short: str = None
             self.caption: str = None
             self.caption_short: str = None
+            self.mixed_caption_selection: Union[MixedCaptionSelection, None] = None
+            self.mixed_caption_sources: Union[tuple, None] = None
 
             dataset_config: DatasetConfig = kwargs.get('dataset_config', None)
             self.extra_values: List[float] = dataset_config.extra_values
@@ -324,9 +335,21 @@ class CaptionProcessingDTOMixin:
     # todo allow for loading from sd-scripts style dict
     def load_caption(self: 'FileItemDTO', caption_dict: Union[dict, None]=None):
         if self.raw_caption is not None:
-            # we already loaded it
-            pass
+            # Sidecar contents are cached on the DTO, but mixed variants must
+            # be selected again every time the item is loaded so configured
+            # weights apply throughout training instead of only once.
+            if self.mixed_caption_sources is not None:
+                tags_prompt, nl_prompt = self.mixed_caption_sources
+                self.mixed_caption_selection = select_mixed_caption_selection(
+                    tags_prompt,
+                    nl_prompt,
+                    self.dataset_config.mixed_weights,
+                    self.dataset_config.keep_tokens_separator,
+                )
+                self.raw_caption = self.mixed_caption_selection.render()
         elif caption_dict is not None and self.path in caption_dict and "caption" in caption_dict[self.path]:
+            self.mixed_caption_selection = None
+            self.mixed_caption_sources = None
             self.raw_caption = caption_dict[self.path]["caption"]
             if 'caption_short' in caption_dict[self.path]:
                 self.raw_caption_short = caption_dict[self.path]["caption_short"]
@@ -337,31 +360,151 @@ class CaptionProcessingDTOMixin:
             path_no_ext = os.path.splitext(self.path)[0]
             prompt_ext = self.dataset_config.caption_ext
             prompt_path = path_no_ext + prompt_ext
+            nl_prompt_path = path_no_ext + '_nl' + prompt_ext
             short_caption = None
 
             if os.path.exists(prompt_path):
                 with open(prompt_path, 'r', encoding='utf-8') as f:
                     prompt = f.read()
-                    short_caption = None
                     prompt = clean_caption(prompt)
-                    if short_caption is not None:
-                        short_caption = clean_caption(short_caption)
-                    
-                    if prompt.strip() == '' and self.dataset_config.default_caption is not None:
-                        prompt = self.dataset_config.default_caption
             else:
                 prompt = ''
-                if self.dataset_config.default_caption is not None:
-                    prompt = self.dataset_config.default_caption
+
+            mixed_caption_selection = None
+            if self.dataset_config.caption_mode == 'mixed':
+                if os.path.exists(nl_prompt_path):
+                    with open(nl_prompt_path, 'r', encoding='utf-8') as f:
+                        nl_prompt = clean_caption(f.read())
+                else:
+                    nl_prompt = ''
+                mixed_caption_selection = select_mixed_caption_selection(
+                    prompt,
+                    nl_prompt,
+                    self.dataset_config.mixed_weights,
+                    self.dataset_config.keep_tokens_separator,
+                )
+                self.mixed_caption_sources = (prompt, nl_prompt)
+                prompt = mixed_caption_selection.render()
+
+            if prompt.strip() == '' and self.dataset_config.default_caption is not None:
+                prompt = self.dataset_config.default_caption
+                # A default caption is not a tags/_nl pair, so process it via
+                # the unchanged single-caption path.
+                mixed_caption_selection = None
+                self.mixed_caption_sources = None
 
             if short_caption is None:
                 short_caption = self.dataset_config.default_caption
             self.raw_caption = prompt
             self.raw_caption_short = short_caption
+            self.mixed_caption_selection = mixed_caption_selection
 
         self.caption = self.get_caption()
         if self.raw_caption_short is not None:
             self.caption_short = self.get_caption(short_caption=True)
+
+    def _get_mixed_caption(
+            self: 'FileItemDTO',
+            trigger=None,
+            to_replace_list=None,
+            add_if_not_present=False,
+    ):
+        """Process only the tag section of a selected mixed caption."""
+        selection = self.mixed_caption_selection
+        protected_tags = selection.protected_tags
+        processable_tags = selection.processable_tags if selection.includes_tags else ''
+        nl_caption = selection.nl_caption if selection.includes_nl else ''
+
+        if self.dataset_config.token_dropout_rate > 0 and not self.dataset_config.cache_text_embeddings:
+            processable_tags = drop_caption_tags(
+                processable_tags,
+                self.dataset_config.token_dropout_rate,
+                self.dataset_config.keep_tokens,
+                self.dataset_config.secondary_separator,
+            )
+
+        # Replace trigger placeholders in every selected section, but decide
+        # where to auto-inject a missing trigger only after inspecting all of
+        # them together. Copy custom replacement lists because the legacy
+        # helper mutates a provided list.
+        def replace_trigger(section):
+            replacements = list(to_replace_list) if to_replace_list is not None else None
+            return inject_trigger_into_prompt(
+                section,
+                trigger,
+                replacements,
+                add_if_not_present=False,
+            )
+
+        protected_tags = replace_trigger(protected_tags)
+        processable_tags = replace_trigger(processable_tags)
+        nl_caption = replace_trigger(nl_caption)
+
+        if (
+            trigger is not None
+            and trigger.strip() != ''
+            and add_if_not_present
+            and not any(
+                trigger in section
+                for section in (protected_tags, processable_tags, nl_caption)
+            )
+        ):
+            def prepend_trigger(section):
+                return f'{trigger} {section}'.rstrip()
+
+            if selection.keep_tokens_separator is not None:
+                protected_tags = prepend_trigger(protected_tags)
+            elif selection.variant in ('nl', 'nl_tags') and nl_caption:
+                nl_caption = prepend_trigger(nl_caption)
+            elif selection.variant in ('tags', 'tags_nl'):
+                processable_tags = prepend_trigger(processable_tags)
+            elif nl_caption:
+                nl_caption = prepend_trigger(nl_caption)
+            else:
+                processable_tags = prepend_trigger(processable_tags)
+
+        extra_tags = ''
+        if self.dataset_config.random_triggers:
+            num_triggers = self.dataset_config.random_triggers_max
+            if num_triggers > 1:
+                num_triggers = random.randint(0, num_triggers)
+            if num_triggers > 0:
+                extra_tags = ', '.join(
+                    random.sample(self.dataset_config.random_triggers, num_triggers)
+                )
+
+        # NL-only variants start with an empty tag section, but can still
+        # receive an auto-injected trigger or configured random tags. Keep
+        # those values separate from the protected NL sentence.
+        processable_tags = join_caption_sections(processable_tags, extra_tags)
+
+        if self.dataset_config.shuffle_caption:
+            processable_tags = shuffle_caption_tags(
+                processable_tags,
+                self.dataset_config.secondary_separator,
+            )
+
+        processable_tags = expand_secondary_separator(
+            processable_tags,
+            self.dataset_config.secondary_separator,
+        )
+        protected_tags = expand_secondary_separator(
+            protected_tags,
+            self.dataset_config.secondary_separator,
+        )
+
+        if selection.variant == 'nl':
+            return selection.render_processed(
+                protected_tags,
+                '',
+                nl_caption,
+                extra_tags=processable_tags,
+            )
+        return selection.render_processed(
+            protected_tags,
+            processable_tags,
+            nl_caption,
+        )
 
     def get_caption(
             self: 'FileItemDTO',
@@ -391,33 +534,40 @@ class CaptionProcessingDTOMixin:
                 # drop the caption
                 return ''
 
-        # get tokens
-        token_list = raw_caption.split(',')
+        if self.mixed_caption_selection is not None and not short_caption:
+            return self._get_mixed_caption(
+                trigger,
+                to_replace_list,
+                add_if_not_present,
+            )
+
+        protected_caption, processable_caption, has_keep_separator = split_caption_at_separator(
+            raw_caption, self.dataset_config.keep_tokens_separator
+        )
 
         # handle token dropout
         if self.dataset_config.token_dropout_rate > 0 and not short_caption and not self.dataset_config.cache_text_embeddings:
-            new_token_list = []
-            keep_tokens: int = self.dataset_config.keep_tokens
-            for idx, token in enumerate(token_list):
-                if idx < keep_tokens:
-                    new_token_list.append(token)
-                elif self.dataset_config.token_dropout_rate >= 1.0:
-                    # drop the token
-                    pass
-                else:
-                    # get a random float form 0 to 1
-                    rand = random.random()
-                    if rand > self.dataset_config.token_dropout_rate:
-                        # keep the token
-                        new_token_list.append(token)
-            token_list = new_token_list
+            # Only tags after keep_tokens_separator participate in token dropout.
+            processable_caption = drop_caption_tags(
+                processable_caption,
+                self.dataset_config.token_dropout_rate,
+                self.dataset_config.keep_tokens,
+                self.dataset_config.secondary_separator,
+            )
 
-        if self.dataset_config.shuffle_tokens:
-            random.shuffle(token_list)
+        # Join the processable tags before trigger and random-trigger handling.
+        caption = processable_caption
+        if has_keep_separator:
+            # Keep the separator temporarily so trigger replacement can happen
+            # in either section while newly injected triggers stay protected.
+            caption = protected_caption + self.dataset_config.keep_tokens_separator + caption
 
-        # join back together
-        caption = ', '.join(token_list)
         caption = inject_trigger_into_prompt(caption, trigger, to_replace_list, add_if_not_present)
+
+        if has_keep_separator:
+            protected_caption, caption, _ = split_caption_at_separator(
+                caption, self.dataset_config.keep_tokens_separator
+            )
 
         if self.dataset_config.random_triggers:
             num_triggers = self.dataset_config.random_triggers_max
@@ -433,11 +583,19 @@ class CaptionProcessingDTOMixin:
                 #     trigger = self.dataset_config.random_triggers[int(random.random() * (len(self.dataset_config.random_triggers)))]
                 #     caption = caption + ', ' + trigger
 
-        if self.dataset_config.shuffle_tokens:
-            # shuffle again
-            token_list = caption.split(',')
-            random.shuffle(token_list)
-            caption = ', '.join(token_list)
+        if self.dataset_config.shuffle_caption:
+            # When a separator is present, caption contains only its processable
+            # section here, leaving protected_caption untouched.
+            caption = shuffle_caption_tags(caption, self.dataset_config.secondary_separator)
+
+        # Group separators are processing hints and must not reach the text encoder.
+        caption = expand_secondary_separator(caption, self.dataset_config.secondary_separator)
+        protected_caption = expand_secondary_separator(
+            protected_caption, self.dataset_config.secondary_separator
+        )
+
+        if has_keep_separator:
+            caption = join_caption_sections(protected_caption, caption)
         if caption == '':
             pass
         return caption

--- a/ui/src/app/jobs/new/SimpleJob.tsx
+++ b/ui/src/app/jobs/new/SimpleJob.tsx
@@ -81,6 +81,26 @@ export default function SimpleJob({
 
   const isVideoModel = !!(modelArch?.group === 'video');
   const isAudioModel = !!(modelArch?.group === 'audio');
+  const hasInvalidMixedCaptionWeights = jobConfig.config.process[0].datasets.some(dataset => {
+    if ((dataset.caption_mode ?? 'single') !== 'mixed') return false;
+    const weights = dataset.mixed_weights;
+    return (
+      (weights?.tags ?? 40) +
+        (weights?.nl ?? 30) +
+        (weights?.tags_nl ?? 20) +
+        (weights?.nl_tags ?? 10) <=
+      0
+    );
+  });
+
+  const handleValidatedSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    if (hasInvalidMixedCaptionWeights) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+    handleSubmit(event);
+  };
 
   const taggedSampleArr: Record<string, any>[] | null = useMemo(() => {
     if (!modelArch) return null;
@@ -222,7 +242,7 @@ export default function SimpleJob({
   return (
     <>
       <form
-        onSubmit={handleSubmit}
+        onSubmit={handleValidatedSubmit}
         className={`space-y-8 relative ${isLoading ? 'pointer-events-none opacity-50' : ''}`}
       >
         {isLoading && (
@@ -869,6 +889,19 @@ export default function SimpleJob({
                   </>
                 )}
               </div>
+              <div>
+                <NumberInput
+                  label="Log Captions Every N Steps"
+                  value={jobConfig.config.process[0].logging.log_captions_every_n_steps ?? 0}
+                  onChange={value =>
+                    setJobConfig(Math.floor(value ?? 0), 'config.process[0].logging.log_captions_every_n_steps')
+                  }
+                  placeholder="0 disables caption logging"
+                  min={0}
+                  docKey="logging.log_captions_every_n_steps"
+                  required
+                />
+              </div>
             </div>
           </Card>
         </div>
@@ -992,6 +1025,72 @@ export default function SimpleJob({
                         onChange={value => setJobConfig(value, `config.process[0].datasets[${i}].default_caption`)}
                         placeholder="eg. A photo of a cat"
                       />
+                      <SelectInput
+                        label="Caption Mode"
+                        className="pt-2"
+                        value={dataset.caption_mode ?? 'single'}
+                        onChange={value => setJobConfig(value, `config.process[0].datasets[${i}].caption_mode`)}
+                        options={[
+                          { value: 'single', label: 'Single (.txt)' },
+                          { value: 'mixed', label: 'Mixed (.txt + _nl.txt)' },
+                        ]}
+                        docKey="datasets.caption_mode"
+                      />
+                      {(dataset.caption_mode ?? 'single') === 'mixed' && (
+                        <>
+                          <NumberInput
+                            label="Tags Weight"
+                            className="pt-2"
+                            value={dataset.mixed_weights?.tags ?? 40}
+                            onChange={value =>
+                              setJobConfig(value, `config.process[0].datasets[${i}].mixed_weights.tags`)
+                            }
+                            min={0}
+                            docKey="datasets.mixed_weights"
+                            required
+                          />
+                          <NumberInput
+                            label="Natural Language Weight"
+                            className="pt-2"
+                            value={dataset.mixed_weights?.nl ?? 30}
+                            onChange={value => setJobConfig(value, `config.process[0].datasets[${i}].mixed_weights.nl`)}
+                            min={0}
+                            docKey="datasets.mixed_weights"
+                            required
+                          />
+                          <NumberInput
+                            label="Tags + Natural Language Weight"
+                            className="pt-2"
+                            value={dataset.mixed_weights?.tags_nl ?? 20}
+                            onChange={value =>
+                              setJobConfig(value, `config.process[0].datasets[${i}].mixed_weights.tags_nl`)
+                            }
+                            min={0}
+                            docKey="datasets.mixed_weights"
+                            required
+                          />
+                          <NumberInput
+                            label="Natural Language + Tags Weight"
+                            className="pt-2"
+                            value={dataset.mixed_weights?.nl_tags ?? 10}
+                            onChange={value =>
+                              setJobConfig(value, `config.process[0].datasets[${i}].mixed_weights.nl_tags`)
+                            }
+                            min={0}
+                            docKey="datasets.mixed_weights"
+                            required
+                          />
+                          {(dataset.mixed_weights?.tags ?? 40) +
+                            (dataset.mixed_weights?.nl ?? 30) +
+                            (dataset.mixed_weights?.tags_nl ?? 20) +
+                            (dataset.mixed_weights?.nl_tags ?? 10) <=
+                            0 && (
+                            <p className="pt-2 text-sm text-red-500">
+                              At least one mixed caption weight must be greater than 0.
+                            </p>
+                          )}
+                        </>
+                      )}
                       <NumberInput
                         label="Caption Dropout Rate"
                         className="pt-2"
@@ -1000,6 +1099,47 @@ export default function SimpleJob({
                         placeholder="eg. 0.05"
                         min={0}
                         required
+                      />
+                      <NumberInput
+                        label="Caption Tag Dropout Rate"
+                        className="pt-2"
+                        value={dataset.token_dropout_rate ?? 0}
+                        onChange={value => setJobConfig(value, `config.process[0].datasets[${i}].token_dropout_rate`)}
+                        placeholder="eg. 0.1"
+                        min={0}
+                        max={1}
+                        docKey="datasets.token_dropout_rate"
+                        required
+                      />
+                      <NumberInput
+                        label="Keep First Tags"
+                        className="pt-2"
+                        value={dataset.keep_tokens ?? 0}
+                        onChange={value =>
+                          setJobConfig(Math.floor(value ?? 0), `config.process[0].datasets[${i}].keep_tokens`)
+                        }
+                        placeholder="eg. 1"
+                        min={0}
+                        docKey="datasets.keep_tokens"
+                        required
+                      />
+                      <TextInput
+                        label="Keep Tokens Separator"
+                        className="pt-2"
+                        value={dataset.keep_tokens_separator ?? ''}
+                        onChange={value =>
+                          setJobConfig(value, `config.process[0].datasets[${i}].keep_tokens_separator`)
+                        }
+                        placeholder="eg. |||"
+                        docKey="datasets.keep_tokens_separator"
+                      />
+                      <TextInput
+                        label="Secondary Separator"
+                        className="pt-2"
+                        value={dataset.secondary_separator ?? ''}
+                        onChange={value => setJobConfig(value, `config.process[0].datasets[${i}].secondary_separator`)}
+                        placeholder="eg. ;;;"
+                        docKey="datasets.secondary_separator"
                       />
                       <CreatableSelectInput
                         label="Caption Extension"
@@ -1039,6 +1179,12 @@ export default function SimpleJob({
                           label="Is Regularization"
                           checked={dataset.is_reg || false}
                           onChange={value => setJobConfig(value, `config.process[0].datasets[${i}].is_reg`)}
+                        />
+                        <Checkbox
+                          label="Shuffle Caption"
+                          checked={dataset.shuffle_caption ?? dataset.shuffle_tokens ?? false}
+                          onChange={value => setJobConfig(value, `config.process[0].datasets[${i}].shuffle_caption`)}
+                          docKey="datasets.shuffle_caption"
                         />
                         {modelArch?.additionalSections?.includes('datasets.auto_frame_count') && (
                           <Checkbox

--- a/ui/src/app/jobs/new/jobConfig.ts
+++ b/ui/src/app/jobs/new/jobConfig.ts
@@ -3,6 +3,13 @@ import { isMac } from '@/helpers/basic';
 import { defaultSampleConfig } from '@/helpers/defaultSamples';
 import { JobConfig, SampleConfig, DatasetConfig, SliderConfig } from '@/types';
 
+const defaultMixedCaptionWeights = {
+  tags: 40,
+  nl: 30,
+  tags_nl: 20,
+  nl_tags: 10,
+};
+
 export const defaultDatasetConfig: DatasetConfig = {
   folder_path: '/path/to/images/folder',
   mask_path: null,
@@ -10,6 +17,13 @@ export const defaultDatasetConfig: DatasetConfig = {
   default_caption: '',
   caption_ext: 'txt',
   caption_dropout_rate: 0.05,
+  caption_mode: 'single',
+  mixed_weights: { ...defaultMixedCaptionWeights },
+  token_dropout_rate: 0,
+  keep_tokens: 0,
+  keep_tokens_separator: '',
+  secondary_separator: '',
+  shuffle_caption: false,
   cache_latents_to_disk: false,
   is_reg: false,
   network_weight: 1,
@@ -102,6 +116,7 @@ export const defaultJobConfig: JobConfig = {
         logging: {
           log_every: 1,
           use_ui_logger: true,
+          log_captions_every_n_steps: 0,
         },
         model: {
           name_or_path: 'ostris/Flex.1-alpha',
@@ -153,11 +168,30 @@ export const migrateJobConfig = (jobConfig: JobConfig): JobConfig => {
     delete jobConfig.config.process[0].model.auto_memory;
   }
 
-  if (!('logging' in jobConfig.config.process[0])) {
-    //@ts-ignore
-    jobConfig.config.process[0].logging = {
+  const processConfig = jobConfig.config.process[0];
+  if (
+    !processConfig.logging ||
+    typeof processConfig.logging !== 'object' ||
+    Array.isArray(processConfig.logging)
+  ) {
+    processConfig.logging = {
       log_every: 1,
       use_ui_logger: true,
+      log_captions_every_n_steps: 0,
+    };
+  }
+  if (processConfig.logging.log_captions_every_n_steps == null) {
+    processConfig.logging.log_captions_every_n_steps = 0;
+  }
+
+  for (const dataset of processConfig.datasets ?? []) {
+    const existingWeights =
+      dataset.mixed_weights && typeof dataset.mixed_weights === 'object' && !Array.isArray(dataset.mixed_weights)
+        ? dataset.mixed_weights
+        : {};
+    dataset.mixed_weights = {
+      ...defaultMixedCaptionWeights,
+      ...existingWeights,
     };
   }
   if (isMac()) {

--- a/ui/src/docs.tsx
+++ b/ui/src/docs.tsx
@@ -153,6 +153,98 @@ const docs: { [key: string]: ConfigDoc } = {
       </>
     ),
   },
+  'datasets.shuffle_caption': {
+    title: 'Shuffle Caption',
+    description: (
+      <>
+        Randomly shuffles comma-separated caption tags each time an item is loaded for training. For example,{' '}
+        <code>a, b, c, d, e</code> may become <code>b, d, a, e, c</code>. This only changes tag order; it does not
+        change the caption files on disk. When Keep Tokens Separator is set, only tags after the separator are shuffled.
+        Tags joined by Secondary Separator are shuffled as one group. Disable text embedding caching when using this
+        option so a new order can be encoded during training.
+      </>
+    ),
+  },
+  'datasets.caption_mode': {
+    title: 'Caption Mode',
+    description: (
+      <>
+        Single mode uses the caption file matching the image name, such as <code>a.txt</code> for <code>a.png</code>.
+        Mixed mode also reads <code>a_nl.txt</code> and randomly chooses tags, natural language, tags followed by
+        natural language, or natural language followed by tags whenever the image is loaded. Disable text embedding
+        caching so the selection can change during training. If the tags caption contains Keep Tokens Separator, its
+        protected prefix is placed first in every mixed variant, including the natural-language-only variant. Shuffle
+        Caption and Caption Tag Dropout only process the tag section; the natural-language section remains unchanged.
+      </>
+    ),
+  },
+  'datasets.mixed_weights': {
+    title: 'Mixed Caption Weight',
+    description: (
+      <>
+        Relative selection weights for the four mixed caption variants. With weights <code>40</code>, <code>30</code>,{' '}
+        <code>20</code>, and <code>10</code>, the variants are selected 40%, 30%, 20%, and 10% of the time. The values
+        do not need to total 100 because they are normalized automatically.
+      </>
+    ),
+  },
+  'datasets.token_dropout_rate': {
+    title: 'Caption Tag Dropout Rate',
+    description: (
+      <>
+        Randomly removes each comma-separated caption tag at the configured probability whenever an item is loaded for
+        training. For example, <code>0.1</code> gives every tag a 10% chance of being omitted. Set this to{' '}
+        <code>0</code> to disable it. When Keep Tokens Separator is set, only tags after the separator can be removed.
+        Tags joined by Secondary Separator share one dropout decision. Text embedding caching must be disabled for the
+        tag selection to change during training.
+      </>
+    ),
+  },
+  'datasets.keep_tokens': {
+    title: 'Keep First Tags',
+    description: (
+      <>
+        Protects this many tags or secondary-separated groups at the beginning of the processable caption section from
+        caption tag dropout. For example, setting this to <code>1</code> always keeps its first unit. These units can
+        still move when Shuffle Caption is enabled.
+      </>
+    ),
+  },
+  'datasets.keep_tokens_separator': {
+    title: 'Keep Tokens Separator',
+    description: (
+      <>
+        Separates a protected caption prefix from tags that may be dropped or shuffled. With <code>|||</code>{' '}
+        configured, a caption such as <code>character name, portrait ||| red hair, blue eyes</code> always keeps the
+        text before <code>|||</code> in place and only processes the tags after it. The separator itself is removed
+        before training.
+      </>
+    ),
+  },
+  'datasets.secondary_separator': {
+    title: 'Secondary Separator',
+    description: (
+      <>
+        Joins adjacent tags into one processing group. With <code>;;;</code> configured, <code>a, b, c;;;d;;;e, f</code>{' '}
+        is processed as four units: <code>a</code>, <code>b</code>, <code>c, d, e</code>, and <code>f</code>. The
+        grouped tags are dropped together and remain adjacent in their original order when shuffled. The separator
+        itself is converted to commas before training.
+      </>
+    ),
+  },
+  'logging.log_captions_every_n_steps': {
+    title: 'Log Captions Every N Steps',
+    description: (
+      <>
+        Prints each training item's final dataset caption to the live job log at this step interval. This is useful for
+        checking mixed-caption selection, tag shuffling, and tag dropout. The caption is recorded before
+        encoder-specific prompt transformations such as adapter injection or prompt saturation. A{' '}
+        <code>cached_embedding=true</code> marker means training used a cached text embedding, so the displayed text is
+        diagnostic rather than a newly encoded prompt. Set this option to <code>0</code> to disable caption logging.
+        Small intervals can produce large logs, especially with larger batches or gradient accumulation.
+      </>
+    ),
+  },
   'train.unload_text_encoder': {
     title: 'Unload Text Encoder',
     description: (

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -89,6 +89,19 @@ export interface DatasetConfig {
   default_caption: string;
   caption_ext: string;
   caption_dropout_rate: number;
+  caption_mode?: 'single' | 'mixed';
+  mixed_weights?: {
+    tags: number;
+    nl: number;
+    tags_nl: number;
+    nl_tags: number;
+  };
+  token_dropout_rate?: number;
+  keep_tokens?: number;
+  keep_tokens_separator?: string;
+  secondary_separator?: string;
+  shuffle_caption?: boolean;
+  /** @deprecated Use shuffle_caption. Kept for loading older job configs. */
   shuffle_tokens?: boolean;
   is_reg: boolean;
   network_weight: number;
@@ -217,6 +230,7 @@ export interface SampleConfig {
 export interface LoggingConfig {
   log_every: number;
   use_ui_logger: boolean;
+  log_captions_every_n_steps?: number;
 }
 
 export interface SliderConfig {


### PR DESCRIPTION
## 변경 내용

- 데이터셋에 `caption_mode`, `mixed_weights`, `keep_tokens_separator`, `secondary_separator`, `shuffle_caption` 옵션을 추가했습니다.
- `mixed` 모드에서 `image.txt`와 `image_nl.txt`를 가중치에 따라 조합하며, 항목을 로드할 때마다 변형을 다시 선택하도록 했습니다.
- 자연어 캡션 영역에는 `shuffle_caption`과 `token_dropout_rate`가 적용되지 않고 태그 영역에만 적용되도록 분리했습니다.
- 기존 `shuffle_tokens` 설정은 호환 alias로 계속 지원하면서 예제 설정은 `shuffle_caption`으로 갱신했습니다.
- Gradio 데이터셋 생성 시 편집한 캡션과 업로드한 `_nl.txt` sidecar가 실제 학습 폴더에 전달되도록 수정했습니다.
- `logging.log_captions_every_n_steps`를 추가해 지정한 완료 스텝마다 실제 배치 캡션을 작업 로그와 Gradio GUI에서 확인할 수 있게 했습니다.
- 기존 UI 설정의 부분 `mixed_weights`와 `logging: null`을 안전하게 마이그레이션하고, 잘못된 가중치와 로깅 주기를 조기에 검증합니다.

## 배경과 원인

GUI에서 작성한 캡션이 메타데이터에는 기록되지만 학습 데이터 로더가 읽는 sidecar 파일로 완전히 전달되지 않는 경로가 있었습니다. 또한 혼합 캡션을 하나의 문자열로 일찍 합치면 태그용 shuffle/dropout이 자연어 문장에도 적용될 수 있었고, 재사용되는 데이터 항목에서 혼합 변형이 최초 한 번만 선택되는 문제가 있었습니다.

이번 변경은 태그·자연어 영역을 선택과 후처리가 끝날 때까지 분리해 유지하고, 최종 캡션을 `FileItemDTO.caption`으로 전달합니다. 디버그 로그는 성공한 완료 스텝에서 main process의 모든 gradient-accumulation microbatch 항목을 출력합니다.

## 사용자 영향

- 태그 캡션과 자연어 캡션을 가중치 기반으로 안정적으로 혼합할 수 있습니다.
- 자연어 문장의 단어 순서와 내용이 태그 shuffle/dropout 때문에 훼손되지 않습니다.
- `log_captions_every_n_steps: 100`처럼 설정하면 100, 200, 300 스텝의 실제 처리된 캡션을 GUI에서 확인할 수 있습니다.
- 값이 `0`이면 캡션 로깅은 비활성화되며, cached embedding 사용 여부도 로그에 표시됩니다.

## 검증

- 관련 Python 단위·회귀 테스트 39개 통과
- 변경 Python 파일 `compileall` 통과
- Next.js 프로덕션 빌드 통과
- `git diff --check` 통과

실제 장시간 GPU 모델 학습은 이번 검증 범위에 포함하지 않았습니다. Next.js 빌드에는 기존 optional `macos-temperature-sensor` 경고만 남아 있습니다.
