### PR TITLE
Add support for reordering active jobs. Desktop+Mobile

### DIFF
--- a/ui/src/app/api/jobs/reorder/route.ts
+++ b/ui/src/app/api/jobs/reorder/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const ACTIVE_JOB_STATUSES = ['queued', 'running', 'stopping'] as const;
+const QUEUE_POSITION_STEP = 1000;
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const jobIds = Array.isArray(body.jobIds) ? body.jobIds.filter((id: unknown): id is string => typeof id === 'string') : [];
+
+    if (jobIds.length < 2) {
+      return NextResponse.json({ error: 'At least two job IDs are required' }, { status: 400 });
+    }
+
+    const jobs = await prisma.job.findMany({
+      where: { id: { in: jobIds } },
+      select: { id: true, gpu_ids: true, status: true },
+    });
+
+    if (jobs.length !== jobIds.length) {
+      return NextResponse.json({ error: 'One or more jobs were not found' }, { status: 404 });
+    }
+
+    const gpuIds = new Set(jobs.map(job => job.gpu_ids));
+    if (gpuIds.size !== 1) {
+      return NextResponse.json({ error: 'Jobs must belong to the same queue' }, { status: 400 });
+    }
+
+    if (jobs.some(job => !ACTIVE_JOB_STATUSES.includes(job.status as (typeof ACTIVE_JOB_STATUSES)[number]))) {
+      return NextResponse.json({ error: 'Only active queue jobs can be reordered' }, { status: 400 });
+    }
+
+    await prisma.$transaction(
+      jobIds.map((id: string, index: number) =>
+        prisma.job.update({
+          where: { id },
+          data: { queue_position: (index + 1) * QUEUE_POSITION_STEP },
+        }),
+      ),
+    );
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Failed to reorder jobs' }, { status: 500 });
+  }
+}

--- a/ui/src/components/JobActionBar.tsx
+++ b/ui/src/components/JobActionBar.tsx
@@ -1,9 +1,17 @@
 import Link from 'next/link';
-import { Eye, Trash2, Pen, Play, Pause, Cog, X, Copy, Save, OctagonX } from 'lucide-react';
+import { Eye, Trash2, Pen, Play, Pause, Cog, X, Copy, Save, OctagonX, ArrowUp, ArrowDown } from 'lucide-react';
 import { Button } from '@headlessui/react';
 import { openConfirm } from '@/components/ConfirmModal';
 import { Job } from '@prisma/client';
-import { startJob, stopJob, deleteJob, getAvaliableJobActions, markJobAsStopped, saveJobNow } from '@/utils/jobs';
+import {
+  startJob,
+  stopJob,
+  deleteJob,
+  getAvaliableJobActions,
+  markJobAsStopped,
+  reorderJobs,
+  saveJobNow,
+} from '@/utils/jobs';
 import { startQueue } from '@/utils/queue';
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
 import { redirect } from 'next/navigation';
@@ -19,6 +27,7 @@ interface JobActionBarProps {
   // Where the gear menu opens; defaults to below. Use 'top end' when the bar is
   // pinned to the bottom of the screen so the menu opens upward into view.
   menuAnchor?: 'bottom' | 'top end';
+  queueJobIds?: string[];
 }
 
 export default function JobActionBar({
@@ -29,10 +38,25 @@ export default function JobActionBar({
   hideView,
   autoStartQueue = false,
   menuAnchor = 'bottom',
+  queueJobIds,
 }: JobActionBarProps) {
   const { canStart, canStop, canDelete, canEdit, canRemoveFromQueue } = getAvaliableJobActions(job);
+  const queueIndex = queueJobIds?.findIndex(id => id === job.id) ?? -1;
+  const canMoveUp = queueIndex > 0;
+  const canMoveDown = queueIndex >= 0 && queueJobIds != null && queueIndex < queueJobIds.length - 1;
 
   if (!afterDelete) afterDelete = onRefresh;
+
+  const moveJob = async (direction: 'up' | 'down') => {
+    if (!queueJobIds || queueIndex < 0) return;
+    const swapIndex = direction === 'up' ? queueIndex - 1 : queueIndex + 1;
+    if (swapIndex < 0 || swapIndex >= queueJobIds.length) return;
+
+    const nextJobIds = [...queueJobIds];
+    [nextJobIds[queueIndex], nextJobIds[swapIndex]] = [nextJobIds[swapIndex], nextJobIds[queueIndex]];
+    await reorderJobs(nextJobIds);
+    onRefresh && onRefresh();
+  };
 
   const iconSizeClass = 'w-5 h-5 sm:w-6 sm:h-6';
   return (
@@ -145,8 +169,8 @@ export default function JobActionBar({
           <Cog className={iconSizeClass} />
         </MenuButton>
         <MenuItems
-          anchor={{ to: menuAnchor, gap: 16 }}
-          className="bg-gray-900 border border-gray-700 rounded shadow-lg w-52 px-2 py-2 z-50"
+          anchor={menuAnchor === 'top end' ? 'top end' : 'bottom end'}
+          className="bg-gray-900 border border-gray-700 rounded shadow-lg w-48 px-2 py-2 mt-1 z-50"
         >
           {job.job_type === 'train' && (
             <MenuItem>
@@ -194,6 +218,32 @@ export default function JobActionBar({
               Mark as Stopped
             </div>
           </MenuItem>
+          {canMoveUp && (
+            <MenuItem>
+              <div
+                className="cursor-pointer px-4 py-1 hover:bg-gray-800 rounded flex items-center gap-2"
+                onClick={async () => {
+                  await moveJob('up');
+                }}
+              >
+                <ArrowUp className="w-4 h-4" />
+                Move Up
+              </div>
+            </MenuItem>
+          )}
+          {canMoveDown && (
+            <MenuItem>
+              <div
+                className="cursor-pointer px-4 py-1 hover:bg-gray-800 rounded flex items-center gap-2"
+                onClick={async () => {
+                  await moveJob('down');
+                }}
+              >
+                <ArrowDown className="w-4 h-4" />
+                Move Down
+              </div>
+            </MenuItem>
+          )}
         </MenuItems>
       </Menu>
     </div>

--- a/ui/src/components/JobsTable.tsx
+++ b/ui/src/components/JobsTable.tsx
@@ -11,8 +11,8 @@ import { startQueue, stopQueue } from '@/utils/queue';
 import { CgSpinner } from 'react-icons/cg';
 import useGPUInfo from '@/hooks/useGPUInfo';
 import { openConfirm } from '@/components/ConfirmModal';
-import { deleteJob, getTotalSteps, stopJob } from '@/utils/jobs';
-import { Trash2 } from 'lucide-react';
+import { deleteJob, getTotalSteps, reorderJobs, stopJob } from '@/utils/jobs';
+import { GripVertical, Trash2 } from 'lucide-react';
 
 interface JobsTableProps {
   autoStartQueue?: boolean;
@@ -26,6 +26,8 @@ export default function JobsTable({ onlyActive = false, job_type = null }: JobsT
   const { gpuList, isGPUInfoLoaded } = useGPUInfo();
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [deleteProgress, setDeleteProgress] = useState<{ done: number; total: number } | null>(null);
+  const [draggedJobId, setDraggedJobId] = useState<string | null>(null);
+  const [dropTargetJobId, setDropTargetJobId] = useState<string | null>(null);
 
   const refresh = () => {
     refreshJobs();
@@ -98,7 +100,49 @@ export default function JobsTable({ onlyActive = false, job_type = null }: JobsT
     });
   };
 
+  const syncQueueOrder = async (nextQueueIds: string[]) => {
+    await reorderJobs(nextQueueIds);
+    refreshJobs();
+  };
+
+  const getDraggedQueueIds = (queueJobs: JobListItem[], targetJobId: string) => {
+    if (!draggedJobId || draggedJobId === targetJobId) return null;
+    const fromIndex = queueJobs.findIndex(job => job.id === draggedJobId);
+    const toIndex = queueJobs.findIndex(job => job.id === targetJobId);
+    if (fromIndex < 0 || toIndex < 0 || fromIndex === toIndex) return null;
+
+    const nextQueueIds = queueJobs.map(job => job.id);
+    const [movedJobId] = nextQueueIds.splice(fromIndex, 1);
+    nextQueueIds.splice(toIndex, 0, movedJobId);
+    return nextQueueIds;
+  };
+
+  const getDropIndicatorClass = (queueJobs: JobListItem[], rowId: string) => {
+    if (!draggedJobId || draggedJobId === rowId) return '';
+
+    const fromIndex = queueJobs.findIndex(job => job.id === draggedJobId);
+    const toIndex = queueJobs.findIndex(job => job.id === rowId);
+    if (fromIndex < 0 || toIndex < 0 || fromIndex === toIndex) return '';
+
+    return fromIndex < toIndex
+      ? '!border-t-0 !border-b-4 !border-blue-400'
+      : '!border-b-0 !border-t-4 !border-blue-400';
+  };
+
   const columns: TableColumn[] = [
+    {
+      title: '',
+      key: 'drag',
+      className: 'w-10',
+      render: row => {
+        const isActiveQueueJob = ['queued', 'running', 'stopping'].includes(row.status);
+        return isActiveQueueJob && !onlyActive ? (
+          <span className="inline-flex cursor-grab text-gray-500" title="Drag to reorder queue">
+            <GripVertical className="w-4 h-4" />
+          </span>
+        ) : null;
+      },
+    },
     {
       title: (
         <input
@@ -198,7 +242,9 @@ export default function JobsTable({ onlyActive = false, job_type = null }: JobsT
       key: 'actions',
       className: 'text-right',
       render: row => {
-        return <JobActionBar job={row} onRefresh={refreshJobs} autoStartQueue={false} />;
+        const queueJobs = jobsDict[row.gpu_ids]?.jobs ?? [];
+        const queueJobIds = ['queued', 'running', 'stopping'].includes(row.status) ? queueJobs.map(job => job.id) : undefined;
+        return <JobActionBar job={row} onRefresh={refreshJobs} autoStartQueue={false} queueJobIds={queueJobIds} />;
       },
     },
   ];
@@ -331,6 +377,36 @@ export default function JobsTable({ onlyActive = false, job_type = null }: JobsT
                 rows={jobsDict[gpuKey].jobs}
                 isLoading={isLoading}
                 onRefresh={refresh}
+                getRowKey={row => row.id}
+                getRowProps={row => ({
+                  draggable: !onlyActive,
+                  onDragStart: () => {
+                    setDraggedJobId(row.id);
+                    setDropTargetJobId(row.id);
+                  },
+                  onDragOver: event => {
+                    event.preventDefault();
+                    if (draggedJobId !== row.id) {
+                      setDropTargetJobId(row.id);
+                    }
+                  },
+                  onDrop: async event => {
+                    event.preventDefault();
+                    const nextQueueIds = getDraggedQueueIds(jobsDict[gpuKey].jobs, row.id);
+                    setDraggedJobId(null);
+                    setDropTargetJobId(null);
+                    if (!nextQueueIds) return;
+                    await syncQueueOrder(nextQueueIds);
+                  },
+                  onDragEnd: () => {
+                    setDraggedJobId(null);
+                    setDropTargetJobId(null);
+                  },
+                  className: classNames(
+                    draggedJobId === row.id && 'opacity-60',
+                    dropTargetJobId === row.id && getDropIndicatorClass(jobsDict[gpuKey].jobs, row.id),
+                  ),
+                })}
                 theadClassName={
                   queue?.is_running
                     ? 'bg-green-700 dark:bg-green-950 text-white dark:text-gray-400'

--- a/ui/src/components/UniversalTable.tsx
+++ b/ui/src/components/UniversalTable.tsx
@@ -1,5 +1,6 @@
 import Loading from './Loading';
 import classNames from 'classnames';
+import { HTMLAttributes } from 'react';
 
 export interface TableColumn {
   title: React.ReactNode;
@@ -18,6 +19,8 @@ interface TableProps {
   isLoading: boolean;
   theadClassName?: string;
   onRefresh: () => void;
+  getRowKey?: (row: TableRow, index: number) => string;
+  getRowProps?: (row: TableRow, index: number) => HTMLAttributes<HTMLTableRowElement>;
 }
 
 export default function UniversalTable({
@@ -26,6 +29,8 @@ export default function UniversalTable({
   isLoading,
   theadClassName = 'text-gray-400',
   onRefresh = () => {},
+  getRowKey,
+  getRowProps,
 }: TableProps) {
   return (
     <div className="w-full bg-gray-900 rounded-md shadow-md">
@@ -59,9 +64,14 @@ export default function UniversalTable({
               {rows?.map((row, index) => {
                 // Style for alternating rows
                 const rowClass = index % 2 === 0 ? 'bg-gray-900' : 'bg-gray-800';
+                const extraRowProps = getRowProps ? getRowProps(row, index) : {};
 
                 return (
-                  <tr key={index} className={`${rowClass} border-b border-gray-700 hover:bg-gray-700`}>
+                  <tr
+                    key={getRowKey ? getRowKey(row, index) : index}
+                    {...extraRowProps}
+                    className={classNames(rowClass, 'border-b border-gray-700 hover:bg-gray-700', extraRowProps.className)}
+                  >
                     {columns.map(column => (
                       <td key={column.key} className={classNames('px-3 py-2', column.className)}>
                         {column.render ? column.render(row) : row[column.key]}

--- a/ui/src/utils/jobs.ts
+++ b/ui/src/utils/jobs.ts
@@ -82,6 +82,22 @@ export const markJobAsStopped = (jobID: string) => {
   });
 };
 
+export const reorderJobs = (jobIds: string[]) => {
+  return new Promise<void>((resolve, reject) => {
+    apiClient
+      .post('/api/jobs/reorder', { jobIds })
+      .then(res => res.data)
+      .then(data => {
+        console.log('Jobs reordered:', data);
+        resolve();
+      })
+      .catch(error => {
+        console.error('Error reordering jobs:', error);
+        reject(error);
+      });
+  });
+};
+
 export const getJobConfig = (job: Job) => {
   return JSON.parse(job.job_config) as JobConfig;
 };


### PR DESCRIPTION
* Vibecoded w/ gpt5-5-high
* Manually reviewed and tested on desktop + mobile
* You can reorder using by either drag and dropping the row with or without the move handle, or use the Move Up / Move Down buttons in the cog wheel
* Does NOT stop the active job