### PR TITLE
Honor model-declared patch size

### DIFF
--- a/jobs/process/BaseSDTrainProcess.py
+++ b/jobs/process/BaseSDTrainProcess.py
@@ -1197,6 +1197,9 @@ class BaseSDTrainProcess(BaseTrainProcess):
                     if self.sd.is_flux or 'flex' in self.sd.arch:
                         # flux is a patch size of 1, but latents are divided by 2, so we need to double it
                         patch_size = 2
+                    elif getattr(self.sd, 'patch_size', None) is not None:
+                        # Prefer a model-declared patch size when available.
+                        patch_size = self.sd.patch_size
                     elif hasattr(self.sd.unet, 'config') and hasattr(self.sd.unet.config, 'patch_size'):
                         patch_size = self.sd.unet.config.patch_size
                     


### PR DESCRIPTION
This fixes the patch name incompatibility for Krea2 and any other model with a similar issue.