### PR TITLE
Skip empty cancelled timers

### DIFF
--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -1,0 +1,13 @@
+from toolkit.timer import Timer
+
+
+def test_print_ignores_cancelled_timer_without_samples():
+    timer = Timer()
+    printed_timings = []
+    timer.add_after_print_hook(printed_timings.append)
+
+    timer.start("cancelled")
+    timer.cancel("cancelled")
+    timer.print()
+
+    assert printed_timings == [{}]

--- a/toolkit/timer.py
+++ b/toolkit/timer.py
@@ -48,6 +48,8 @@ class Timer:
         timing_dict = {}
         # sort by longest at top
         for timer_name, timings in sorted(self.timers.items(), key=lambda x: sum(x[1]), reverse=True):
+            if not timings:
+                continue
             avg_time = sum(timings) / len(timings)
             
             if not is_ui:


### PR DESCRIPTION
I found this error while doing various benchmark tests. 


Timer.start() creates an empty deque, while Timer.cancel() removes only the active start time. Upstream Timer.print() later calculates:

sum(timings) / len(timings)

That divides by zero when the first timed execution was cancelled by an exception or handled OOM.