### PR TITLE
run: preserve original error when job creation fails

### DIFF
--- a/run.py
+++ b/run.py
@@ -107,6 +107,7 @@ def main():
         print_acc(f"Running {len(config_file_list)} job{'' if len(config_file_list) == 1 else 's'}")
 
     for config_file in config_file_list:
+        job = None
         try:
             job = get_job(config_file, args.name)
             job.run()
@@ -116,7 +117,8 @@ def main():
             print_acc(f"Error running job: {e}")
             jobs_failed += 1
             try:
-                job.process[0].on_error(e)
+                if job is not None:
+                    job.process[0].on_error(e)
             except Exception as e2:
                 print_acc(f"Error running on_error: {e2}")
             if not args.recover:
@@ -124,7 +126,8 @@ def main():
                 raise e
         except KeyboardInterrupt as e:
             try:
-                job.process[0].on_error(e)
+                if job is not None:
+                    job.process[0].on_error(e)
             except Exception as e2:
                 print_acc(f"Error running on_error: {e2}")
             if not args.recover:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,19 @@
+import sys
+
+import run
+
+
+def test_main_skips_on_error_when_job_construction_fails(monkeypatch):
+    messages = []
+
+    def fail_to_construct_job(config_file, name):
+        raise RuntimeError("invalid job configuration")
+
+    monkeypatch.setattr(sys, "argv", ["run.py", "--recover", "broken.yaml"])
+    monkeypatch.setattr(run, "get_job", fail_to_construct_job)
+    monkeypatch.setattr(run, "print_acc", messages.append)
+
+    run.main()
+
+    assert "Error running job: invalid job configuration" in messages
+    assert not any("Error running on_error" in message for message in messages)


### PR DESCRIPTION
## Description

Current code assigns job inside the try, but its exception handlers unconditionally access job.process.

This is a minor change to preserve the original error message rather then just output "UnboundLocalError"