### PR TITLE
captioner: fix Ideogram4 prompt Unicode escape syntax

### DIFF
--- a/extensions_built_in/captioner/prompts/ideogram4_prompt.py
+++ b/extensions_built_in/captioner/prompts/ideogram4_prompt.py
@@ -1,4 +1,4 @@
-ideogram4_prompt = """
+ideogram4_prompt = r"""
 [META]
 frozen: false
 description: Slim single-shot magic prompt — splatter planning + v15 output discipline, deduped for faster inference. Thinking off.

--- a/tests/test_captioner_prompts.py
+++ b/tests/test_captioner_prompts.py
@@ -1,0 +1,6 @@
+def test_ideogram4_prompt_imports():
+    from extensions_built_in.captioner.prompts.ideogram4_prompt import (
+        ideogram4_prompt,
+    )
+
+    assert ideogram4_prompt.startswith("\n[META]")


### PR DESCRIPTION
## Description

Current code declares the prompt as a normal string while containing the literal \uNNNN. Python interprets that as a malformed Unicode escape, so the module can fail during import.

Fix is to just add the raw-string prefix. 