### PR TITLE
bug fix: do_differential_guidance option is not working

### DIFF
--- a/extensions_built_in/sd_trainer/SDTrainer.py
+++ b/extensions_built_in/sd_trainer/SDTrainer.py
@@ -736,13 +736,13 @@ class SDTrainer(BaseSDTrainProcess):
                 unconditional_target = unconditional_target * alpha
                 target = unconditional_target + guidance_scale * (target - unconditional_target)
 
-            if self.train_config.do_differential_guidance:
-                with torch.no_grad():
-                    guidance_scale = self.train_config.differential_guidance_scale
-                    target = noise_pred + guidance_scale * (target - noise_pred)
-            
         if target is None:
             target = noise
+
+        if self.train_config.do_differential_guidance:
+            with torch.no_grad():
+                guidance_scale = self.train_config.differential_guidance_scale
+                target = noise_pred + guidance_scale * (target - noise_pred)
 
         pred = noise_pred
 


### PR DESCRIPTION
## Description

<!-- Describe your changes -->

`do_differential_guidance` has no effect unless `do_guidance_loss` is also enabled, because the block was nested inside the `do_guidance_loss` branch in `extensions_built_in/sd_trainer/SDTrainer.py`:

https://github.com/ostris/ai-toolkit/blob/e00f3791e221eb65d87351224a7788906b361b89/extensions_built_in/sd_trainer/SDTrainer.py#L697-L742

```python
if self.train_config.do_guidance_loss:
    ...
    if self.train_config.do_differential_guidance:   # <-- unreachable on its own
```

So enabling it alone silently does nothing, even though it is exposed as an independent checkbox in `ui/src/app/jobs/new/SimpleJob.tsx` and its in-app description in `ui/src/docs.tsx` presents it as a standalone technique.

I fixed this by moving the block to the top level, after the `if target is None: target = noise` fallback so `target` is always defined:

```python
if target is None:
    target = noise

if self.train_config.do_differential_guidance:
    with torch.no_grad():
        guidance_scale = self.train_config.differential_guidance_scale
        target = noise_pred + guidance_scale * (target - noise_pred)
```

It now works on its own, and behavior is unchanged when both `do_differential_guidance` and `do_guidance_loss` are enabled.