### PR TITLE
fix: exclude LoRA Manager sidecar .metadata.json from resume scan

### DIFF
--- a/jobs/process/BaseSDTrainProcess.py
+++ b/jobs/process/BaseSDTrainProcess.py
@@ -823,6 +823,8 @@ class BaseSDTrainProcess(BaseTrainProcess):
                     paths = [p for p in paths if '_t2i' not in p]
                 if '_cn' not in name:
                     paths = [p for p in paths if '_cn' not in p]
+                # Exclude sidecar metadata written by model managers (e.g. ComfyUI LoRA Manager)
+                paths = [p for p in paths if not p.endswith('.metadata.json')]
 
                 if len(paths) > 0:
                     latest_path = max(paths, key=os.path.getctime)


### PR DESCRIPTION
`get_latest_save_path()` uses a broad glob pattern (`f"{name}*{post}"`) that matches `.metadata.json` sidecar files written by model managers like the ComfyUI LoRA Manager. These sidecars have a later ctime than the matching `.safetensors` checkpoints, so `max()` picks them as the latest save path.

When `torch.load()` is then called on the `.metadata.json` file, it fails with:
```
WeightsUnpickler error: Unsupported operand 123
```
because JSON is not a valid pickle format.

**Fix:** filter out `.metadata.json` from the candidate paths list, following the same pattern as the existing false-positive filters (`_LoRA`, `_refiner`, `_t2i`, `_cn`).