### PR TITLE
fix: make every get_lr_scheduler branch tolerate the injected total_iters

### DIFF
--- a/toolkit/scheduler.py
+++ b/toolkit/scheduler.py
@@ -24,6 +24,11 @@ def get_lr_scheduler(
         # StepLR decays purely on step_size/gamma and has no notion of run
         # length, so drop the total_iters the trainer injects.
         kwargs.pop('total_iters', None)
+        if 'step_size' not in kwargs:
+            raise ValueError(
+                "lr_scheduler 'step' requires lr_scheduler_params.step_size "
+                "(number of steps between each lr decay)"
+            )
 
         return torch.optim.lr_scheduler.StepLR(
             optimizer, **kwargs

--- a/toolkit/scheduler.py
+++ b/toolkit/scheduler.py
@@ -21,6 +21,9 @@ def get_lr_scheduler(
             optimizer, **kwargs
         )
     elif name == "step":
+        # StepLR decays purely on step_size/gamma and has no notion of run
+        # length, so drop the total_iters the trainer injects.
+        kwargs.pop('total_iters', None)
 
         return torch.optim.lr_scheduler.StepLR(
             optimizer, **kwargs

--- a/toolkit/scheduler.py
+++ b/toolkit/scheduler.py
@@ -43,7 +43,7 @@ def get_lr_scheduler(
         if 'num_warmup_steps' not in kwargs:
             print(f"WARNING: num_warmup_steps not in kwargs. Using default value of 1000")
             kwargs['num_warmup_steps'] = 1000
-        del kwargs['total_iters']
+        kwargs.pop('total_iters', None)
         return get_constant_schedule_with_warmup(optimizer, **kwargs)
     else:
         # try to use a diffusers scheduler


### PR DESCRIPTION
## Summary

`lr_scheduler: "step"` is currently unusable — any job configured with it crashes during trainer setup with:

```
TypeError: StepLR.__init__() got an unexpected keyword argument 'total_iters'
```

This drops the injected `total_iters` before constructing `StepLR`, bringing the `step` branch in line with every other branch in `get_lr_scheduler`.

It also fixes the same defect in the opposite direction in `constant_with_warmup`, which used an unguarded `del kwargs['total_iters']` and so raised `KeyError: 'total_iters'` when `get_lr_scheduler` was called *without* the injection. After this PR every branch is safe both with and without the key.

## Reproduction

Any config with a `step` scheduler, e.g.:

```yaml
train:
  steps: 3000
  lr_scheduler: "step"
  lr_scheduler_params:
    step_size: 1000
    gamma: 0.2
```

Scheduler construction happens after model setup, so the crash only surfaces once the model has fully downloaded, quantized and loaded — several minutes of billed GPU on a large model (observed at ~7 min on a 20B-class checkpoint). Log excerpt, trimmed:

```
Model Loaded
create LoRA network. base dim (rank): 32, alpha: 32
create LoRA for U-Net: 252 modules.
enable LoRA for U-Net
Error running job: StepLR.__init__() got an unexpected keyword argument 'total_iters'

Traceback (most recent call last):
  ...
  File "/app/ai-toolkit/jobs/process/BaseSDTrainProcess.py", line 2230, in run
    lr_scheduler = get_lr_scheduler(
  File "/app/ai-toolkit/toolkit/scheduler.py", line 25, in get_lr_scheduler
    return torch.optim.lr_scheduler.StepLR(
TypeError: StepLR.__init__() got an unexpected keyword argument 'total_iters'
```

No GPU needed to reproduce:

```python
import torch
from toolkit.scheduler import get_lr_scheduler

opt = torch.optim.SGD([torch.nn.Parameter(torch.zeros(1))], lr=1e-4)
get_lr_scheduler("step", opt, step_size=1000, gamma=0.2, total_iters=3000)  # TypeError
```

## Root cause

`jobs/process/BaseSDTrainProcess.py` unconditionally injects `total_iters` into the scheduler kwargs:

```python
lr_scheduler_params = self.train_config.lr_scheduler_params

# make sure it had bare minimum
if 'max_iterations' not in lr_scheduler_params:
    lr_scheduler_params['total_iters'] = self.train_config.steps

lr_scheduler = get_lr_scheduler(
    self.train_config.lr_scheduler,
    optimizer,
    **lr_scheduler_params
)
```

The `max_iterations` guard never fires — that string appears nowhere else in the repository, so nothing can set it. In practice `total_iters` is *always* injected.

`toolkit/scheduler.py` then handles that injected key in every branch except `step`:

| `lr_scheduler` | handling of `total_iters` |
| --- | --- |
| `cosine` | remapped to `T_max` |
| `cosine_with_restarts` | remapped to `T_0` |
| `constant` | accepted natively by `ConstantLR` |
| `linear` | accepted natively by `LinearLR` |
| `constant_with_warmup` | deleted before the call — unguarded, see below |
| **`step`** | **forwarded untouched to `StepLR`** |

`StepLR.__init__` takes only `step_size`, `gamma` and `last_epoch` — there is no `total_iters` parameter on it in any torch version — so the call raises.

`get_lr_scheduler` has exactly one caller (`BaseSDTrainProcess.py:2230`), and it always injects. That is why the `constant_with_warmup` `del` has never blown up in a training run: nothing ever reaches it without the key. It does still make the function unsafe to call directly, which is why this PR fixes it too.

## Why discard rather than remap

Unlike the cosine schedulers, `StepLR` has no parameter that expresses run length — its decay is fully determined by `step_size` and `gamma`. There is nothing meaningful to map `total_iters` onto, so dropping it is the correct handling rather than a workaround. This mirrors what the `constant_with_warmup` branch already does.

`kwargs.pop('total_iters', None)` is used rather than `del` so that `get_lr_scheduler` remains safe to call directly without the trainer's injection.

## Verification

Every branch was exercised twice — once with `total_iters` injected as the trainer does, and once without it to cover direct calls — asserting that each scheduler receives only kwargs its real signature accepts.

Against unpatched `main` this reproduces both defects: `TypeError: StepLR.__init__() got an unexpected keyword argument 'total_iters'` for `step`, and `KeyError: 'total_iters'` for a direct `constant_with_warmup` call. After this PR both pass, `StepLR` receives exactly `{step_size, gamma}`, and `cosine` / `constant` / `linear` are unchanged.

## Why an error, not a default, for a missing `step_size`

`step` with no `lr_scheduler_params` previously died on `StepLR`'s required positional argument. This raises with the config path instead — `lr_scheduler 'step' requires lr_scheduler_params.step_size` — since torch's `missing 1 required positional argument: 'step_size'` is Python-level phrasing that doesn't tell a config author where the value goes.

Deliberately *not* a default, even though neighbouring branches default (`factor=1.0`, `num_warmup_steps=1000`). `step_size` determines the shape of the entire LR curve: a guessed value doesn't fail, it trains to completion and quietly yields a worse result with no signal anything was wrong. Given the crash only surfaces after the model has loaded and quantized, a fast clear error is worth more here than a convenient guess.

## Deliberately out of scope

1. **The fallback diffusers branch** has the same root cause but needs a design decision, so it is split out as #996. Short version: `polynomial` and `piecewise_constant` are the only two `SchedulerType`s that reach it, both fail on the injected `total_iters`, and the resulting `ValueError` names neither the real cause nor those schedulers — so that branch cannot currently succeed for any input. Happy to send a PR once you've said which shape you want.
