### PR TITLE
Default sample neg to an empty string instead of False

### DIFF
--- a/toolkit/config_modules.py
+++ b/toolkit/config_modules.py
@@ -83,7 +83,7 @@ class SampleConfig:
         self.sample_start_step: int = kwargs.get('sample_start_step', 0)
         self.width: int = kwargs.get('width', 512)
         self.height: int = kwargs.get('height', 512)
-        self.neg = kwargs.get('neg', False)
+        self.neg = kwargs.get('neg', '')
         self.seed = kwargs.get('seed', 0)
         self.walk_seed = kwargs.get('walk_seed', False)
         self.guidance_scale = kwargs.get('guidance_scale', 7)


### PR DESCRIPTION
`SampleConfig.neg` defaults to `False` while every consumer types it as `str` — `GenerateImageConfig.neg: str`, and both trainer construction sites pass it verbatim as `negative_prompt`. A yaml `sample:` section without a `neg:` key crashes prompt encoding with `'bool' object has no attribute 'strip'` (hit in `minimax_h3.get_prompt_embeds` during `cache_sample_prompts`).

The UI presets always write `sample.neg`, so UI-driven jobs never hit this — only hand-written configs do.

The three other classes with a `neg` field already default to `''` (`Img2ImgGenerator`, `ReferenceGenerator`, `GenerateProcess`); this brings the outlier in line. `''` and `False` are equally falsy, so no truthiness behavior changes anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)