### PR TITLE
Free the text encoder on unload instead of parking it on CPU

### DIFF
--- a/toolkit/memory_management/manager.py
+++ b/toolkit/memory_management/manager.py
@@ -165,11 +165,16 @@ class MemoryManager:
                     continue
 
     @classmethod
-    def detach(cls, module: torch.nn.Module):
+    def detach(cls, module: torch.nn.Module, unpin_cpu_tensors: bool = False):
         """
         Reverse of attach(). Moves unmanaged modules back to CPU, restores the
-        original .to() and forward methods on all child layers, unpins CPU weight
-        tensors, and clears the global CUDA device state.
+        original .to() and forward methods on all child layers, and clears the
+        global CUDA device state.
+
+        CPU weights are left pinned by default. Unpinning requires cloning each
+        pinned tensor, which temporarily doubles its host-memory allocation. Set
+        ``unpin_cpu_tensors=True`` only when the detached module will remain
+        resident and must release its pinned-memory allocations.
 
         Call this before unloading/replacing a module that had attach() applied.
         """
@@ -212,7 +217,7 @@ class MemoryManager:
                 if param is None or not isinstance(param, torch.nn.Parameter):
                     continue
                 try:
-                    if param.data.is_pinned():
+                    if unpin_cpu_tensors and param.data.is_pinned():
                         object.__setattr__(
                             child,
                             param_name,
@@ -225,14 +230,15 @@ class MemoryManager:
                     pass
 
             if getattr(child, "is_ostris_quantized", False):
-                # move quantized buffers home and unpin them (clone drops pinning)
+                # Move quantized buffers home. Keep CPU buffers pinned by default;
+                # cloning to unpin them temporarily doubles their host allocation.
                 for buf_name, buf in list(child._buffers.items()):
                     if buf is None:
                         continue
                     try:
                         if buf.device.type != "cpu":
                             buf = buf.to("cpu")
-                        if buf.is_pinned():
+                        if unpin_cpu_tensors and buf.is_pinned():
                             buf = buf.clone()
                         child._buffers[buf_name] = buf
                     except Exception:

--- a/toolkit/unloader.py
+++ b/toolkit/unloader.py
@@ -35,10 +35,26 @@ class FakeTextEncoder(torch.nn.Module):
         return self
 
 
-def _detach_and_cpu(te: torch.nn.Module):
+def _detach_and_free(te: torch.nn.Module):
     MemoryManager.detach(te)
-    # bypass any nopped-out .to() override and force an actual CPU move
-    torch.nn.Module.to(te, 'cpu')
+    # bypass any nopped-out .to() override and free the weight storages by
+    # moving them to the meta device. After the FakeTextEncoder swap every
+    # public handle points at the fake, so keeping the real module resident
+    # on CPU only costs host RAM (a quantized 32B text encoder is ~15.7 GB);
+    # any stray reference that tried to run it after unload was already
+    # unsupported.
+    torch.nn.Module.to(te, 'meta')
+
+
+def _trim_host_heap():
+    # glibc keeps freed arenas mapped; without this the RSS of a large
+    # unloaded text encoder never returns to the OS (measured ~3.4 GB
+    # retained after a full gc on linux).
+    try:
+        import ctypes
+        ctypes.CDLL("libc.so.6").malloc_trim(0)
+    except Exception:
+        pass
 
 
 def unload_text_encoder(model: "BaseModel"):
@@ -53,7 +69,7 @@ def unload_text_encoder(model: "BaseModel"):
 
             # the pipeline stores text encoders like text_encoder, text_encoder_2, text_encoder_3, etc.
             if hasattr(pipe, "text_encoder"):
-                _detach_and_cpu(pipe.text_encoder)
+                _detach_and_free(pipe.text_encoder)
                 te = FakeTextEncoder(device=model.device_torch, dtype=model.torch_dtype)
                 text_encoder_list.append(te)
                 pipe.text_encoder = te
@@ -61,7 +77,7 @@ def unload_text_encoder(model: "BaseModel"):
             i = 2
             while hasattr(pipe, f"text_encoder_{i}"):
                 real_te = getattr(pipe, f"text_encoder_{i}")
-                _detach_and_cpu(real_te)
+                _detach_and_free(real_te)
                 te = FakeTextEncoder(device=model.device_torch, dtype=model.torch_dtype)
                 text_encoder_list.append(te)
                 setattr(pipe, f"text_encoder_{i}", te)
@@ -69,7 +85,7 @@ def unload_text_encoder(model: "BaseModel"):
             model.text_encoder = text_encoder_list
         else:
             # only has a single text encoder
-            _detach_and_cpu(model.text_encoder)
+            _detach_and_free(model.text_encoder)
             model.text_encoder = FakeTextEncoder(
                 device=model.device_torch,
                 dtype=model.torch_dtype
@@ -78,3 +94,4 @@ def unload_text_encoder(model: "BaseModel"):
     torch.cuda.empty_cache()
     gc.collect()
     flush()
+    _trim_host_heap()


### PR DESCRIPTION
`unload_text_encoder` swaps in `FakeTextEncoder` but `_detach_and_cpu` moves the real module to CPU, where it stays resident for the rest of the run — stray references keep it alive through gc. With the MiniMax H3 Qwen3-VL 32B nvfp4 encoder that is **15.7 GB of host RAM** doing nothing (verified with a live-tensor census after unload: 13.7 GB uint8 + 1.2 GB bf16 + 0.8 GB int8, all text-encoder weights).

This changes the helper to move storages to the **meta device** — freeing them regardless of stray references — and adds a guarded `malloc_trim(0)`, since glibc otherwise retains ~3.4 GB of freed arenas (measured: with zero live tensors, RssAnon stayed at 4.2 GB until trim; 0.8 GB after).

Measured on an H3 LoRA run with `cache_text_embeddings: true`: ready-to-train host RssAnon **15,874 MB → 791 MB**. Trained a 600-step run plus sampling on the patched path with no regressions.

Semantics note: after the fake swap every public handle points at the fake, so any code running the real encoder post-unload was already unsupported — this makes the free explicit instead of accidental-retention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)