### PR TITLE
Add torchaudio to requirements

### DIFF
--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -38,5 +38,6 @@ matplotlib==3.10.1
 setuptools>=77.0.3
 av==16.0.1
 torchcodec==0.9.1
+torchaudio
 librosa==0.11.0
 mutagen==1.47.0


### PR DESCRIPTION
`toolkit/config_modules.py:7` imports `torchaudio` at module level (also used in `dataloader_mixins` and `toolkit/audio`), but it isn't declared in requirements, so a fresh `pip install -r requirements.txt` env fails on the first toolkit import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)