### PR TITLE
Fix offload buffer stream lifetime

### DIFF
--- a/toolkit/memory_management/manager_modules.py
+++ b/toolkit/memory_management/manager_modules.py
@@ -762,7 +762,19 @@ class OstrisLinearLayerMemoryManager(BaseLayerMemoryManager):
                     state["w_buffers"][idx] = gpu_bufs
                     state["b_buffers"][idx] = gpu_bias
                     state["fwd_slot_ready"][idx].record()
-                torch.cuda.current_stream().wait_event(state["fwd_slot_ready"][idx])
+                compute_stream = torch.cuda.current_stream()
+                compute_stream.wait_event(state["fwd_slot_ready"][idx])
+
+                # These buffers are allocated on the transfer stream but consumed
+                # on the compute stream. ConvRot's training operators also save the
+                # quantized buffers for their custom autograd backward, which can
+                # outlive the forward-only fwd_slot_free event below. Register the
+                # consuming stream so the caching allocator cannot recycle their
+                # storage while either forward or backward kernels still use it.
+                for tensor in gpu_bufs.values():
+                    tensor.record_stream(compute_stream)
+                if gpu_bias is not None:
+                    gpu_bias.record_stream(compute_stream)
 
                 # swap the quantized state onto the device, run the quantizer's own
                 # forward, then swap the pinned CPU state back


### PR DESCRIPTION
## Description

Addresses issues noted by multiple users (FitzyCodesThings/whatsthisaithing, Gary, ssjenforcer191) when offloading during minimax h3 training, ESPECIALLY when only partially offloading the transformer.

Test runs on a fresh copy of AIT with a fresh dataset confirmed corruption of the 50% offloaded run compared to the non-offloaded baseline by 250 steps. 

Further discussion revealed, though anecdotal, that known users with the issue all had PCIe 5.0 and were using Windows where issues WITHOUT the problem had PCIe 4.0

Codex identified likely race condition-like issues as described and corrected below. 

Fix direction was verified first by specifying `AI_TOOLKIT_OFFLOAD_DEPTH=2` in the repo .env file and confirming a good run with 50% offload, then with a followup permanent code fix (and the removal of the depth adjustment in the .env file).

Final fix test run confirmed no degradation and possibly even IMPROVED learning/lora behavior in both AIT samples and ComfyUI renders. 

## Technical Description
Fixes a cross-stream CUDA allocator lifetime issue in quantized transformer layer offloading.

The offloaded quantized buffers are allocated on the transfer stream, then consumed on the compute stream. ConvRot's custom autograd operators can also save those buffers for backward. Although the compute stream waits for the transfer-ready event, the caching allocator was not informed that the compute stream continued using the allocations.

This registers the compute stream with each staged weight buffer and optional bias using `record_stream()`. That prevents their storage from being recycled while forward or backward kernels may still reference it.

Without this registration, MiniMax H3 video LoRA training showed progressive sample corruption when transformer offloading was enabled. The issue was strongly timing-sensitive and was reproduced most consistently on Windows systems using PCIe 5.0. Reducing `AI_TOOLKIT_OFFLOAD_DEPTH` from its default of 4 to 2 substantially mitigated the problem, supporting premature buffer reuse as the cause.

After this change, a controlled MiniMax H3 video LoRA comparison using the same dataset and global seed produced clean results with 50% transformer offloading at the default offload depth.

Checks performed:

- `python -m py_compile toolkit/memory_management/manager_modules.py`
- `git diff --check`
- End-to-end MiniMax H3 video LoRA training with 50% transformer offloading and default offload depth
