### PR TITLE
Fix sample image grid ordering for 10+ prompts

### DIFF
--- a/toolkit/models/base_model.py
+++ b/toolkit/models/base_model.py
@@ -708,7 +708,7 @@ class BaseModel:
                         extra,
                     )
 
-                    gen_config.save_image_atomic(img, i)
+                    gen_config.save_image_atomic(img, i, len(image_configs))
                     gen_config.log_image(img, i)
                     self._after_sample_image(i, len(image_configs))
                     flush()

--- a/toolkit/stable_diffusion_model.py
+++ b/toolkit/stable_diffusion_model.py
@@ -1728,7 +1728,7 @@ class StableDiffusion:
                             generator=generator,
                         ).images[0]
 
-                    gen_config.save_image_atomic(img, i)
+                    gen_config.save_image_atomic(img, i, len(image_configs))
                     gen_config.log_image(img, i)
                     self._after_sample_image(i, len(image_configs))
                     flush()

--- a/ui/src/app/api/jobs/[jobID]/samples/route.ts
+++ b/ui/src/app/api/jobs/[jobID]/samples/route.ts
@@ -37,7 +37,7 @@ export async function GET(request: NextRequest, { params }: { params: { jobID: s
     .map(file => {
       return path.join(samplesFolder, file);
     })
-    .sort();
+    .sort((a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' }));
 
   return NextResponse.json({ samples });
 }


### PR DESCRIPTION
Closes #1008

Fixes the image grid scrambling (1, 2, 11, 12, 13, 14, 3, 4...) reported when training with 10 or more prompts.
  
`save_image_atomic` was called without `max_count` in `base_model.py` and `stable_diffusion_model.py`, so the `[count]` placeholder was never zero-padded. With 10+ prompts this produced unpadded filenames (0, 1, 10, 11...) which sort lexicographically in the wrong order. The `max_count` parameter already existed in `GenerateImageConfig` for exactly this purpose it just wasn't being passed at the call sites.
  
Also switches the samples API route sort to `localeCompare` with `numeric: true` as a safety net for existing outputs that were saved without zero-padding. 