### PR TITLE
Fix cache_text_encoder device preset missing in BaseModel

### DIFF
--- a/toolkit/models/base_model.py
+++ b/toolkit/models/base_model.py
@@ -1567,6 +1567,8 @@ class BaseModel:
             active_modules = ['vae']
         if device_state_preset in ['cache_clip']:
             active_modules = ['clip']
+        if device_state_preset in ['cache_text_encoder']:
+            active_modules = ['text_encoder']
         if device_state_preset in ['generate']:
             active_modules = ['vae', 'unet',
                               'text_encoder', 'adapter', 'refiner_unet']


### PR DESCRIPTION
## Bug

`BaseModel.set_device_state_preset()` (toolkit/models/base_model.py) handles `cache_latents`, `cache_clip`, and `generate`, but has no branch for `cache_text_encoder`. When `TextEmbeddingCachingMixin.cache_text_embeddings()` calls `set_device_state_preset('cache_text_encoder')`, `active_modules` stays empty and the text encoder is assigned to `'cpu'`.

## Observed impact

Training a Chroma LoRA with `cache_text_embeddings: true` on Windows (RTX 5060 Ti 16GB, `quantize_te` on): every caption was encoded on CPU by the quantized T5-XXL at **~6.5 minutes per caption** — about **21 hours** for a 205-image dataset — while the GPU sat idle at ~12W. After this fix the text encoder loads on the GPU for the caching pass, which finishes in minutes.

## Fix

Add the same two lines that `StableDiffusion.set_device_state_preset()` (toolkit/stable_diffusion_model.py) already has:

```python
if device_state_preset in ['cache_text_encoder']:
    active_modules = ['text_encoder']
```

This affects every arch built on `BaseModel` that uses text-embedding caching, not just Chroma.