### PR TITLE
Make torchaudio optional for non-audio paths, add librosa fallback for audio captioner

### DIFF
--- a/extensions_built_in/captioner/AceStepCaptioner.py
+++ b/extensions_built_in/captioner/AceStepCaptioner.py
@@ -6,9 +6,13 @@ except ImportError:
     librosa = None
 import numpy as np
 import torch
-import torchaudio
-from transformers import Qwen2_5OmniForConditionalGeneration, Qwen2_5OmniProcessor
+
+try:
+    import torchaudio
+except Exception:  # optional: platforms without torchaudio wheels (e.g.
+    torchaudio = None  # Linux aarch64) fall back to librosa/soundfile
 from collections import OrderedDict
+from transformers import Qwen2_5OmniForConditionalGeneration, Qwen2_5OmniProcessor
 
 from optimum.quanto import freeze
 from toolkit.basic import flush
@@ -35,6 +39,27 @@ MINOR_PROFILE = np.array(
     [6.33, 2.68, 3.52, 5.38, 2.60, 3.53, 2.54, 4.75, 3.98, 2.69, 3.34, 3.17]
 )
 KEY_NAMES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+
+
+def load_audio_mono(audio_path: str, target_sr: int = TARGET_SAMPLE_RATE):
+    """Load an audio file as a mono tensor at ``target_sr``.
+
+    Uses torchaudio when available; otherwise falls back to librosa/soundfile
+    so platforms without torchaudio wheels (e.g. Linux aarch64) keep working.
+    Returns ``(waveform[1, samples], sample_rate)``.
+    """
+    if torchaudio is not None:
+        waveform, sr = torchaudio.load(audio_path)
+        if waveform.shape[0] > 1:
+            waveform = waveform.mean(dim=0, keepdim=True)
+        if sr != target_sr:
+            waveform = torchaudio.functional.resample(waveform, sr, target_sr)
+        return waveform, target_sr
+
+    import librosa  # lazy: only needed on the fallback path
+
+    y, sr = librosa.load(audio_path, sr=target_sr, mono=True)
+    return torch.from_numpy(y).unsqueeze(0), target_sr
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -228,15 +253,9 @@ class AceStepCaptioner(BaseCaptioner):
             # analyze audio with librosa
             analysis = analyze_audio(file_path)
 
-            # load audio with torchaudio for transcription
-            waveform, sr = torchaudio.load(file_path)
+            # load audio for transcription (torchaudio or librosa fallback)
+            waveform, sr = load_audio_mono(file_path, TARGET_SAMPLE_RATE)
             waveform = waveform.to(self.device_torch)
-            if waveform.shape[0] > 1:
-                waveform = waveform.mean(dim=0, keepdim=True)
-            if sr != TARGET_SAMPLE_RATE:
-                waveform = torchaudio.functional.resample(
-                    waveform, sr, TARGET_SAMPLE_RATE
-                )
             audio_data = waveform.squeeze(0).cpu().numpy()
 
             # get the lyrics from the audio

--- a/toolkit/audio/preserve_pitch.py
+++ b/toolkit/audio/preserve_pitch.py
@@ -1,7 +1,10 @@
 import math
 import torch
 import torch.nn.functional as F
-import torchaudio
+try:
+    import torchaudio  # optional on platforms without torchaudio wheels
+except Exception:
+    torchaudio = None
     
 def time_stretch_preserve_pitch(waveform: torch.Tensor, sample_rate: int, target_samples: int) -> torch.Tensor:
     """

--- a/toolkit/config_modules.py
+++ b/toolkit/config_modules.py
@@ -4,7 +4,14 @@ from typing import List, Optional, Literal, Tuple, Union, TYPE_CHECKING, Dict
 import random
 
 import torch
-import torchaudio
+
+# torchaudio is optional at import time: it has no wheels on some platforms
+# (e.g. Linux aarch64). Audio save jobs that need it raise a clear error at
+# use time instead of crashing every toolkit import.
+try:
+    import torchaudio
+except Exception:
+    torchaudio = None
 
 from toolkit.audio.album_artwork import add_album_artwork
 from toolkit.prompt_utils import PromptEmbeds
@@ -1330,6 +1337,11 @@ class GenerateImageConfig:
         elif self.output_ext in ['wav', 'mp3', 'flac', 'ogg']:
             # save audio file
             audio_path = self.get_image_path(count, max_count)
+            if torchaudio is None:
+                raise RuntimeError(
+                    "Saving audio outputs requires torchaudio, which is not "
+                    "installed. Install it with `pip install torchaudio`."
+                )
             torchaudio.save(
                 audio_path, 
                 image[0].to('cpu'),


### PR DESCRIPTION
## Problem

`toolkit/config_modules.py:7` imports `torchaudio` at module level (also `toolkit/audio/preserve_pitch.py` and the AceStep audio captioner), but `torchaudio` is not declared in `requirements.txt`. On a fresh environment — and permanently on platforms where torchaudio wheels don't exist (e.g. Linux aarch64) — **every** `import toolkit.config_modules` (i.e. any training job startup) crashes with `ModuleNotFoundError: No module named 'torchaudio'`, even for jobs that never touch audio (#415, #436).

## Root cause

Hard top-level `import torchaudio` in modules that only *optionally* need audio I/O, combined with torchaudio being absent from the declared requirements.

## Fix (3 files, +46/−12)

- Guard the top-level imports with `try/except Exception: torchaudio = None` in:
  - `toolkit/config_modules.py` — audio save now raises an actionable `RuntimeError("... pip install torchaudio")` at use time instead of crashing every startup;
  - `toolkit/audio/preserve_pitch.py`;
  - `extensions_built_in/captioner/AceStepCaptioner.py`.
- Add `load_audio_mono()` helper in the AceStep captioner: uses torchaudio when available, otherwise falls back to **librosa** (which the file already requires for BPM/key analysis) for load + mono downmix + resample. The transcription path uses it, so audio captioning keeps working without torchaudio.

`except Exception` (not just `ImportError`) also covers broken installs where the wheel exists but native libs fail to load.

Note: complementary to #1000 — that PR adds torchaudio to requirements for platforms that have wheels; this change keeps non-audio paths (and wheel-less platforms) working regardless.

## Verification

On Ascend 910B (Linux aarch64, torch 2.14.0a0 + torch_npu, **no torchaudio installed**):

- `import toolkit.config_modules` and `import toolkit.audio.preserve_pitch` succeed, `torchaudio is None`.
- `load_audio_mono()` librosa fallback on a synthetic 1.5 s stereo 44.1 kHz wav: returns `(1, 24000)` mono tensor at 16 kHz; FFT peak at 440.0 Hz (same tone as input → mono downmix + resample correct).
- Audio save path raises a clear `RuntimeError` naming the fix instead of a bare `ModuleNotFoundError`.

(Verified with the repo modules copied into the container; heavy unrelated deps like diffusers/optimum stubbed, since the container targets this change only.)

Fixes #415
Fixes #436
