### PR TITLE
Skip sampling instead of crashing when cache_text_embeddings faked the text encoder

### DIFF
--- a/jobs/process/BaseSDTrainProcess.py
+++ b/jobs/process/BaseSDTrainProcess.py
@@ -279,8 +279,31 @@ class BaseSDTrainProcess(BaseTrainProcess):
         # override in subclass
         return generate_image_config_list
 
+    def _text_encoder_is_faked(self) -> bool:
+        from toolkit.unloader import FakeTextEncoder
+
+        text_encoder = getattr(self.sd, "text_encoder", None)
+        encoders = (
+            text_encoder if isinstance(text_encoder, list) else [text_encoder]
+        )
+        return any(
+            isinstance(encoder, FakeTextEncoder) for encoder in encoders
+        )
+
     def sample(self, step=None, is_first=False):
         if not self.accelerator.is_main_process:
+            return
+        if self._text_encoder_is_faked():
+            # cache_text_embeddings replaces the text encoder with
+            # FakeTextEncoder to free memory, so sample prompts cannot be
+            # encoded; crashing here used to kill the whole training run at
+            # the first sample step. Skip sampling instead of aborting.
+            print_acc(
+                "Skipping sampling: the text encoder is unloaded by "
+                "cache_text_embeddings, so sample prompts cannot be encoded. "
+                "Set disable_sampling: true to silence this warning, or "
+                "disable cache_text_embeddings to restore samples."
+            )
             return
         flush()
         sample_folder = os.path.join(self.save_root, 'samples')


### PR DESCRIPTION
## Bug

With `cache_text_embeddings: true`, the text encoder is replaced by `FakeTextEncoder` (toolkit/unloader.py) to free memory. When a scheduled mid-training sample fires, prompt encoding hits the fake encoder and raises:

```
AttributeError: 'FakeTextEncoder' object has no attribute 'encoder'
```

which propagates out of `job.run()` and **kills the entire training run at the first sample step**. Observed on a Chroma LoRA run (Windows, RTX 5060 Ti 16GB): the process trained fine for ~80 minutes and died exactly at step 250, the first `sample_every` boundary. The step-250 checkpoint survived only because saving runs before sampling.

## Fix

Before sampling, detect whether the (possibly list-typed) text encoder is a `FakeTextEncoder`; if so, print an actionable warning — pointing at `disable_sampling: true`, or turning off `cache_text_embeddings` to restore samples — and skip the sample pass instead of aborting, so the run keeps training.

A fuller alternative would be to temporarily reload the real text encoder for the sample pass, but that reintroduces the memory spike this option exists to avoid; graceful skip seemed like the right default. Happy to adjust if you prefer a different behavior.

Related: #1021 (the `cache_text_encoder` device preset missing from `BaseModel`, found on the same run).