### PR TITLE
Fix in-place downsampling of reference images in QwenImageEditPlusModel

### DIFF
--- a/extensions_built_in/diffusion_models/qwen_image/qwen_image_edit_plus.py
+++ b/extensions_built_in/diffusion_models/qwen_image/qwen_image_edit_plus.py
@@ -193,7 +193,7 @@ class QwenImageEditPlusModel(QwenImageModel):
         prompt_embeds_mask_list = []
         
         for b in range(len(prompt)):
-            batch_control_images = control_images[b]
+            batch_control_images = list(control_images[b])  # copy so we don't mutate the caller's list
 
             for i in range(len(batch_control_images)):
                 if len(batch_control_images[i].shape) == 3:


### PR DESCRIPTION
## Problem

`QwenImageEditPlusModel.get_prompt_embeds()` mutates the caller's control image
list in place. Since `SDTrainer` passes `batch.control_tensor_list` directly
(no copy), the batch's reference images are permanently replaced with versions
downsampled to `CONDITION_IMAGE_SIZE` (384*384 = 147456 px, aspect preserved).

Later in the same step, `get_noise_prediction()` reads that same
`batch.control_tensor_list` and resizes it up to `VAE_IMAGE_SIZE` (1024*1024)
before the VAE encode. So the VAE receives a 384²-area image upscaled to
1024²-area instead of the original.

For a 1024x1024 reference image, the VAE effectively sees 14% of the original
pixels. For a 1312x1312 reference image, 8.6%.

Training runs without error, loss decreases normally — the degradation is silent.

## Cause

In `extensions_built_in/diffusion_models/qwen_image/qwen_image_edit_plus.py`:

```python
batch_control_images = control_images[b]     # aliases batch.control_tensor_list
...
batch_control_images[i] = F.interpolate(     # writes back into the batch
    batch_control_images[i], size=(height, width), mode="bilinear"
)
```

The earlier `if not isinstance(control_images[0], list): control_images = [control_images]`
only adds an outer list — `control_images[0]` is still the caller's list object.

## Trigger

Both conditions required:

- `cache_text_embeddings: false`, so the live text-encoder branch in `SDTrainer` runs
- `batch.control_tensor_list is not None` (multi-control path; always true for
  `qwen_image_edit_plus`, which sets `has_multiple_control_images = True`)

The other two `prompt_kwargs['control_images']` assignment sites use
`batch.control_tensor.to(...)`, which copies, so they are unaffected.

Introduced in e9ab387 (2026-04-30). Before that commit this combination raised
`ValueError("Missing control images for QwenImageEditPlusModel")`, so the code
path was unreachable — which is likely why the silent regression went unnoticed.

## Fix

Copy the inner list before mutating it. The text encoder still receives the
384²-area conditioning images (unchanged behaviour); only the batch is left
intact so the VAE gets the originals.

```diff
-            batch_control_images = control_images[b]
+            batch_control_images = list(control_images[b])
```

## Verification

Extracting the patched `get_prompt_embeds` and running it against a fake batch:

| input | batch after call | what the TE received |
|---|---|---|
| 1024x1024 | 1024x1024 (was 384x384) | 384x384 |
| 1312x1312 | 1312x1312 (was 384x384) | 384x384 |
| 1024x672  | 1024x672 (was 480x320)  | 480x320 |

Note the loop's earlier `unsqueeze(0)` write-back is also no longer visible to
the batch; `get_noise_prediction()` already handles 3-dim control tensors
(`if len(control_img.shape) == 3: control_img = control_img.unsqueeze(0)`),
so nothing downstream depends on that side effect.