### PR TITLE
Fix: QwenImageEditPlusModel crashes with batch_size > 1

### DIFF
--- a/extensions_built_in/diffusion_models/qwen_image/qwen_image_edit_plus.py
+++ b/extensions_built_in/diffusion_models/qwen_image/qwen_image_edit_plus.py
@@ -211,7 +211,7 @@ class QwenImageEditPlusModel(QwenImageModel):
                 )
 
             prompt_embeds, prompt_embeds_mask = self.pipeline.encode_prompt(
-                prompt,
+                [prompt[b]],
                 image=batch_control_images,
                 device=self.device_torch,
                 num_images_per_prompt=1,
@@ -223,6 +223,20 @@ class QwenImageEditPlusModel(QwenImageModel):
                 )
             prompt_embeds_list.append(prompt_embeds)
             prompt_embeds_mask_list.append(prompt_embeds_mask)
+
+        # each sample is encoded separately, so sequence lengths differ.
+        # pad on the right before concatenating, same as diffusers does internally.
+        max_seq_len = max(e.shape[1] for e in prompt_embeds_list)
+        for i, (e, m) in enumerate(zip(prompt_embeds_list, prompt_embeds_mask_list)):
+            pad_len = max_seq_len - e.shape[1]
+            if pad_len > 0:
+                prompt_embeds_list[i] = torch.cat(
+                    [e, e.new_zeros(e.shape[0], pad_len, e.shape[2])], dim=1
+                )
+                prompt_embeds_mask_list[i] = torch.cat(
+                    [m, m.new_zeros(m.shape[0], pad_len)], dim=1
+                )
+
         pe = PromptEmbeds(torch.cat(prompt_embeds_list, dim=0))
         pe.attention_mask = torch.cat(prompt_embeds_mask_list, dim=0)
         return pe


### PR DESCRIPTION
## Problem

`QwenImageEditPlusModel.get_prompt_embeds()` cannot run with `batch_size > 1`
when text embeddings are not cached. There are two issues, the first hiding the second.

### 1. The full prompt list is passed on every loop iteration

The loop iterates over `b`, but `prompt` is never indexed:

```python
for b in range(len(prompt)):
    batch_control_images = control_images[b]     # per-sample refs
    ...
    prompt_embeds, prompt_embeds_mask = self.pipeline.encode_prompt(
        prompt,                                  # <-- entire batch, not prompt[b]
        image=batch_control_images,
        ...
    )
```

`encode_prompt` reaches `_get_qwen_prompt_embeds`, which builds the image
placeholders from the whole `image` list and prepends them to *every* prompt:

```python
txt = [template.format(base_img_prompt + e) for e in prompt]
model_inputs = self.processor(text=txt, images=image, padding=True, return_tensors="pt")
```

So the text contains `len(prompt) * len(image)` `<|image_pad|>` tokens while only
`len(image)` images are supplied, and `Qwen2VLProcessor` raises `IndexError`.

### 2. Per-sample embeds cannot be concatenated as-is

With issue 1 fixed by passing `[prompt[b]]`, each call encodes a single caption,
so the returned `seq_len` is that caption's own length — diffusers only pads
within a single call. The final

```python
pe = PromptEmbeds(torch.cat(prompt_embeds_list, dim=0))
```

then fails on dim 1 whenever two captions in a batch tokenize to different
lengths (i.e. almost always).

## Repro

No model weights needed — the processor alone reproduces issue 1:

```python
from transformers import AutoProcessor
import torch

proc = AutoProcessor.from_pretrained("Qwen/Qwen-Image-Edit-2511", subfolder="processor")
TEMPLATE = "<|im_start|>user\n{}<|im_end|>\n"          # shortened for brevity
IMG = "Picture {}: <|vision_start|><|image_pad|><|vision_end|>"

image = [torch.rand(1, 3, 384, 384)]                   # one reference image
base = "".join(IMG.format(i + 1) for i in range(len(image)))
txt = [TEMPLATE.format(base + p) for p in ["make it pixar", "make it anime"]]

proc(text=txt, images=image, padding=True, return_tensors="pt")
# IndexError: index 1 is out of bounds for dimension 0 with size 1
```

| len(prompt) | reference images | `<|image_pad|>` tokens | result |
|---|---|---|---|
| 1 | 1 | 1 | ok, `input_ids=(1, 276)` |
| 2 | 1 | 2 | `IndexError: index 1 is out of bounds for dimension 0 with size 1` |
| 2 | 2 | 4 | `IndexError: index 2 is out of bounds for dimension 0 with size 2` |
| 4 | 1 | 4 | `IndexError: index 1 is out of bounds for dimension 0 with size 1` |

## Fix

Pass only the current sample's caption, and right-pad before concatenating
(mirroring the padding `_get_qwen_prompt_embeds` already does internally):

```diff
             prompt_embeds, prompt_embeds_mask = self.pipeline.encode_prompt(
-                prompt,
+                [prompt[b]],
                 image=batch_control_images,
```

```diff
             prompt_embeds_mask_list.append(prompt_embeds_mask)
+
+        max_seq_len = max(e.shape[1] for e in prompt_embeds_list)
+        for i, (e, m) in enumerate(zip(prompt_embeds_list, prompt_embeds_mask_list)):
+            pad_len = max_seq_len - e.shape[1]
+            if pad_len > 0:
+                prompt_embeds_list[i] = torch.cat(
+                    [e, e.new_zeros(e.shape[0], pad_len, e.shape[2])], dim=1
+                )
+                prompt_embeds_mask_list[i] = torch.cat(
+                    [m, m.new_zeros(m.shape[0], pad_len)], dim=1
+                )
+
         pe = PromptEmbeds(torch.cat(prompt_embeds_list, dim=0))
```

## Verification

Single caption plus that sample's own references passes the processor for any
number of reference images:

| call shape | result |
|---|---|
| 1 prompt x 1 ref | ok, `input_ids=(1, 276)`, `image_grid_thw=(1, 3)` |
| 1 prompt x 2 refs | ok, `input_ids=(1, 479)`, `image_grid_thw=(2, 3)` |
| 1 prompt x 3 refs | ok, `input_ids=(1, 682)`, `image_grid_thw=(3, 3)` |

Sequence lengths do differ per caption, which is what the padding block handles:

| caption length (chars) | `seq_len` |
|---|---|
| 13 | 276 |
| 89 | 299 |

## Notes

- Only reachable with `cache_text_embeddings: false`. With caching enabled the
  dataset path calls `encode_prompt` once per item with a single caption string,
  so `len(prompt)` is always 1. Caching is the default, which is probably why
  this went unnoticed.
- Independent of #1035, which fixes a different problem in the same method.
  The two changes touch different lines and do not conflict.